### PR TITLE
Added high-value E2E coverage for dashboard, backups, edit dialog, upgrade, browser, console

### DIFF
--- a/src/KRINT.Tests/E2E/BackupTests.cs
+++ b/src/KRINT.Tests/E2E/BackupTests.cs
@@ -10,18 +10,101 @@ public class BackupTests
     [Test]
     public async Task BackupNow_CreatesBackupRowForInstance()
     {
-        var stack = await KrintStack.GetAsync();
-        var session = await KrintTestFixture.NewAuthenticatedSessionAsync(stack);
-        var page = session.Page;
-        var instance = await WizardHelper.ProvisionPostgresAsync(page, stack, "bk_" + DateTime.UtcNow.ToString("HHmmssfff"));
-        try
+        await WithInstance("bk_", async (page, instance) =>
         {
-            await page.GotoAsync(stack.AppUrl + "/backups");
-            // Scope to the instance via the left sidebar (instance picker).
-            await page.Locator("aside button").Filter(new() { HasText = instance.DisplayName }).ClickAsync();
+            await page.GotoAsync($"{(await KrintStack.GetAsync()).AppUrl}/backups");
+            await ScopeToInstance(page, instance.DisplayName);
             await page.GetByRole(AriaRole.Button, new() { Name = "Create backup", Exact = true }).ClickAsync();
             await Assertions.Expect(page.Locator("tbody tr").First)
                 .ToBeVisibleAsync(new() { Timeout = 60000 });
+        });
+    }
+
+    [Test]
+    public async Task BackupRestore_CompletesWithoutError()
+    {
+        await WithInstance("brst_", async (page, instance) =>
+        {
+            var stack = await KrintStack.GetAsync();
+            await page.GotoAsync(stack.AppUrl + "/backups");
+            await ScopeToInstance(page, instance.DisplayName);
+            await page.GetByRole(AriaRole.Button, new() { Name = "Create backup", Exact = true }).ClickAsync();
+            var backupRow = page.Locator("tbody tr").First;
+            await Assertions.Expect(backupRow).ToBeVisibleAsync(new() { Timeout = 60000 });
+
+            var restoreBtn = backupRow.Locator("button[aria-label='Restore from this backup']");
+            await restoreBtn.ClickAsync();
+            await page.GetByRole(AriaRole.Button, new() { Name = "Restore", Exact = true }).ClickAsync();
+            await Assertions.Expect(page.Locator("[role=dialog]")).ToBeHiddenAsync(new() { Timeout = 60000 });
+
+            // SPA disables the row's Restore button while restoring() === entry.id. Wait
+            // for it to re-enable - that's the "restore completed" signal, success or
+            // failure. If it failed, an error banner would appear too.
+            await Assertions.Expect(restoreBtn).ToBeEnabledAsync(new() { Timeout = 90000 });
+            await Assertions.Expect(page.Locator("main .text-destructive")).ToHaveCountAsync(0);
+            // Restore doesn't duplicate the backup row.
+            await Assertions.Expect(page.Locator("tbody tr")).ToHaveCountAsync(1);
+        });
+    }
+
+    [Test]
+    public async Task BackupDelete_RemovesRowFromList()
+    {
+        await WithInstance("bdel_", async (page, instance) =>
+        {
+            var stack = await KrintStack.GetAsync();
+            await page.GotoAsync(stack.AppUrl + "/backups");
+            await ScopeToInstance(page, instance.DisplayName);
+            await page.GetByRole(AriaRole.Button, new() { Name = "Create backup", Exact = true }).ClickAsync();
+            var row = page.Locator("tbody tr").First;
+            await Assertions.Expect(row).ToBeVisibleAsync(new() { Timeout = 60000 });
+
+            await row.Locator("button[aria-label='Delete backup']").ClickAsync();
+            // The confirm modal's primary button is just labelled "Delete".
+            await page.GetByRole(AriaRole.Button, new() { Name = "Delete", Exact = true }).ClickAsync();
+            await Assertions.Expect(row).ToBeHiddenAsync(new() { Timeout = 15000 });
+        });
+    }
+
+    [Test]
+    public async Task BackupSchedule_CreatesAndDeletesPresetSchedule()
+    {
+        await WithInstance("bsch_", async (page, instance) =>
+        {
+            var stack = await KrintStack.GetAsync();
+            await page.GotoAsync(stack.AppUrl + "/backups");
+            await ScopeToInstance(page, instance.DisplayName);
+
+            await page.GetByRole(AriaRole.Button, new() { Name = "New schedule", Exact = true }).ClickAsync();
+            // The dialog presets are buttons whose label starts with the cadence name.
+            await page.Locator("[role=dialog] button").Filter(new() { HasTextRegex = new System.Text.RegularExpressions.Regex("^Every hour") }).ClickAsync();
+            await page.GetByRole(AriaRole.Button, new() { Name = "Create schedule", Exact = true }).ClickAsync();
+
+            var scheduleRow = page.Locator("tbody tr").Filter(new() { HasText = "Hourly backup" });
+            await Assertions.Expect(scheduleRow).ToBeVisibleAsync(new() { Timeout = 15000 });
+
+            await scheduleRow.Locator("button[aria-label='Delete schedule']").ClickAsync();
+            // The confirm modal's primary button text is "Delete schedule" - scope to the
+            // dialog so we don't also match the row's icon button (same aria-label).
+            await page.Locator("[role=dialog] button").Filter(new() { HasText = "Delete schedule" }).ClickAsync();
+            await Assertions.Expect(scheduleRow).ToBeHiddenAsync(new() { Timeout = 15000 });
+        });
+    }
+
+    private static async Task ScopeToInstance(IPage page, string displayName)
+    {
+        await page.Locator("aside button").Filter(new() { HasText = displayName }).ClickAsync();
+    }
+
+    private static async Task WithInstance(string prefix, Func<IPage, WizardHelper.ProvisionedInstance, Task> body)
+    {
+        var stack = await KrintStack.GetAsync();
+        var session = await KrintTestFixture.NewAuthenticatedSessionAsync(stack);
+        var page = session.Page;
+        var instance = await WizardHelper.ProvisionPostgresAsync(page, stack, prefix + DateTime.UtcNow.ToString("HHmmssfff"));
+        try
+        {
+            await body(page, instance);
         }
         finally
         {

--- a/src/KRINT.Tests/E2E/BrowserTests.cs
+++ b/src/KRINT.Tests/E2E/BrowserTests.cs
@@ -1,0 +1,50 @@
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using TUnit.Core;
+
+namespace KRINT.Tests.E2E;
+
+[NotInParallel("e2e")]
+public class BrowserTests
+{
+    /// <summary>
+    /// Pick an instance, type a CREATE TABLE in the Query tab, run it, switch back to
+    /// the Data tab, and verify the new table shows up in the Entities sidebar. Covers
+    /// the run-query + entity-refresh code paths in one shot.
+    /// </summary>
+    [Test]
+    public async Task Browser_RunsCreateTableAndShowsItInSidebar()
+    {
+        var stack = await KrintStack.GetAsync();
+        var session = await KrintTestFixture.NewAuthenticatedSessionAsync(stack);
+        var page = session.Page;
+        var instance = await WizardHelper.ProvisionPostgresAsync(page, stack, "brw_" + DateTime.UtcNow.ToString("HHmmssfff"));
+        try
+        {
+            await page.GotoAsync(stack.AppUrl + "/browser");
+            await page.Locator("aside button").Filter(new() { HasText = instance.DisplayName }).ClickAsync();
+
+            await page.GetByRole(AriaRole.Button, new() { Name = "Query", Exact = true }).ClickAsync();
+            // CodeMirror's contenteditable doesn't respond to Fill; focus + execCommand
+            // is the cheapest cross-extension way to push text in.
+            await page.Locator(".cm-content").ClickAsync();
+            await page.EvaluateAsync(@"() => {
+                document.querySelector('.cm-content').focus();
+                document.execCommand('insertText', false, 'CREATE TABLE e2e_browser_test (id int);');
+            }");
+            await page.GetByRole(AriaRole.Button, new() { Name = "Run query", Exact = true }).ClickAsync();
+            await Assertions.Expect(page.GetByText("0 rows affected"))
+                .ToBeVisibleAsync(new() { Timeout = 15000 });
+
+            await page.GetByRole(AriaRole.Button, new() { Name = "Data", Exact = true }).ClickAsync();
+            await page.Locator("button[aria-label='Refresh instances, databases, and entities']").ClickAsync();
+            await Assertions.Expect(page.Locator("aside").GetByText("e2e_browser_test"))
+                .ToBeVisibleAsync(new() { Timeout = 15000 });
+        }
+        finally
+        {
+            await WizardHelper.CleanupAsync(page, stack, instance.DisplayName);
+            await session.Context.CloseAsync();
+        }
+    }
+}

--- a/src/KRINT.Tests/E2E/ConsoleTests.cs
+++ b/src/KRINT.Tests/E2E/ConsoleTests.cs
@@ -1,0 +1,51 @@
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using TUnit.Core;
+
+namespace KRINT.Tests.E2E;
+
+[NotInParallel("e2e")]
+public class ConsoleTests
+{
+    /// <summary>
+    /// Pick an instance, switch to the Exec tab, type a marker echo, and confirm the
+    /// SignalR exec stream pipes the output back into the in-page terminal.
+    /// </summary>
+    [Test]
+    public async Task Console_ExecsCommandAndStreamsOutput()
+    {
+        var stack = await KrintStack.GetAsync();
+        var session = await KrintTestFixture.NewAuthenticatedSessionAsync(stack);
+        var page = session.Page;
+        var instance = await WizardHelper.ProvisionPostgresAsync(page, stack, "cns_" + DateTime.UtcNow.ToString("HHmmssfff"));
+        try
+        {
+            await page.GotoAsync(stack.AppUrl + "/console");
+            await page.Locator("aside button").Filter(new() { HasText = instance.DisplayName }).ClickAsync();
+            await page.GetByRole(AriaRole.Button, new() { Name = "Exec", Exact = true }).ClickAsync();
+
+            // xterm uses a hidden helper textarea (.xterm-helper-textarea) to absorb
+            // keystrokes - it's not Playwright-visible. Click the visible terminal viewport
+            // to give it focus, then type via page.Keyboard.
+            // Wait for the SignalR exec channel to actually open before typing - the OPEN
+            // badge surfaces this in the UI; without it, keystrokes hit a dead socket.
+            await Assertions.Expect(page.Locator("main").GetByText("OPEN").First)
+                .ToBeVisibleAsync(new() { Timeout = 20000 });
+            // xterm uses an opacity-0 helper <textarea> to absorb keystrokes - Playwright
+            // refuses to click it (invisible). Focus it via JS, then dispatch real
+            // keystrokes with page.Keyboard so they flow through the SignalR exec channel.
+            await page.EvaluateAsync("() => document.querySelector('.xterm-helper-textarea').focus()");
+            await page.Keyboard.TypeAsync("echo krint_e2e_marker");
+            await page.Keyboard.PressAsync("Enter");
+
+            // xterm renders text into many spans; scope to <main> and match substring.
+            await Assertions.Expect(page.Locator("main").GetByText("krint_e2e_marker").First)
+                .ToBeVisibleAsync(new() { Timeout = 15000 });
+        }
+        finally
+        {
+            await WizardHelper.CleanupAsync(page, stack, instance.DisplayName);
+            await session.Context.CloseAsync();
+        }
+    }
+}

--- a/src/KRINT.Tests/E2E/DashboardTests.cs
+++ b/src/KRINT.Tests/E2E/DashboardTests.cs
@@ -1,0 +1,48 @@
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using TUnit.Core;
+
+namespace KRINT.Tests.E2E;
+
+[NotInParallel("e2e")]
+public class DashboardTests
+{
+    /// <summary>
+    /// After provisioning, the home dashboard's "Instances" KPI should pick up the new
+    /// instance (via the SignalR push, or at worst the next poll) and the recent
+    /// activity list should include the instance.create event for it.
+    /// </summary>
+    [Test]
+    public async Task Dashboard_ReflectsNewlyProvisionedInstance()
+    {
+        var stack = await KrintStack.GetAsync();
+        var session = await KrintTestFixture.NewAuthenticatedSessionAsync(stack);
+        var page = session.Page;
+
+        await page.GotoAsync(stack.AppUrl + "/");
+        var instancesCard = page.Locator("article").Filter(new() { HasText = "Instances" }).First;
+        var beforeText = (await instancesCard.InnerTextAsync()).Trim();
+        var before = ParseLeadingInt(beforeText.Split('\n').Last().Trim());
+
+        var instance = await WizardHelper.ProvisionPostgresAsync(page, stack, "dash_" + DateTime.UtcNow.ToString("HHmmssfff"));
+        try
+        {
+            await page.GotoAsync(stack.AppUrl + "/");
+            await Assertions.Expect(instancesCard.Locator(".text-2xl"))
+                .ToHaveTextAsync((before + 1).ToString(), new() { Timeout = 15000 });
+
+            // "Recent activity" lives in a <section>, not <article>; rows show the
+            // instance's container name in a .truncate <span>.
+            var recentActivity = page.Locator("section").Filter(new() { HasText = "Recent activity" });
+            await Assertions.Expect(recentActivity.GetByText(instance.ContainerName).First)
+                .ToBeVisibleAsync(new() { Timeout = 15000 });
+        }
+        finally
+        {
+            await WizardHelper.CleanupAsync(page, stack, instance.DisplayName);
+            await session.Context.CloseAsync();
+        }
+    }
+
+    private static int ParseLeadingInt(string s) => int.TryParse(new string(s.TakeWhile(char.IsDigit).ToArray()), out var n) ? n : 0;
+}

--- a/src/KRINT.Tests/E2E/InstanceDialogTests.cs
+++ b/src/KRINT.Tests/E2E/InstanceDialogTests.cs
@@ -50,6 +50,120 @@ public class InstanceDialogTests
         }, "eus_");
     }
 
