### PR TITLE
Update self-host + dev-setup docs to match new compose / config

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -44,7 +44,7 @@ Verify with `dotnet user-secrets list --project src/KRINT.API`.
 
 ## 2. Application config — `krint.yaml`
 
-Non-secret app config lives in **`krint.yaml`** at the repo root. The API loads it via `IConfigurationBuilder.AddKrintYaml(env)` (see `src/KRINT.API/Extensions/KrintConfigExtensions.cs`), which walks up from the content root to find the file. Override the path with the `KRINT_CONFIG` environment variable.
+Non-secret app config lives in **`krint.yaml`** at the repo root. The API loads it via `services.AddKrintConfig(env)` (see `src/KRINT.API/Extensions/KrintConfigExtensions.cs`), which walks up from the content root to find the file. Override the path with the `KRINT_CONFIG` environment variable.
 
 Currently used to declare which host ports each engine is allowed to bind:
 

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -3,7 +3,7 @@
 Run KRINT against the pre-built image. This guide assumes:
 
 - A Linux or Windows host with **Docker + Compose v2**
-- A directory you can leave running (the data lives in named volumes)
+- A directory you can leave running (state lives in named Docker volumes and a `./backups` bind mount)
 - Outbound network access to **ghcr.io** (or Docker Hub) for the image pull, and to your engines' Docker images (`postgres`, `mysql`, etc.) when users provision instances
 
 The image: `ghcr.io/pianonic/krint:latest` (also `pianonic/krint:latest` on Docker Hub).
@@ -23,6 +23,8 @@ docker compose up -d            # pulls krint + postgres + keycloak, starts ever
 open http://localhost:5000      # KRINT UI
 ```
 
+Everything is wired in the shipped `compose.yml` — you don't need to add or override services. A single `.env` configures the stack.
+
 ---
 
 ## What you get
@@ -41,27 +43,50 @@ KRINT itself spins up **separate, isolated containers** for every database insta
 
 ## Environment
 
-Copy `.env.example` to `.env` and fill the values. Required:
+Copy `.env.example` to `.env` and fill the values. Variables use the same names the containers actually read (no compose-level rewriting), so anything you set here lands directly in the relevant container's environment.
 
-| Variable                       | What it is                                                                                                                     |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
-| `POSTGRES_PASSWORD`            | Password for the shared Postgres super-user. Used by both KRINT and Keycloak.                                                  |
-| `KC_BOOTSTRAP_ADMIN_USERNAME`  | Initial Keycloak admin (default `admin`).                                                                                      |
-| `KC_BOOTSTRAP_ADMIN_PASSWORD`  | Initial Keycloak admin password. Change after first login.                                                                     |
-| `KC_HOSTNAME`                  | Public URL Keycloak should advertise (e.g. `http://localhost:8080`, or your reverse-proxied domain).                           |
-| `KC_DB_USERNAME` / `KC_DB_PASSWORD` | Keycloak's DB credentials. Easiest: reuse `postgres` / `${POSTGRES_PASSWORD}`.                                            |
-| `KRINT_VAULT_KEY`              | **32 random bytes, base64-encoded.** AES-256 key for the secrets vault. Generate with `openssl rand -base64 32`.                |
-| `KRINT_OIDC_AUTHORITY`         | Keycloak realm URL, e.g. `http://localhost:8080/realms/krint`.                                                                 |
-| `KRINT_OIDC_REDIRECT_URI`      | The KRINT URL users return to after login, e.g. `http://localhost:5000/`.                                                      |
-| `KRINT_CORS_ORIGIN`            | Browser origin allowed to call the API. Match `KRINT_OIDC_REDIRECT_URI` without the trailing slash.                            |
+### Keycloak
 
