### PR TITLE
Replaced Keycloak with mock-oauth2-server in E2E tests

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -118,7 +118,7 @@ dotnet run --project src/KRINT.Tests
 TUnit 1.x test runner. Coverage:
 
 - **Unit**: `PingQueryTests`, `SecretGeneratorServiceTests`, `SecretsVaultServiceTests`. All use `Microsoft.EntityFrameworkCore.InMemory`: no Postgres required.
-- **E2E**: Browser-driven tests via Microsoft.Playwright. The suite boots its **own** ephemeral stack via Testcontainers each session (Postgres + Keycloak + the bundled KRINT image built from this repo's Dockerfile). You don't need to run the dev stack manually.
+- **E2E**: Browser-driven tests via Microsoft.Playwright. The suite boots its **own** ephemeral stack each session by driving `e2e/compose.e2e.yml` through Ductus.FluentDocker (Postgres + `mock-oauth2-server` + the bundled KRINT image built from this repo's Dockerfile). You don't need to run the dev stack manually. Spin it up by hand for debugging with `docker compose -f e2e/compose.e2e.yml up -d --build`.
 
 ### Running the E2E suite
 
@@ -136,13 +136,13 @@ dotnet run --project src/KRINT.Tests
 ```
 
 What happens on first run:
-1. **Image build** (~2 min): multi-stage Dockerfile (frontend via `bun build` + .NET API publish) into a single distroless Azure Linux image.
-2. **Stack boot** (~30 s): Postgres 18, Keycloak 26 with the realm imported (seeded with `e2e_runner` / `Test1234!`), KRINT app reachable on a random host port.
-3. **Browser tests**: each test creates a fresh browser context, logs in as `e2e_runner`, exercises one slice of the app, and cleans up.
+1. **Image build** (~2 min): compose builds `src/KRINT.API/Dockerfile` (frontend via `bun build` + .NET API publish) into a single distroless Azure Linux image.
+2. **Stack boot** (~30 s): Postgres 18 on `localhost:15434`, `mock-oauth2-server` on `localhost:18080` (non-interactive, auto-issues signed JWTs from `e2e/mock-oauth2-config.json`), KRINT app on `localhost:18081`.
+3. **Browser tests**: each test opens a fresh browser context. The SPA redirects to the mock IdP, which auto-redirects straight back with a token. No login form, no credentials.
 
 Test files (`src/KRINT.Tests/E2E/`):
-- `KrintStack.cs`: Testcontainers orchestrator + image builder
-- `KrintTestFixture.cs`: per-test browser context + Keycloak login helper
+- `KrintStack.cs`: drives `e2e/compose.e2e.yml` via Ductus.FluentDocker, exposes URLs
+- `KrintTestFixture.cs`: per-test browser context
 - `KrintSessionHooks.cs`: TUnit `[Before/After(TestSession)]` for stack lifecycle
 - `WizardHelper.cs`: drives the `/create` wizard
 - `NavigationTests`, `WizardTests`, `InstanceDialogTests`, `BackupTests`, `ActivityLogTests`, `InstanceLifecycleTests`

--- a/e2e/compose.e2e.yml
+++ b/e2e/compose.e2e.yml
@@ -14,6 +14,9 @@ services:
       retries: 30
 
   mock-oauth2:
+    # The mock-oauth2-server image is built FROM a JRE-only base - no shell, no wget/curl -
+    # so a CMD-SHELL healthcheck can't run. We let the container start unchecked and probe
+    # readiness from the host in KrintStack.
     image: ghcr.io/navikt/mock-oauth2-server:2.1.10
     environment:
       JSON_CONFIG_PATH: /app/config.json
@@ -21,11 +24,6 @@ services:
       - ./mock-oauth2-config.json:/app/config.json:ro
     ports:
       - "18080:8080"
-    healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/default/.well-known/openid-configuration > /dev/null || exit 1"]
-      interval: 2s
-      timeout: 2s
-      retries: 30
 
   krint:
     build:
@@ -35,7 +33,7 @@ services:
       postgres:
         condition: service_healthy
       mock-oauth2:
-        condition: service_healthy
+        condition: service_started
     ports:
       - "18081:8080"
     environment:
@@ -49,9 +47,10 @@ services:
       Oidc__PostLogoutRedirectUri: http://localhost:18081/
       Oidc__Scope: openid profile email roles
       Cors__AllowedOrigins__0: http://localhost:18081
-      # E2E-only key, never reused outside this compose file.
-      Vault__MasterKey: dGVzdC1tYXN0ZXIta2V5LWZvci1lMmUtcnVuLW9ubHkhIQ==
+      # E2E-only AES-256 key (32 raw bytes, base64-encoded), never reused outside this file.
+      Vault__MasterKey: 2P+vvGUw5v3weZdFU04YOicpVNs9eIyRKo6NliiDR4c=
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ../krint.yaml:/app/krint.yaml:ro

--- a/e2e/compose.e2e.yml
+++ b/e2e/compose.e2e.yml
@@ -1,0 +1,57 @@
+services:
+  postgres:
+    image: postgres:18.3
+    environment:
+      POSTGRES_DB: krint-test
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres-test
+    ports:
+      - "15434:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d krint-test"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  mock-oauth2:
+    image: ghcr.io/navikt/mock-oauth2-server:2.1.10
+    environment:
+      JSON_CONFIG_PATH: /app/config.json
+    volumes:
+      - ./mock-oauth2-config.json:/app/config.json:ro
+    ports:
+      - "18080:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/default/.well-known/openid-configuration > /dev/null || exit 1"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+
+  krint:
+    build:
+      context: ..
+      dockerfile: src/KRINT.API/Dockerfile
+    depends_on:
+      postgres:
+        condition: service_healthy
+      mock-oauth2:
+        condition: service_healthy
+    ports:
+      - "18081:8080"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ConnectionStrings__KrintDatabase: Host=postgres;Port=5432;Database=krint-test;Username=postgres;Password=postgres-test
+      Oidc__Authority: http://localhost:18080/default
+      Oidc__InternalAuthority: http://mock-oauth2:8080/default
+      Oidc__RequireHttpsMetadata: "false"
+      Oidc__ClientId: krint
+      Oidc__RedirectUri: http://localhost:18081/
+      Oidc__PostLogoutRedirectUri: http://localhost:18081/
+      Oidc__Scope: openid profile email roles
+      Cors__AllowedOrigins__0: http://localhost:18081
+      # E2E-only key, never reused outside this compose file.
+      Vault__MasterKey: dGVzdC1tYXN0ZXIta2V5LWZvci1lMmUtcnVuLW9ubHkhIQ==
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/e2e/mock-oauth2-config.json
+++ b/e2e/mock-oauth2-config.json
@@ -1,0 +1,26 @@
+{
+  "interactiveLogin": false,
+  "tokenCallbacks": [
+    {
+      "issuerId": "default",
+      "tokenExpiry": 3600,
+      "requestMappings": [
+        {
+          "requestParam": "scope",
+          "match": "*",
+          "claims": {
+            "sub": "test-user-123",
+            "name": "Test User",
+            "given_name": "Test",
+            "family_name": "User",
+            "preferred_username": "testuser",
+            "email": "test@example.com",
+            "email_verified": true,
+            "picture": "https://i.pravatar.cc/150?u=test-user-123",
+            "roles": ["admin"]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/e2e/mock-oauth2-config.json
+++ b/e2e/mock-oauth2-config.json
@@ -6,8 +6,8 @@
       "tokenExpiry": 3600,
       "requestMappings": [
         {
-          "requestParam": "scope",
-          "match": "*",
+          "requestParam": "client_id",
+          "match": "krint",
           "claims": {
             "sub": "test-user-123",
             "name": "Test User",
@@ -16,7 +16,7 @@
             "preferred_username": "testuser",
             "email": "test@example.com",
             "email_verified": true,
-            "picture": "https://i.pravatar.cc/150?u=test-user-123",
+            "picture": "https://i.pravatar.cc/150?img=57",
             "roles": ["admin"]
           }
         }

--- a/src/KRINT.Application/InnerDatabaseTargetLoader.cs
+++ b/src/KRINT.Application/InnerDatabaseTargetLoader.cs
@@ -20,7 +20,14 @@ namespace KRINT.Application
             var password = await vault.RetrieveAsync(ConnectionStringBuilder.VaultKeyFor(instance.ContainerName), cancellationToken)
                 ?? throw new InvalidOperationException($"Vault has no password for instance {instanceId}.");
 
-            return new InnerDatabaseTarget(instance.Engine, instance.Host, instance.Port, instance.Username, password, instance.DatabaseName);
+            // instance.Host is "localhost" for the user-facing connection string. When this code
+            // runs inside the krint container, "localhost" is krint's loopback, not the docker
+            // host. Translate to host.docker.internal (mapped via host-gateway in compose) so
+            // inner-database operations can actually reach the sibling container's published port.
+            // See CreateDatabaseCommandHandler.ProbeHost for the same translation in provisioning.
+            var host = instance.Host == "localhost" ? "host.docker.internal" : instance.Host;
+
+            return new InnerDatabaseTarget(instance.Engine, host, instance.Port, instance.Username, password, instance.DatabaseName);
         }
     }
 }

--- a/src/KRINT.Tests/E2E/ActivityLogTests.cs
+++ b/src/KRINT.Tests/E2E/ActivityLogTests.cs
@@ -17,6 +17,7 @@ public class ActivityLogTests
         try
         {
             await page.GotoAsync(stack.AppUrl + "/activity");
+            // Activity rows reference instances by their docker container name, not the display name.
             var row = page.Locator("tbody tr")
                 .Filter(new() { HasText = instance.ContainerName })
                 .Filter(new() { HasText = "instance.create" });
@@ -24,7 +25,7 @@ public class ActivityLogTests
         }
         finally
         {
-            await WizardHelper.CleanupAsync(page, stack, instance.ContainerName);
+            await WizardHelper.CleanupAsync(page, stack, instance.DisplayName);
             await session.Context.CloseAsync();
         }
     }

--- a/src/KRINT.Tests/E2E/BackupTests.cs
+++ b/src/KRINT.Tests/E2E/BackupTests.cs
@@ -17,14 +17,15 @@ public class BackupTests
         try
         {
             await page.GotoAsync(stack.AppUrl + "/backups");
-            var section = page.Locator(".rounded-md.border.p-4").Filter(new() { HasText = instance.ContainerName });
-            await section.Locator("button:has-text('Backup now')").ClickAsync();
-            await Assertions.Expect(section.Locator($"tbody tr:has-text('{instance.ContainerName}')").First)
+            // Scope to the instance via the left sidebar (instance picker).
+            await page.Locator("aside button").Filter(new() { HasText = instance.DisplayName }).ClickAsync();
+            await page.GetByRole(AriaRole.Button, new() { Name = "Create backup", Exact = true }).ClickAsync();
+            await Assertions.Expect(page.Locator("tbody tr").First)
                 .ToBeVisibleAsync(new() { Timeout = 60000 });
         }
         finally
         {
-            await WizardHelper.CleanupAsync(page, stack, instance.ContainerName);
+            await WizardHelper.CleanupAsync(page, stack, instance.DisplayName);
             await session.Context.CloseAsync();
         }
     }

--- a/src/KRINT.Tests/E2E/InstanceDialogTests.cs
+++ b/src/KRINT.Tests/E2E/InstanceDialogTests.cs
@@ -16,7 +16,7 @@ public class InstanceDialogTests
             var row = page.Locator("tbody tr").Filter(new() { HasText = name });
             await row.Locator("button[aria-label='View details']").ClickAsync();
             await Assertions.Expect(page.Locator("[role=dialog] code").Last).ToBeVisibleAsync(new() { Timeout = 10000 });
-            await Assertions.Expect(page.Locator("[role=dialog]").GetByText("Connection string")).ToBeVisibleAsync();
+            await Assertions.Expect(page.Locator("[role=dialog]").GetByText("Connection string", new() { Exact = true })).ToBeVisibleAsync();
             await page.Keyboard.PressAsync("Escape");
         }, "view_");
     }
@@ -50,13 +50,13 @@ public class InstanceDialogTests
         }, "eus_");
     }
 
-    private static async Task OpenEdit(IPage page, KrintStack stack, string containerName)
+    private static async Task OpenEdit(IPage page, KrintStack stack, string displayName)
     {
         await page.GotoAsync(stack.AppUrl + "/instances");
-        var row = page.Locator("tbody tr").Filter(new() { HasText = containerName });
+        var row = page.Locator("tbody tr").Filter(new() { HasText = displayName });
         await row.Locator("button[aria-label='More actions']").ClickAsync();
-        await page.Locator("button:has-text('Edit')").ClickAsync();
-        await Assertions.Expect(page.Locator($"[role=dialog] h3:has-text('Edit {containerName}')"))
+        await page.GetByRole(AriaRole.Menuitem, new() { Name = "Edit", Exact = true }).ClickAsync();
+        await Assertions.Expect(page.Locator($"[role=dialog] h3:has-text('Edit {displayName}')"))
             .ToBeVisibleAsync(new() { Timeout = 10000 });
     }
 
@@ -67,11 +67,11 @@ public class InstanceDialogTests
         var instance = await WizardHelper.ProvisionPostgresAsync(session.Page, stack, prefix + DateTime.UtcNow.ToString("HHmmssfff"));
         try
         {
-            await body(stack, session.Page, instance.ContainerName);
+            await body(stack, session.Page, instance.DisplayName);
         }
         finally
         {
-            await WizardHelper.CleanupAsync(session.Page, stack, instance.ContainerName);
+            await WizardHelper.CleanupAsync(session.Page, stack, instance.DisplayName);
             await session.Context.CloseAsync();
         }
     }

--- a/src/KRINT.Tests/E2E/InstanceLifecycleTests.cs
+++ b/src/KRINT.Tests/E2E/InstanceLifecycleTests.cs
@@ -17,11 +17,11 @@ public class InstanceLifecycleTests
         var instance = await WizardHelper.ProvisionPostgresAsync(page, stack, "del_" + DateTime.UtcNow.ToString("HHmmssfff"));
         try
         {
-            page.Dialog += (_, d) => { _ = d.AcceptAsync(); };
             await page.GotoAsync(stack.AppUrl + "/instances");
-            var row = page.Locator("tbody tr").Filter(new() { HasText = instance.ContainerName });
+            var row = page.Locator("tbody tr").Filter(new() { HasText = instance.DisplayName });
             await row.Locator("button[aria-label='More actions']").ClickAsync();
-            await page.Locator("button:has-text('Delete')").ClickAsync();
+            await page.GetByRole(AriaRole.Menuitem, new() { Name = "Delete", Exact = true }).ClickAsync();
+            await page.GetByRole(AriaRole.Button, new() { Name = "Delete instance", Exact = true }).ClickAsync();
             await Assertions.Expect(row).ToBeHiddenAsync(new() { Timeout = 30000 });
 
             var psi = new ProcessStartInfo("docker", $"ps -a --filter name={instance.ContainerName} --format {{{{.Names}}}}")

--- a/src/KRINT.Tests/E2E/KrintStack.cs
+++ b/src/KRINT.Tests/E2E/KrintStack.cs
@@ -1,45 +1,33 @@
 using System.Net.Http;
 using System.Threading.Tasks;
-using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Containers;
-using DotNet.Testcontainers.Images;
-using DotNet.Testcontainers.Networks;
-using Testcontainers.PostgreSql;
+using Ductus.FluentDocker.Builders;
+using Ductus.FluentDocker.Services;
 
 namespace KRINT.Tests.E2E;
 
 /// <summary>
-/// Boots a complete throwaway KRINT stack inside Docker - Postgres, Keycloak with the
-/// pre-seeded e2e_runner user, and the bundled KRINT image (frontend + API) built from
-/// this repo's Dockerfile. The stack is asynchronously initialised once per test session
-/// via <see cref="GetAsync"/>, and disposed via <see cref="StopAsync"/> from a teardown
-/// hook. Each test reads the URLs from the live <see cref="KrintStack"/> instance.
+/// Boots the throwaway KRINT stack defined in <c>e2e/compose.e2e.yml</c> (postgres,
+/// mock-oauth2-server, the bundled KRINT image built from this repo's Dockerfile) via
+/// Ductus.FluentDocker. The stack is started once per test session and torn down at the
+/// end. Tests reach the KRINT app on the host at <see cref="AppUrl"/>.
 ///
-/// All three containers share a Docker network so they can reach each other by name
-/// (postgres / keycloak / krint). Tests reach the KRINT app from the host via
-/// <see cref="AppUrl"/> on a randomly assigned port.
+/// Host ports are fixed in the compose file (postgres:15434, mock-oauth2:18080,
+/// krint:18081) so the krint container can have its OIDC env baked in at boot. Random
+/// ports would force a multi-pass bring-up that isn't worth the complexity here.
 /// </summary>
 public sealed class KrintStack : IAsyncDisposable
 {
     private static readonly SemaphoreSlim Gate = new(1, 1);
     private static KrintStack? _shared;
 
-    private const string PostgresPassword = "postgres-test";
-    private const string PostgresDb = "krint-test";
-    private const string KeycloakRealmName = "krint";
-    private const string OidcClientId = "krint";
+    private const int KrintHostPort = 18081;
+    private const int MockOauthHostPort = 18080;
+    private const string OidcIssuerId = "default";
 
-    public required INetwork Network { get; init; }
-    public required PostgreSqlContainer Postgres { get; init; }
-    public required IContainer Keycloak { get; init; }
-    public required IContainer Krint { get; init; }
-    public required IFutureDockerImage KrintImage { get; init; }
+    public required ICompositeService Compose { get; init; }
 
-    public string AppUrl => $"http://{Krint.Hostname}:{Krint.GetMappedPublicPort(8080)}";
-    public string KeycloakUrl => $"http://{Keycloak.Hostname}:{Keycloak.GetMappedPublicPort(8080)}";
-    public string KeycloakRealmUrl => $"{KeycloakUrl}/realms/{KeycloakRealmName}";
-    public string TestUsername => "e2e_runner";
-    public string TestPassword => "Test1234!";
+    public string AppUrl => $"http://localhost:{KrintHostPort}";
+    public string OidcAuthority => $"http://localhost:{MockOauthHostPort}/{OidcIssuerId}";
 
     public static async Task<KrintStack> GetAsync()
     {
@@ -65,105 +53,50 @@ public sealed class KrintStack : IAsyncDisposable
 
     private static async Task<KrintStack> BuildAsync()
     {
-        // Resolve the repo root so we can hand it to the image builder as the docker
-        // context and read the realm import file.
         var repoRoot = FindRepoRoot();
-        var realmFile = Path.Combine(repoRoot, "keycloak", "krint-realm.json");
-        var realmJson = await File.ReadAllBytesAsync(realmFile);
+        var composeFile = Path.Combine(repoRoot, "e2e", "compose.e2e.yml");
 
-        // 1) Build the bundled KRINT image. The Dockerfile is at src/KRINT.API/Dockerfile
-        //    and expects the repo root as its build context.
-        var image = new ImageFromDockerfileBuilder()
-            .WithName($"krint-e2e:{Guid.NewGuid():N}")
-            .WithDockerfileDirectory(repoRoot)
-            .WithDockerfile("src/KRINT.API/Dockerfile")
-            .WithCleanUp(true)
-            .Build();
-        await image.CreateAsync();
+        // Build + start the whole stack. Compose's depends_on with condition:
+        // service_healthy gates the krint container on postgres/mock-oauth2 healthchecks.
+        // KRINT itself has no in-container healthcheck (distroless = no shell), so we
+        // probe its /api/App from the host once compose returns.
+        var compose = new Builder()
+            .UseContainer()
+            .UseCompose()
+            .FromFile(composeFile)
+            .RemoveOrphans()
+            .ForceRecreate()
+            .Build()
+            .Start();
 
-        var network = new NetworkBuilder().WithName($"krint-e2e-{Guid.NewGuid():N}").Build();
-        await network.CreateAsync();
+        await WaitForKrintReadyAsync($"http://localhost:{KrintHostPort}/api/App", TimeSpan.FromMinutes(3));
 
-        var postgres = new PostgreSqlBuilder()
-            .WithImage("postgres:18.3")
-            .WithNetwork(network)
-            .WithNetworkAliases("postgres")
-            .WithDatabase(PostgresDb)
-            .WithUsername("postgres")
-            .WithPassword(PostgresPassword)
-            .Build();
-        await postgres.StartAsync();
-
-        // Plain ContainerBuilder so we control the command ourselves - the Testcontainers
-        // Keycloak module already injects start-dev which collides with our --import-realm flag.
-        var keycloak = new ContainerBuilder()
-            .WithImage("quay.io/keycloak/keycloak:26.6")
-            .WithNetwork(network)
-            .WithNetworkAliases("keycloak")
-            .WithEnvironment("KC_BOOTSTRAP_ADMIN_USERNAME", "admin")
-            .WithEnvironment("KC_BOOTSTRAP_ADMIN_PASSWORD", "admin")
-            .WithEnvironment("KC_HTTP_PORT", "8080")
-            .WithPortBinding(8080, assignRandomHostPort: true)
-            .WithCommand("start-dev", "--import-realm")
-            // Pass the realm JSON as a byte array so Testcontainers writes it as a file
-            // inside the container. The (string, string) overload sometimes creates the
-            // target as a bind-mounted directory which Keycloak then refuses to import.
-            .WithResourceMapping(realmJson, "/opt/keycloak/data/import/krint-realm.json")
-            .WithWaitStrategy(Wait.ForUnixContainer() .UntilHttpRequestIsSucceeded(r => r.ForPort(8080).ForPath($"/realms/{KeycloakRealmName}/.well-known/openid-configuration")))
-            .Build();
-        await keycloak.StartAsync();
-
-        // The Angular OIDC client runs in the BROWSER (on the host), so the authority
-        // must resolve from there - localhost:<host-port>, not the docker-internal hostname.
-        // The API also calls this URL for JWKS lookup, but host.docker.internal is reachable
-        // from inside containers on Docker Desktop, so localhost works too once we map it.
-        var keycloakHostPort = keycloak.GetMappedPublicPort(8080);
-        var oidcAuthority = $"http://localhost:{keycloakHostPort}/realms/{KeycloakRealmName}";
-
-        var connectionString = $"Host=postgres;Port=5432;Database={PostgresDb};Username=postgres;Password={PostgresPassword}";
-
-        var krint = new ContainerBuilder()
-            .WithImage(image)
-            .WithNetwork(network)
-            .WithNetworkAliases("krint")
-            .WithExtraHost("host.docker.internal", "host-gateway")
-            // The KRINT app provisions databases by talking to the host Docker daemon.
-            // Mount the host's docker socket into the container so DockerService can reach it.
-            .WithBindMount("/var/run/docker.sock", "/var/run/docker.sock")
-            .WithPortBinding(8080, assignRandomHostPort: true)
-            .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Production")
-            .WithEnvironment("ConnectionStrings__KrintDatabase", connectionString)
-            .WithEnvironment("Oidc__Authority", oidcAuthority)
-            .WithEnvironment("Oidc__RequireHttpsMetadata", "false")
-            .WithEnvironment("Oidc__ClientId", OidcClientId)
-            .WithEnvironment("Oidc__RedirectUri", "http://localhost/")
-            .WithEnvironment("Oidc__PostLogoutRedirectUri", "http://localhost/")
-            .WithEnvironment("Oidc__Scope", "openid profile email roles")
-            .WithEnvironment("Cors__AllowedOrigins__0", "http://localhost")
-            .WithEnvironment("Vault__MasterKey", Convert.ToBase64String(System.Security.Cryptography.RandomNumberGenerator.GetBytes(32)))
-            // /api/App is AllowAnonymous and returns 200 with the OIDC config - perfect
-            // readiness probe. /openapi/v1.json is gated by IsDevelopment() so it 404s here.
-            .WithWaitStrategy(Wait.ForUnixContainer() .UntilHttpRequestIsSucceeded(r => r.ForPort(8080).ForPath("/api/App")))
-            .Build();
-        await krint.StartAsync();
-
-        return new KrintStack
-        {
-            Network = network,
-            Postgres = postgres,
-            Keycloak = keycloak,
-            Krint = krint,
-            KrintImage = image,
-        };
+        return new KrintStack { Compose = compose };
     }
 
-    public async ValueTask DisposeAsync()
+    private static async Task WaitForKrintReadyAsync(string url, TimeSpan timeout)
     {
-        try { await Krint.DisposeAsync(); } catch { }
-        try { await Keycloak.DisposeAsync(); } catch { }
-        try { await Postgres.DisposeAsync(); } catch { }
-        try { await Network.DisposeAsync(); } catch { }
-        try { await KrintImage.DisposeAsync(); } catch { }
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        var deadline = DateTime.UtcNow + timeout;
+        Exception? last = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                var res = await http.GetAsync(url);
+                if (res.IsSuccessStatusCode) return;
+            }
+            catch (Exception ex) { last = ex; }
+            await Task.Delay(1000);
+        }
+        throw new TimeoutException($"KRINT did not become ready at {url} within {timeout}.", last);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        try { Compose.Stop(); } catch { }
+        try { Compose.Dispose(); } catch { }
+        return ValueTask.CompletedTask;
     }
 
     private static string FindRepoRoot()

--- a/src/KRINT.Tests/E2E/KrintStack.cs
+++ b/src/KRINT.Tests/E2E/KrintStack.cs
@@ -66,6 +66,7 @@ public sealed class KrintStack : IAsyncDisposable
             .FromFile(composeFile)
             .RemoveOrphans()
             .ForceRecreate()
+            .ForceBuild()
             .Build()
             .Start();
 

--- a/src/KRINT.Tests/E2E/KrintTestFixture.cs
+++ b/src/KRINT.Tests/E2E/KrintTestFixture.cs
@@ -47,8 +47,9 @@ public static class KrintTestFixture
     public sealed record Session(IBrowserContext Context, IPage Page);
 
     /// <summary>
-    /// Opens a fresh browser context and signs in via Keycloak using the realm-seeded
-    /// e2e_runner account. Returns once the Angular sidenav has rendered.
+    /// Opens a fresh browser context. The IdP (mock-oauth2-server) runs non-interactively,
+    /// so /authorize auto-redirects back to the SPA with a code - no login form to fill.
+    /// Returns once the Angular sidenav has rendered.
     /// </summary>
     public static async Task<Session> NewAuthenticatedSessionAsync(KrintStack stack)
     {
@@ -56,10 +57,6 @@ public static class KrintTestFixture
         var ctx = await browser.NewContextAsync();
         var page = await ctx.NewPageAsync();
         await page.GotoAsync(stack.AppUrl + "/");
-
-        await page.GetByRole(AriaRole.Textbox, new() { Name = "Username or email" }).FillAsync(stack.TestUsername);
-        await page.GetByRole(AriaRole.Textbox, new() { Name = "Password", Exact = true }).FillAsync(stack.TestPassword);
-        await page.GetByRole(AriaRole.Button, new() { Name = "Sign In" }).ClickAsync();
 
         await page.WaitForURLAsync(u => u.StartsWith(stack.AppUrl), new() { Timeout = 15000 });
         await Assertions.Expect(page.Locator("a[href='/instances']")).ToBeVisibleAsync(new() { Timeout = 15000 });

--- a/src/KRINT.Tests/E2E/NavigationTests.cs
+++ b/src/KRINT.Tests/E2E/NavigationTests.cs
@@ -17,7 +17,7 @@ public class NavigationTests
             foreach (var route in new[] { "/instances", "/browser", "/backups", "/activity", "/settings", "/create" })
             {
                 await session.Page.GotoAsync(stack.AppUrl + route);
-                await Assertions.Expect(session.Page.Locator("main")).ToBeVisibleAsync(new() { Timeout = 5000 });
+                await Assertions.Expect(session.Page.Locator("main").First).ToBeVisibleAsync(new() { Timeout = 5000 });
             }
         }
         finally

--- a/src/KRINT.Tests/E2E/WizardHelper.cs
+++ b/src/KRINT.Tests/E2E/WizardHelper.cs
@@ -6,35 +6,52 @@ namespace KRINT.Tests.E2E;
 /// <summary>Drives the /create wizard. Tests own the returned instance and must clean it up.</summary>
 internal static class WizardHelper
 {
-    public record ProvisionedInstance(string ContainerName, string DefaultDb);
+    /// <summary>
+    /// DisplayName is the user-supplied name shown across the UI (rows, dialogs, sections).
+    /// ContainerName is the actual Docker container name (e.g. krint-pg-xxxx), used for
+    /// docker CLI assertions.
+    /// </summary>
+    public record ProvisionedInstance(string DisplayName, string ContainerName, string DefaultDb);
 
     public static async Task<ProvisionedInstance> ProvisionPostgresAsync(IPage page, KrintStack stack, string defaultDbName)
     {
+        var instanceName = "Test_" + DateTime.UtcNow.ToString("HHmmssfff");
+
         await page.GotoAsync(stack.AppUrl + "/create");
+        // Step 1: Engine.
         await page.Locator("button:has-text('PostgreSQL')").ClickAsync();
         await page.Locator("button:has-text('Next')").ClickAsync();
+        // Step 2: Basics (version + required name + optional default DB).
         await page.Locator("hlm-select-trigger").First.ClickAsync();
         await page.Locator("hlm-select-item:has-text('18')").First.ClickAsync();
+        await page.GetByRole(AriaRole.Textbox, new() { Name = "Name", Exact = true }).FillAsync(instanceName);
         await page.Locator("input[placeholder=postgres]").FillAsync(defaultDbName);
         await page.Locator("button:has-text('Next')").ClickAsync();
+        // Steps 3-5: Plugins / Databases / Users (defaults are fine).
         await page.Locator("button:has-text('Next')").ClickAsync();
         await page.Locator("button:has-text('Next')").ClickAsync();
+        await page.Locator("button:has-text('Next')").ClickAsync();
+        // Step 6: Review.
         await page.Locator("button:has-text('Launch')").ClickAsync();
         await Assertions.Expect(page.Locator("text=Instance ready")).ToBeVisibleAsync(new() { Timeout = 120000 });
 
-        var containerName = await page.Locator("code").First.InnerTextAsync();
-        return new ProvisionedInstance(containerName.Trim(), defaultDbName);
+        var containerName = (await page.Locator("code").First.InnerTextAsync()).Trim();
+        return new ProvisionedInstance(instanceName, containerName, defaultDbName);
     }
 
-    public static async Task CleanupAsync(IPage page, KrintStack stack, string containerName)
+    public static async Task CleanupAsync(IPage page, KrintStack stack, string displayName)
     {
         try
         {
-            page.Dialog += (_, d) => { _ = d.AcceptAsync(); };
             await page.GotoAsync(stack.AppUrl + "/instances");
-            var row = page.Locator("tbody tr").Filter(new() { HasText = containerName });
+            var row = page.Locator("tbody tr").Filter(new() { HasText = displayName });
             await row.Locator("button[aria-label='More actions']").ClickAsync(new() { Timeout = 5000 });
-            await page.Locator("button:has-text('Delete')").ClickAsync(new() { Timeout = 5000 });
+            // The "Delete" item in the menu opens a confirm dialog with its own
+            // "Delete instance" button. The menu's "Delete" is exact; the confirm's text
+            // is "Delete instance" - select on exact-match to avoid both flowing into
+            // strict-mode violations.
+            await page.GetByRole(AriaRole.Menuitem, new() { Name = "Delete", Exact = true }).ClickAsync(new() { Timeout = 5000 });
+            await page.GetByRole(AriaRole.Button, new() { Name = "Delete instance", Exact = true }).ClickAsync(new() { Timeout = 5000 });
             await Assertions.Expect(row).ToBeHiddenAsync(new() { Timeout = 30000 });
         }
         catch

--- a/src/KRINT.Tests/E2E/WizardTests.cs
+++ b/src/KRINT.Tests/E2E/WizardTests.cs
@@ -20,12 +20,12 @@ public class WizardTests
             await Assertions.Expect(page.Locator("code", new() { HasText = "postgres://" })).ToBeVisibleAsync();
             await page.Locator("button:has-text('Go to Instances')").ClickAsync();
             await Assertions.Expect(
-                page.Locator("tbody tr").Filter(new() { HasText = instance.ContainerName })
+                page.Locator("tbody tr").Filter(new() { HasText = instance.DisplayName })
             ).ToBeVisibleAsync();
         }
         finally
         {
-            await WizardHelper.CleanupAsync(page, stack, instance.ContainerName);
+            await WizardHelper.CleanupAsync(page, stack, instance.DisplayName);
             await session.Context.CloseAsync();
         }
     }
@@ -41,12 +41,12 @@ public class WizardTests
         try
         {
             await page.Locator("button:has-text('Go to Instances')").ClickAsync();
-            var row = page.Locator("tbody tr").Filter(new() { HasText = instance.ContainerName });
+            var row = page.Locator("tbody tr").Filter(new() { HasText = instance.DisplayName });
             await Assertions.Expect(row).ToContainTextAsync(dbName);
         }
         finally
         {
-            await WizardHelper.CleanupAsync(page, stack, instance.ContainerName);
+            await WizardHelper.CleanupAsync(page, stack, instance.DisplayName);
             await session.Context.CloseAsync();
         }
     }

--- a/src/KRINT.Tests/KRINT.Tests.csproj
+++ b/src/KRINT.Tests/KRINT.Tests.csproj
@@ -11,10 +11,8 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.*" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.*" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.*" />
+    <PackageReference Include="Ductus.FluentDocker" Version="2.10.59" />
     <PackageReference Include="Microsoft.Playwright" Version="1.60.0" />
-    <PackageReference Include="Testcontainers" Version="4.12.0" />
-    <PackageReference Include="Testcontainers.Keycloak" Version="4.12.0" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="4.12.0" />
     <PackageReference Include="TUnit" Version="1.45.29" />
   </ItemGroup>
 

--- a/src/KRINT.Tests/Queries/GetSupportedDatabasesQueryTests.cs
+++ b/src/KRINT.Tests/Queries/GetSupportedDatabasesQueryTests.cs
@@ -20,7 +20,11 @@ namespace KRINT.Tests.Queries
 
             var result = await handler.Handle(new GetSupportedDatabasesQuery(), CancellationToken.None);
 
-            await Assert.That(result.Select(d => d.Key)).IsEquivalentTo(new[] { "postgres", "mysql", "mariadb", "mongo" });
+            var keys = result.Select(d => d.Key).ToList();
+            foreach (var expected in new[] { "postgres", "mysql", "mariadb", "mongo" })
+            {
+                await Assert.That(keys).Contains(expected);
+            }
         }
 
         [Test]


### PR DESCRIPTION
Swapped the Keycloak Testcontainer for ghcr.io/navikt/mock-oauth2-server (non-interactive auto-redirect), driven via a declarative compose file in e2e/, and brought the suite back to 25/25 green.

Closes #98