### PR TITLE
Add migration for MigratedToInstanceId column

### DIFF
--- a/src/KRINT.Infrastructure/Migrations/20260612113437_PendingChanges.Designer.cs
+++ b/src/KRINT.Infrastructure/Migrations/20260612113437_PendingChanges.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using KRINT.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace KRINT.Infrastructure.Migrations
 {
     [DbContext(typeof(KrintDbContext))]
-    partial class KrintDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260612113437_PendingChanges")]
+    partial class PendingChanges
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/KRINT.Infrastructure/Migrations/20260612113437_PendingChanges.cs
+++ b/src/KRINT.Infrastructure/Migrations/20260612113437_PendingChanges.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace KRINT.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class PendingChanges : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "MigratedToInstanceId",
+                table: "DatabaseInstances",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MigratedToInstanceId",
+                table: "DatabaseInstances");
+        }
+    }
+}


### PR DESCRIPTION
Generates the missing migration that adds MigratedToInstanceId to DatabaseInstances, resolving the PendingModelChangesWarning crash on startup.

Closes #127