### PR TITLE
Add Buy Me a Coffee link to the content header

### DIFF
--- a/src/KRINT.Frontend/src/app/shared/components/content-header/content-header.html
+++ b/src/KRINT.Frontend/src/app/shared/components/content-header/content-header.html
@@ -19,5 +19,17 @@
     >
       <ng-icon name="simpleGithub" size="16" />
     </a>
+    <a
+      hlmBtn
+      variant="ghost"
+      size="icon"
+      href="https://buymeacoffee.com/pianonic"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Buy me a coffee"
+      hlmTooltip="Buy me a coffee"
+    >
+      <ng-icon name="simpleBuymeacoffee" size="16" />
+    </a>
   </div>
 </header>

--- a/src/KRINT.Frontend/src/app/shared/components/content-header/content-header.ts
+++ b/src/KRINT.Frontend/src/app/shared/components/content-header/content-header.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { simpleGithub } from '@ng-icons/simple-icons';
+import { simpleBuymeacoffee, simpleGithub } from '@ng-icons/simple-icons';
 import { HlmButtonImports } from '@spartan-ng/helm/button';
 import { HlmSidebarImports } from '@spartan-ng/helm/sidebar';
 import { HlmTooltipImports } from '@spartan-ng/helm/tooltip';
@@ -9,7 +9,7 @@ import { HlmTooltipImports } from '@spartan-ng/helm/tooltip';
   selector: 'app-content-header',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIcon, HlmButtonImports, HlmSidebarImports, HlmTooltipImports],
-  providers: [provideIcons({ simpleGithub })],
+  providers: [provideIcons({ simpleGithub, simpleBuymeacoffee })],
   templateUrl: './content-header.html',
 })
 export class ContentHeader {}


### PR DESCRIPTION
Adds a Buy Me a Coffee button next to the KRINT Repo button in the header. Same icon-button style and tooltip pattern; uses `simpleBuymeacoffee` from the already-installed `@ng-icons/simple-icons` package, so no new deps.

Link: https://buymeacoffee.com/pianonic