### PR TITLE
Added mssql to migration wizard allow-lists

### DIFF
--- a/src/KRINT.Application/Command/Migration/StreamMigrateContainerCommand.cs
+++ b/src/KRINT.Application/Command/Migration/StreamMigrateContainerCommand.cs
@@ -27,12 +27,12 @@ namespace KRINT.Application.Command.Migration
         IActivityLogger activity)
         : IStreamCommandHandler<StreamMigrateContainerCommand, MigrationProgressDto>
     {
-        // v1 supports SQL engines with an existing IBackupService. mssql/cockroachdb/clickhouse
-        // backup services are deferred (see issue #114, follow-up PRs 1b/1c/1d) - excluding
-        // them here gives a clear error rather than a NotSupportedException from the resolver.
+        // v1 supports SQL engines with an existing IBackupService. cockroachdb and clickhouse
+        // backups are still deferred (issues #119 and #120 capture why) - excluding them here
+        // gives a clear error instead of NotSupportedException from the resolver.
         private static readonly HashSet<string> SupportedSourceEngines = new(StringComparer.OrdinalIgnoreCase)
         {
-            "postgres", "pgvector", "timescaledb", "mysql", "mariadb",
+            "postgres", "pgvector", "timescaledb", "mysql", "mariadb", "mssql",
         };
 
         private const int TotalSteps = 5;

--- a/src/KRINT.Frontend/src/app/databases/database-register-external-dialog.ts
+++ b/src/KRINT.Frontend/src/app/databases/database-register-external-dialog.ts
@@ -216,7 +216,7 @@ export class DatabaseRegisterExternalDialog {
 
   // v1 of the migration command supports only the SQL engines with an existing IBackupService.
   // Keep this in sync with StreamMigrateContainerCommandHandler.SupportedSourceEngines.
-  private static readonly migrationEngines = new Set(['postgres', 'pgvector', 'timescaledb', 'mysql', 'mariadb']);
+  private static readonly migrationEngines = new Set(['postgres', 'pgvector', 'timescaledb', 'mysql', 'mariadb', 'mssql']);
 
   protected canMigrate(c: DiscoveredContainerDto): boolean {
     return !!c.composeProject


### PR DESCRIPTION
Added mssql to migration wizard allow-lists

Closes #114

Depends on #116, #117, and #118. Branch is stacked on #117 with #116 merged in; needs a rebase onto main once those land. Touches one line on each side (backend `SupportedSourceEngines`, frontend `migrationEngines`) so the SQL Server backup service from #118 is actually reachable through the wizard.