### PR TITLE
Switch runtime to non-distroless for ICU/MSSQL support

### DIFF
--- a/src/KRINT.API/Dockerfile
+++ b/src/KRINT.API/Dockerfile
@@ -25,7 +25,7 @@ COPY src .
 RUN dotnet publish "KRINT.API/KRINT.API.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 # ---------- Stage 4: runtime (distroless Azure Linux) ----------
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.8-azurelinux3.0-distroless AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.8-azurelinux3.0 AS final
 WORKDIR /app
 EXPOSE 8080
 ENV ASPNETCORE_URLS=http://+:8080 ASPNETCORE_ENVIRONMENT=Production


### PR DESCRIPTION
The distroless Azure Linux image lacks ICU libraries, causing SqlClient to throw 'Globalization Invariant Mode is not supported' on any MSSQL operation. Switching to the non-distroless aspnet image provides the required libraries.

Closes #125