+    [Test]
+    public async Task EditDialog_RenamesInstance()
+    {
+        await Run(async (stack, page, name) =>
+        {
+            await OpenEdit(page, stack, name);
+            var newName = "rn_" + DateTime.UtcNow.ToString("HHmmssfff");
+            await page.Locator("[role=dialog] input[placeholder*='Pangolin']").FillAsync(newName);
+            await page.GetByRole(AriaRole.Button, new() { Name = "Save name", Exact = true }).ClickAsync();
+            // The dialog title updates immediately (optimistic UI), and the API call
+            // succeeds in the background. Verifying the title is sufficient end-to-end
+            // proof that the rename was issued; persistence belongs in an integration
+            // test where we can read the API directly.
+            await Assertions.Expect(page.Locator($"[role=dialog] h3:has-text('Edit {newName}')"))
+                .ToBeVisibleAsync(new() { Timeout = 10000 });
+            await page.Keyboard.PressAsync("Escape");
+        }, "ren_");
+    }
+
+    [Test]
+    public async Task EditDialog_DropsInnerDatabase()
+    {
+        await Run(async (stack, page, name) =>
+        {
+            await OpenEdit(page, stack, name);
+            await page.Locator("[role=dialog] input[placeholder=my_database]").FillAsync("todrop");
+            await page.Locator("[role=dialog] button:has-text('Add')").ClickAsync();
+            var item = page.Locator("[role=dialog] li").Filter(new() { HasText = "todrop" });
+            await Assertions.Expect(item).ToBeVisibleAsync(new() { Timeout = 10000 });
+
+            await page.Locator("button[aria-label='Drop todrop']").ClickAsync();
+            // Scope the confirm to the topmost dialog so we don't match anything in the
+            // edit dialog underneath.
+            await page.Locator("[role=dialog]").Last.Locator("button").Filter(new() { HasText = "Drop database" }).ClickAsync();
+            await Assertions.Expect(item).ToBeHiddenAsync(new() { Timeout = 30000 });
+            await page.Keyboard.PressAsync("Escape");
+        }, "drp_");
+    }
+
+    [Test]
+    public async Task EditDialog_DeletesUser()
+    {
+        await Run(async (stack, page, name) =>
+        {
+            await OpenEdit(page, stack, name);
+            await page.Locator("[role=dialog] button:has-text('Users')").ClickAsync();
+            await page.Locator("[role=dialog] input[placeholder=alice]").FillAsync("victim");
+            await page.Locator("[role=dialog] button:has-text('Create')").ClickAsync();
+            var row = page.Locator("[role=dialog] li").Filter(new() { HasText = "victim" });
+            await Assertions.Expect(row).ToBeVisibleAsync(new() { Timeout = 15000 });
+
+            await page.Locator("button[aria-label='Delete user victim']").ClickAsync();
+            await page.GetByRole(AriaRole.Button, new() { Name = "Delete user", Exact = true }).ClickAsync();
+            await Assertions.Expect(row).ToBeHiddenAsync(new() { Timeout = 15000 });
+            await page.Keyboard.PressAsync("Escape");
+        }, "delu_");
+    }
+
+    [Test]
+    public async Task EditDialog_ResetsUserPassword()
+    {
+        await Run(async (stack, page, name) =>
+        {
+            await OpenEdit(page, stack, name);
+            await page.Locator("[role=dialog] button:has-text('Users')").ClickAsync();
+            var userInput = page.Locator("[role=dialog] input[placeholder=alice]");
+            await userInput.FillAsync("rotator");
+            // Wait for the Create button to enable - it's bound to newUserName.length > 0
+            // and can lag a frame behind FillAsync.
+            var createBtn = page.Locator("[role=dialog] button:has-text('Create')");
+            await Assertions.Expect(createBtn).ToBeEnabledAsync(new() { Timeout = 5000 });
+            await createBtn.ClickAsync();
+            // First reveal panel from initial create.
+            await Assertions.Expect(page.Locator("[role=dialog]").GetByText("Save this password"))
+                .ToBeVisibleAsync(new() { Timeout = 15000 });
+            // Dismiss it so we can confirm the reset triggers a *new* reveal.
+            await page.Locator("[role=dialog] button[aria-label='Dismiss']").ClickAsync();
+
+            await page.Locator("button[aria-label='Reset password for rotator']").ClickAsync();
+            await page.GetByRole(AriaRole.Button, new() { Name = "Reset password", Exact = true }).ClickAsync();
+            await Assertions.Expect(page.Locator("[role=dialog]").GetByText("Save this password"))
+                .ToBeVisibleAsync(new() { Timeout = 15000 });
+            await Assertions.Expect(page.Locator("[role=dialog]").GetByText("User rotator"))
+                .ToBeVisibleAsync();
+            await page.Keyboard.PressAsync("Escape");
+        }, "rst_");
+    }
+
+    [Test]
+    public async Task EditDialog_GrantsUserAccessToDatabase()
+    {
+        await Run(async (stack, page, name) =>
+        {
+            await OpenEdit(page, stack, name);
+            await page.Locator("[role=dialog] button:has-text('Users')").ClickAsync();
+            await page.Locator("[role=dialog] input[placeholder=alice]").FillAsync("grantee");
+            await page.Locator("[role=dialog] button:has-text('Create')").ClickAsync();
+            var userRow = page.Locator("[role=dialog] li").Filter(new() { HasText = "grantee" });
+            await Assertions.Expect(userRow).ToBeVisibleAsync(new() { Timeout = 15000 });
+            // Dismiss the password reveal so we can find the user row's Grant button.
+            await page.Locator("[role=dialog] button[aria-label='Dismiss']").ClickAsync();
+
+            // The grant control is an hlm-select-trigger (custom element), not a real
+            // <button>, so target by its placeholder text instead of an aria-label.
+            await userRow.Locator("hlm-select-trigger").ClickAsync();
+            // The dropdown's option is the default database name "postgres".
+            await page.GetByRole(AriaRole.Option, new() { Name = "postgres", Exact = true }).ClickAsync();
+
+            // Grant badge appears inline on the user row.
+            await Assertions.Expect(userRow.GetByText("postgres")).ToBeVisibleAsync(new() { Timeout = 10000 });
+            await page.Keyboard.PressAsync("Escape");
+        }, "grnt_");
+    }
+
     private static async Task OpenEdit(IPage page, KrintStack stack, string displayName)
     {
         await page.GotoAsync(stack.AppUrl + "/instances");
@@ -60,7 +174,7 @@ public class InstanceDialogTests
             .ToBeVisibleAsync(new() { Timeout = 10000 });
     }
 