-> **Don't lose `KRINT_VAULT_KEY`.** All provisioned-instance passwords are encrypted under this key. Lose it and you can't decrypt the vault — there is no recovery flow and **no key-rotation flow yet**, so don't rotate it once you have data.
+| Variable                       | What it is                                                                                                |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| `KC_BOOTSTRAP_ADMIN_USERNAME`  | Initial Keycloak admin (master realm). Defaults to `admin`.                                               |
+| `KC_BOOTSTRAP_ADMIN_PASSWORD`  | Initial Keycloak admin password. Change after first login.                                                |
+| `KC_HOSTNAME`                  | **Full** public URL Keycloak should advertise (e.g. `http://localhost:8080`, or `https://sso.example.com`). Tokens carry this in `iss`. |
+| `KC_HTTP_ENABLED`              | `true` for local HTTP. Keep `true` even behind a TLS-terminating proxy.                                   |
+| `KC_PROXY_HEADERS`             | `xforwarded` — trusts `X-Forwarded-*` from a reverse proxy.                                               |
+| `KC_HOSTNAME_BACKCHANNEL_DYNAMIC` | `true` — lets the API container fetch Keycloak metadata via the compose-network URL while browsers still see the public URL. Required for OIDC to work end-to-end. |
+
+> DB credentials (`POSTGRES_PASSWORD`, `KC_DB_USERNAME`, `KC_DB_PASSWORD`) are **not** in `.env` — they're hardcoded in `compose.yml` because they only matter inside the compose network. Edit `compose.yml` directly if you want to change them.
+
+### KRINT API
+
+| Variable                       | What it is                                                                                                |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| `Vault__MasterKey`             | **32 random bytes, base64-encoded.** AES-256 key for the secrets vault. Generate with `openssl rand -base64 32`. |
+| `Oidc__Authority`              | **Public** Keycloak realm URL, e.g. `http://localhost:8080/realms/krint`. This is what tokens carry in `iss`. |
+| `Oidc__ClientId`               | `krint` (matches the realm import).                                                                       |
+| `Oidc__RedirectUri`            | KRINT URL users return to after login, e.g. `http://localhost:5000/`.                                     |
+| `Oidc__PostLogoutRedirectUri`  | Same value, usually.                                                                                      |
+| `Oidc__Scope`                  | `openid profile email roles`.                                                                             |
+| `Oidc__RequireHttpsMetadata`   | `false` for plain-HTTP dev. Set to `true` (or remove) once Keycloak is behind HTTPS.                      |
+| `Cors__AllowedOrigins__0`      | Browser origin allowed to call the API. Match the SPA origin (no trailing slash). Add more as `__1`, `__2`. |
+
+> **Don't lose `Vault__MasterKey`.** All provisioned-instance passwords are encrypted under this key. Lose it and you can't decrypt the vault — there is no recovery flow and **no key-rotation flow yet**, so don't rotate it once you have data.
+
+### Set inside `compose.yml`, not `.env`
+
+These live in the `krint` service's `environment:` block because they reference the compose network or include credentials that mirror `compose.yml`:
+
+| Variable                            | Value                                                                                    |
+| ----------------------------------- | ---------------------------------------------------------------------------------------- |
+| `ConnectionStrings__KrintDatabase`  | `Host=db;Port=5432;Database=krint;Username=postgres;Password=<the-shared-pw>`            |
+| `Oidc__InternalAuthority`           | `http://keycloak:8080/realms/krint` — the in-cluster Keycloak URL the API fetches discovery + JWKS from. Don't change unless you rename the keycloak service. |
 
 ### Generating the vault key
 
 ```bash
 openssl rand -base64 32
-# example output: hXp+J3kQz9N2Y... (paste into KRINT_VAULT_KEY)
+# example output: hXp+J3kQz9N2Y... (paste into Vault__MasterKey)
 ```
 
 PowerShell equivalent:
