### PR TITLE
Fixed provision and upgrade readiness probe to reach sibling containers via host.docker.internal

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -45,6 +45,12 @@ services:
       dockerfile: src/KRINT.API/Dockerfile
     container_name: krint
     restart: unless-stopped
+    # KRINT probes sibling DB containers via their host-published ports during provision /
+    # upgrade readiness. Inside this container localhost is the krint loopback, not the host,
+    # so the probe needs a name that resolves to the Docker host. host-gateway is supported on
+    # Docker Desktop and on Docker Engine 20.10+ for plain Linux.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     env_file: .env
     environment:
       ConnectionStrings__KrintDatabase: "Host=db;Port=5432;Database=krint;Username=postgres;Password=d4vpas8w0rd13!!!"

--- a/src/KRINT.Application/Command/Database/CreateDatabaseCommand.cs
+++ b/src/KRINT.Application/Command/Database/CreateDatabaseCommand.cs
@@ -19,6 +19,11 @@ namespace KRINT.Application.Command.Database
     public class CreateDatabaseCommandHandler(IDockerService docker, ISecretGeneratorService secretGenerator, ISecretsVaultService vault, KrintDbContext db, IOptions<KrintOptions> options, IActivityLogger activity, IInnerDatabaseServiceResolver innerDbs) : ICommandHandler<CreateDatabaseCommand, ProvisionedDatabaseDto>
     {
         private const string Host = "localhost";
+        // krint runs in its own container; localhost there is krint's loopback, not the Docker
+        // host. host.docker.internal resolves to the host via the host-gateway alias set in
+        // compose.yml's extra_hosts, so readiness + init probes can actually reach sibling
+        // containers' published ports. The user-facing instance.Host stays "localhost".
+        internal const string ProbeHost = "host.docker.internal";
 
         private readonly KrintOptions _options = options.Value;
 
@@ -97,7 +102,7 @@ namespace KRINT.Application.Command.Database
                 await vault.StoreAsync(ConnectionStringBuilder.VaultKeyFor(containerName), password, cancellationToken);
 
                 // Wait for the engine inside the container to accept connections.
-                var readinessTarget = new InnerDatabaseTarget(command.Engine, Host, hostPort, spec.DefaultUsername, password, databaseName);
+                var readinessTarget = new InnerDatabaseTarget(command.Engine, ProbeHost, hostPort, spec.DefaultUsername, password, databaseName);
                 await WaitForReadyAsync(readinessTarget, cancellationToken);
 
                 // pgvector engine entry: enable the extension once the container accepts connections.

--- a/src/KRINT.Application/Command/Database/UpgradeDatabaseCommand.cs
+++ b/src/KRINT.Application/Command/Database/UpgradeDatabaseCommand.cs
@@ -114,7 +114,9 @@ namespace KRINT.Application.Command.Database
                 await docker.StartContainerAsync(newCreateResult.ID, cancellationToken);
 
                 // Wait for the engine inside the new container to accept connections.
-                var readinessTarget = new InnerDatabaseTarget(instance.Engine, instance.Host, instance.Port, spec.DefaultUsername, password, spec.DefaultDatabase);
+                // Probe via host.docker.internal so krint can reach the host-published port.
+                // See CreateDatabaseCommandHandler.ProbeHost for the rationale.
+                var readinessTarget = new InnerDatabaseTarget(instance.Engine, CreateDatabaseCommandHandler.ProbeHost, instance.Port, spec.DefaultUsername, password, spec.DefaultDatabase);
                 await WaitForReadyAsync(readinessTarget, cancellationToken);
 
                 // 5. Restore the pre-upgrade dump into NEW.


### PR DESCRIPTION
Fixed provision and upgrade readiness probe to reach sibling containers via host.docker.internal

Closes #70