### PR TITLE
Fixed release sync PR merge to use admin bypass instead of self-approval

### DIFF
--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -53,8 +53,7 @@ jobs:
             --title "Bumped application.properties to $TAG_VERSION for release" \
             --body "Bumped application.properties to $TAG_VERSION for release" \
             --label CI/CD)
-          gh pr review "$PR_URL" --approve
-          gh pr merge "$PR_URL" --squash --delete-branch
+          gh pr merge "$PR_URL" --admin --squash --delete-branch
 
   build-and-push-multiarch:
     name: Build and Push Multi-Arch Docker Images


### PR DESCRIPTION
Fixed release sync PR merge to use admin bypass instead of self-approval

Closes #81