@@ -75,70 +100,35 @@ PowerShell equivalent:
 ## `.env.example`
 
 ```env
-# Postgres (shared by KRINT app DB and Keycloak DB)
-POSTGRES_PASSWORD=change-me
-
-# Keycloak admin
+# ---------- Keycloak ----------
 KC_BOOTSTRAP_ADMIN_USERNAME=admin
 KC_BOOTSTRAP_ADMIN_PASSWORD=change-me
+
 KC_HOSTNAME=http://localhost:8080
-KC_DB_USERNAME=postgres
-KC_DB_PASSWORD=change-me
+KC_HTTP_ENABLED=true
+KC_PROXY_HEADERS=xforwarded
+KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true
 
-# KRINT
-KRINT_VAULT_KEY=GENERATE_WITH_openssl_rand_base64_32
-KRINT_OIDC_AUTHORITY=http://localhost:8080/realms/krint
-KRINT_OIDC_REDIRECT_URI=http://localhost:5000/
-KRINT_CORS_ORIGIN=http://localhost:5000
+# ---------- KRINT API ----------
+Vault__MasterKey=GENERATE_WITH_openssl_rand_base64_32
+
+Oidc__Authority=http://localhost:8080/realms/krint
+Oidc__ClientId=krint
+Oidc__RedirectUri=http://localhost:5000/
+Oidc__PostLogoutRedirectUri=http://localhost:5000/
+Oidc__Scope=openid profile email roles
+Oidc__RequireHttpsMetadata=false
+
+Cors__AllowedOrigins__0=http://localhost:5000
 ```