-    private static async Task Run(Func<KrintStack, IPage, string, Task> body, string prefix)
+    private static async Task Run(Func<KrintStack, IPage, string, Task> body, string prefix, bool skipOuterCleanup = false)
     {
         var stack = await KrintStack.GetAsync();
         var session = await KrintTestFixture.NewAuthenticatedSessionAsync(stack);
@@ -71,7 +185,8 @@ public class InstanceDialogTests
         }
         finally
         {
-            await WizardHelper.CleanupAsync(session.Page, stack, instance.DisplayName);
+            if (!skipOuterCleanup)
+                await WizardHelper.CleanupAsync(session.Page, stack, instance.DisplayName);
             await session.Context.CloseAsync();
         }
     }

--- a/src/KRINT.Tests/E2E/UpgradeTests.cs
+++ b/src/KRINT.Tests/E2E/UpgradeTests.cs
@@ -1,0 +1,78 @@
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using TUnit.Core;
+
+namespace KRINT.Tests.E2E;
+
+[NotInParallel("e2e")]
+public class UpgradeTests
+{
+    /// <summary>
+    /// Provision postgres (WizardHelper actually lands on 18.4 because its has-text("18")
+    /// matches the first version row), fire the upgrade API to 17 directly (the SPA's
+    /// hlm-select dropdown inside a dialog refuses to open under headless Playwright
+    /// reliably; the UI control is not what we're testing here), and verify the row's
+    /// Version cell flips to 17 after a fresh /instances fetch. The upgrade pipeline
+    /// does a real dump → fresh container → restore → swap, so we allow a generous
+    /// timeout.
+    /// </summary>
+    [Test]
+    public async Task Upgrade_BumpsVersionAndUpdatesRow()
+    {
+        var stack = await KrintStack.GetAsync();
+        var session = await KrintTestFixture.NewAuthenticatedSessionAsync(stack);
+        var page = session.Page;
+        var instance = await WizardHelper.ProvisionPostgresAsync(page, stack, "up_" + DateTime.UtcNow.ToString("HHmmssfff"));
+        try
+        {
+            // Pull the bearer token out of the angular-auth-oidc-client's sessionStorage
+            // so raw fetch calls can authenticate the same way Angular's HttpClient does.
+            var token = await page.EvaluateAsync<string>(@"() => {
+                for (let i = 0; i < sessionStorage.length; i++) {
+                    const k = sessionStorage.key(i);
+                    if (!k) continue;
+                    const v = sessionStorage.getItem(k);
+                    try {
+                        const j = JSON.parse(v);
+                        if (j?.authnResult?.access_token) return j.authnResult.access_token;
+                        if (j?.access_token) return j.access_token;
+                    } catch { /* not json */ }
+                }
+                return null;
+            }");
+            await Assert.That(token).IsNotNull();
+
+            // Look up the instance id and fire the upgrade endpoint directly. The
+            // hlm-select dropdown inside a dialog refuses to open reliably under headless
+            // Playwright, so we bypass the UI control for this assertion.
+            var id = await page.EvaluateAsync<string>($@"async () => {{
+                const res = await fetch('/api/Database', {{ headers: {{ Authorization: 'Bearer {token}', Accept: 'application/json' }} }});
+                const list = await res.json();
+                const match = list.find(d => d.displayName === '{instance.DisplayName}');
+                return match?.id;
+            }}");
+            await Assert.That(id).IsNotNull();
+
+            var status = await page.EvaluateAsync<int>($@"async () => {{
+                const res = await fetch('/api/Database/{id}/upgrade', {{
+                    method: 'POST',
+                    headers: {{ 'Content-Type': 'application/json', Authorization: 'Bearer {token}' }},
+                    body: JSON.stringify({{ targetVersion: '17' }}),
+                }});
+                return res.status;
+            }}");
+            await Assert.That(status).IsEqualTo(200);
+
+            // The handler returns once the dump-restore-swap finishes, so by here the
+            // version field is already updated. Refresh /instances and assert the cell.
+            await page.GotoAsync(stack.AppUrl + "/instances");
+            var row = page.Locator("tbody tr").Filter(new() { HasText = instance.DisplayName });
+            await Assertions.Expect(row.Locator("td").Nth(1)).ToHaveTextAsync("17", new() { Timeout = 30000 });
+        }
+        finally
+        {
+            await WizardHelper.CleanupAsync(page, stack, instance.DisplayName);
+            await session.Context.CloseAsync();
+        }
+    }
+}


### PR DESCRIPTION
Extended the E2E suite from 25 to 37 tests (all green). New coverage: dashboard KPIs + recent activity, backup restore/delete/schedules, edit-dialog rename/drop-db/delete-user/reset-password/grant-access, upgrade version, browser query + entity refresh, console exec stream.

Closes #100