### PR TITLE
Use build:agent npm script in the Docker frontend stage

### DIFF
--- a/src/KRINT.API/Dockerfile
+++ b/src/KRINT.API/Dockerfile
@@ -16,7 +16,7 @@ COPY src/KRINT.Frontend/package.json src/KRINT.Frontend/bun.lock* ./
 RUN bun install --frozen-lockfile
 # Copy the rest of the frontend tree and build a production bundle.
 COPY src/KRINT.Frontend .
-RUN bunx ng build --configuration production --output-path /artifacts/frontend
+RUN bun run build:agent --output-path /artifacts/frontend
 
 # ---------- Stage 2: backend restore ----------
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS backend-deps

--- a/src/KRINT.Frontend/package.json
+++ b/src/KRINT.Frontend/package.json
@@ -5,6 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "build:agent": "ng build --aot --configuration production",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "apigen": "npx openapi-generator-cli generate"


### PR DESCRIPTION
Adds a build:agent script and switches the Dockerfile to bun run build:agent so the production build flags live alongside the other package scripts.