-
----
-
-## `compose.yml` (self-host shape)
-
-The `compose.yml` shipped with the repo today only includes `db` + `keycloak` — you'll need to add the `krint` service. Drop this in:
-
-```yaml
-services:
-  krint:
-    image: ghcr.io/pianonic/krint:latest
-    container_name: krint
-    restart: unless-stopped
-    depends_on:
-      - db
-      - keycloak
-    ports:
-      - "5000:8080"
-    environment:
-      ASPNETCORE_URLS: http://+:8080
-      ConnectionStrings__KrintDatabase: "Host=db;Port=5432;Database=krint;Username=postgres;Password=${POSTGRES_PASSWORD}"
-      Vault__MasterKey: ${KRINT_VAULT_KEY}
-      Oidc__Authority: ${KRINT_OIDC_AUTHORITY}
-      Oidc__ClientId: krint
-      Oidc__RedirectUri: ${KRINT_OIDC_REDIRECT_URI}
-      Oidc__PostLogoutRedirectUri: ${KRINT_OIDC_REDIRECT_URI}
-      Oidc__Scope: "openid profile email roles"
-      Oidc__RequireHttpsMetadata: "false"
-      Cors__AllowedOrigins__0: ${KRINT_CORS_ORIGIN}
-    volumes:
-      # Docker socket - KRINT provisions DB containers as siblings on this host
-      - /var/run/docker.sock:/var/run/docker.sock
-      # Persistent backup directory (matches the Backup:Directory default)
-      - krint-backups:/app/backups
-
-volumes:
-  krint-backups:
-```
-
-> Windows hosts: replace the socket mount with `//var/run/docker.sock:/var/run/docker.sock` (the leading double-slash is what Docker Desktop's Linux engine needs).
 
 ---
 
 ## First-run checklist
 
-1. **Pull + start:** `docker compose up -d`
+1. **Pull + start:** `docker compose up -d`. The shipped compose waits for Postgres `pg_isready` before starting `krint`, so first boot is race-free.
 2. **Wait for Keycloak.** First boot imports the `krint` realm and seeds the OIDC client — give it 30–60s. Tail with `docker compose logs -f keycloak` and wait for `Listening on: http://0.0.0.0:8080`.
-3. **Create your first user.** Open `http://localhost:8080`, log in as the admin from `.env`, switch to the **krint** realm, **Users → Add user**, set a password under **Credentials**.
+3. **Create your first user.** Open `http://localhost:8080`, log in as the bootstrap admin from `.env`, switch to the **krint** realm, **Users → Add user**, set a password under **Credentials**, then complete the profile (first/last name) on first login.
 4. **Log in to KRINT.** Open `http://localhost:5000`. You'll be redirected to Keycloak, authenticate, and land back on the dashboard.
 5. **Provision an instance.** Click **Create**, pick an engine, click Launch. KRINT pulls the engine image, starts a sibling container, generates credentials, and hands you a connection string.
 
@@ -159,14 +149,14 @@ To pin a version, replace `:latest` with a tag — see https://github.com/PianoN
 
 ## Data persistence
 
-| Volume                | What it holds                                                                                                   |
-| --------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `postgres-data`       | KRINT's metadata DB + Keycloak's DB (users, sessions, realm config).                                            |
-| `keycloak-data`       | Keycloak's writeable state (kept separately from the DB).                                                       |
-| `krint-backups`       | Dumps written by **Backups** for instances that support `pg_dump` / `mysqldump` / `mongodump` / Redis snapshot. |
-| *(per-instance)*      | Each provisioned engine gets its own auto-named volume (`krint-<engine>-<id>-data`).                            |
+| Location                | What it holds                                                                                                   |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `postgres-data` volume  | KRINT's metadata DB + Keycloak's DB (users, sessions, realm config).                                            |
+| `keycloak-data` volume  | Keycloak's writeable state (kept separately from the DB).                                                       |
+| `./backups/` (bind)     | Dumps written by **Backups** for instances that support `pg_dump` / `mysqldump` / `mongodump` / Redis snapshot. Visible directly in your repo folder, gitignored. |
+| *(per-instance volumes)*| Each provisioned engine gets its own auto-named volume (`krint-<engine>-<id>-data`).                            |
 
-Back up the first three before any major upgrade. Provisioned-instance volumes are independent and survive `docker compose down` of the KRINT stack.
+Back up `postgres-data`, `keycloak-data`, and `./backups/` before any major upgrade. Provisioned-instance volumes are independent and survive `docker compose down` of the KRINT stack.
 
 ---
 
@@ -174,8 +164,8 @@ Back up the first three before any major upgrade. Provisioned-instance volumes a
 
 If you're putting KRINT behind a reverse proxy (Caddy, Traefik, nginx), you need:
 
-1. **Public origin** matches `KRINT_OIDC_REDIRECT_URI` and `KRINT_CORS_ORIGIN`. Update both if your domain changes.
-2. **Keycloak's `KC_HOSTNAME`** must be the public Keycloak URL — the OIDC tokens carry the `iss` claim from this value, and KRINT validates it.
+1. **Public origin** matches `Oidc__RedirectUri` and `Cors__AllowedOrigins__0`. Update both if your domain changes.
+2. **Keycloak's `KC_HOSTNAME`** must be the full public Keycloak URL — tokens carry this as `iss`, and the API's `Oidc__Authority` must match it exactly.
 3. **Trust `X-Forwarded-*`** headers in the proxy. The compose already sets `KC_PROXY_HEADERS=xforwarded` on Keycloak; KRINT's API trusts forwarded headers via ASP.NET defaults.
 4. **WebSockets** aren't used today, so no special websocket config is needed.
 
@@ -194,10 +184,14 @@ Then in `.env`:
 
 ```env
 KC_HOSTNAME=https://sso.example.com
-KRINT_OIDC_AUTHORITY=https://sso.example.com/realms/krint
-KRINT_OIDC_REDIRECT_URI=https://krint.example.com/
-KRINT_CORS_ORIGIN=https://krint.example.com
+Oidc__Authority=https://sso.example.com/realms/krint
+Oidc__RedirectUri=https://krint.example.com/
+Oidc__PostLogoutRedirectUri=https://krint.example.com/
+Oidc__RequireHttpsMetadata=true
+Cors__AllowedOrigins__0=https://krint.example.com
 ```
+
+`Oidc__InternalAuthority` in `compose.yml` stays as `http://keycloak:8080/realms/krint` — the API always reaches Keycloak via the compose network regardless of what the public URL looks like.
 
 ---
 
@@ -205,17 +199,20 @@ KRINT_CORS_ORIGIN=https://krint.example.com
 
 | Symptom                                                                          | Likely cause / fix                                                                                                           |
 | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `krint` exits with `Vault:MasterKey must decode to 32 bytes`                     | `KRINT_VAULT_KEY` is empty or not a base64-encoded 32-byte value. Regenerate with `openssl rand -base64 32`.                 |
-| Login loop / `iss` mismatch                                                      | `KC_HOSTNAME` and `KRINT_OIDC_AUTHORITY` don't agree on the same public Keycloak URL.                                        |
-| CORS error in the browser console                                                | `KRINT_CORS_ORIGIN` doesn't match the origin the browser is loading the SPA from. Trailing slashes must be excluded.         |
+| `krint` exits with `Vault:MasterKey must decode to 32 bytes`                     | `Vault__MasterKey` is empty or not a base64-encoded 32-byte value. Regenerate with `openssl rand -base64 32`.                |
+| API returns `401 invalid_token: issuer is invalid`                               | `Oidc__Authority` doesn't equal `KC_HOSTNAME` + `/realms/krint`. They must be the same public URL byte-for-byte (incl. scheme + port). |
+| API returns `401 invalid_token: signature key was not found`                     | `Oidc__InternalAuthority` is wrong or Keycloak's `KC_HOSTNAME_BACKCHANNEL_DYNAMIC` is unset — API can't reach the JWKS endpoint. |
+| CORS error in the browser console on `/realms/krint/protocol/openid-connect/token` | The Keycloak client's web origins don't include the SPA origin. Edit `keycloak/krint-realm.json` (or use the admin UI), add your origin to `webOrigins`, drop `krint_keycloak-data` volume, restart. |
+| CORS error in the browser console on `/api/*`                                    | `Cors__AllowedOrigins__0` doesn't match the SPA origin (no trailing slash).                                                  |
 | Create fails with `Cannot connect to the Docker daemon`                          | The Docker socket isn't mounted into `krint`. Verify the `/var/run/docker.sock` bind exists in the running container.        |
 | `No free host port in range` when provisioning                                   | `krint.yaml`'s `port_ranges` exhausted. Either delete a previous instance or expand the range and `docker compose restart krint`. |
-| Keycloak admin works but the krint realm 404s                                    | Realm import didn't run — `keycloak/krint-realm.json` is missing from the build context. Pull fresh and rebuild.             |
+| Keycloak admin works but the krint realm 404s                                    | Realm import was skipped because the data volume already existed. `docker compose down && docker volume rm krint_keycloak-data && docker compose up -d`. |
+| DB auth fails on a re-run with a changed password                                | `POSTGRES_PASSWORD` is only honoured on **first init**. Either reset the password in-DB or wipe `postgres-data`.             |
 
 ---
 
 ## Going further
 
-- **Backups** — schedule cron-based dumps from the Backups page (uses the `krint-backups` volume).
+- **Backups** — schedule cron-based dumps from the Backups page (writes into `./backups/`).
 - **Engines and plugins** — see the engine matrix in the SPA's Create wizard or the README's Supported Engines table.
 - **Hacking on it** — see [`docs/dev-setup.md`](./dev-setup.md) for the local-development setup with bun + `dotnet run`.


### PR DESCRIPTION
Follow-up to #6 — the docs still referenced the old `KRINT_*` env-var names, the old \"add the krint service yourself\" workflow, and the wrong extension method name.

## self-host.md
- TL;DR no longer asks the user to add a krint service; compose.yml is complete.
- Environment table uses real container env names (\`Vault__MasterKey\`, \`Oidc__*\`, \`Cors__AllowedOrigins__0\`, \`KC_HOSTNAME_BACKCHANNEL_DYNAMIC\`).
- Documents that DB creds and \`Oidc__InternalAuthority\` live in \`compose.yml\` (not \`.env\`) and why.
- \`.env.example\` block matches the shipped file.
- Drop the redundant ad-hoc \"compose.yml shape\" snippet.
- Data persistence: \`./backups\` bind mount, not named volume.
- Troubleshooting covers the issuer/JWKS dual-URL pitfalls and the \"wipe keycloak-data to re-import realm\" case.

## dev-setup.md
- Reference the actual extension name (\`AddKrintConfig\`, not \`AddKrintYaml\`).

## Test plan
- [x] Render check in GitHub preview
- [x] Cross-check every variable name against \`src/KRINT.API/Program.cs\` and \`.env.example\`