### PR TITLE
Fixed external localhost instances failing inner-database operations

### DIFF
--- a/src/KRINT.Application/Command/DatabaseInstance/RegisterExternalDatabaseCommand.cs
+++ b/src/KRINT.Application/Command/DatabaseInstance/RegisterExternalDatabaseCommand.cs
@@ -46,7 +46,7 @@ namespace KRINT.Application.Command.DatabaseInstance
             // itself. Rewrite to host.docker.internal for the probe only; the original host is
             // stored in the DB so the UI shows what the user typed.
             var inner = ResolveInner(req.Engine);
-            var probeHost = (req.Host is "localhost" or "127.0.0.1") ? "host.docker.internal" : req.Host;
+            var probeHost = InnerDatabaseTargetLoader.ResolveTargetHost(req.Host, isManaged: false, isPublic: false);
             var target = new InnerDatabaseTarget(req.Engine, probeHost, req.Port, req.Username, req.Password, req.DatabaseName);
             try
             {

--- a/src/KRINT.Application/InnerDatabaseTargetLoader.cs
+++ b/src/KRINT.Application/InnerDatabaseTargetLoader.cs
@@ -20,19 +20,22 @@ namespace KRINT.Application
             var password = await vault.RetrieveAsync(ConnectionStringBuilder.VaultKeyFor(instance), cancellationToken)
                 ?? throw new InvalidOperationException($"Vault has no password for instance {instanceId}.");
 
-            // For managed instances, instance.Host is "localhost" - the user-facing connection
-            // string. When this code runs inside the krint container, "localhost" is krint's
-            // loopback, not the docker host. Translate based on the container's binding:
-            //   * IsPublic (0.0.0.0): use host.docker.internal so KRINT-in-a-container can reach
-            //     the host-published port via the host-gateway alias.
-            //   * !IsPublic (127.0.0.1): the binding only accepts loopback connections, so we
-            //     must use 127.0.0.1 directly - host.docker.internal resolves to a different IP.
-            // External instances use the host the user typed verbatim - never translate that.
-            var host = instance.IsManaged && instance.Host == "localhost"
-                ? (instance.IsPublic ? "host.docker.internal" : "127.0.0.1")
-                : instance.Host;
+            var host = ResolveTargetHost(instance.Host, instance.IsManaged, instance.IsPublic);
 
             return new InnerDatabaseTarget(instance.Engine, host, instance.Port, instance.Username, password, instance.DatabaseName);
         }
+
+        // "localhost"/"127.0.0.1" in instance.Host is the user-facing connection string. Inside
+        // the krint container that's krint's own loopback, not the docker host, so translate:
+        //   * managed + !IsPublic: the container port is bound to 127.0.0.1 only, which rejects
+        //     host.docker.internal (a different IP) - keep 127.0.0.1.
+        //   * everything else (managed public, external on localhost): host.docker.internal via
+        //     the host-gateway alias - the same rewrite RegisterExternalDatabaseCommand uses for
+        //     its probe, so post-registration operations reach the same address that was probed.
+        // Any other host the user typed is used verbatim.
+        public static string ResolveTargetHost(string host, bool isManaged, bool isPublic) =>
+            host is not ("localhost" or "127.0.0.1") ? host
+            : isManaged && !isPublic ? "127.0.0.1"
+            : "host.docker.internal";
     }
 }

--- a/src/KRINT.Tests/Services/ResolveTargetHostTests.cs
+++ b/src/KRINT.Tests/Services/ResolveTargetHostTests.cs
@@ -1,0 +1,47 @@
+using KRINT.Application;
+
+namespace KRINT.Tests.Services
+{
+    /// <summary>
+    /// External instances registered with "localhost" must be reached via host.docker.internal
+    /// from inside the krint container, exactly like the registration probe. Regressing this
+    /// made every post-registration inner-database operation 500 (issue #134).
+    /// </summary>
+    public class ResolveTargetHostTests
+    {
+        [Test]
+        public async Task ExternalLocalhost_ReturnsHostDockerInternal()
+        {
+            var host = InnerDatabaseTargetLoader.ResolveTargetHost("localhost", isManaged: false, isPublic: true);
+            await Assert.That(host).IsEqualTo("host.docker.internal");
+        }
+
+        [Test]
+        public async Task External127001_ReturnsHostDockerInternal()
+        {
+            var host = InnerDatabaseTargetLoader.ResolveTargetHost("127.0.0.1", isManaged: false, isPublic: true);
+            await Assert.That(host).IsEqualTo("host.docker.internal");
+        }
+
+        [Test]
+        public async Task ManagedLocalhostPrivate_Returns127Loopback()
+        {
+            var host = InnerDatabaseTargetLoader.ResolveTargetHost("localhost", isManaged: true, isPublic: false);
+            await Assert.That(host).IsEqualTo("127.0.0.1");
+        }
+
+        [Test]
+        public async Task ManagedLocalhostPublic_ReturnsHostDockerInternal()
+        {
+            var host = InnerDatabaseTargetLoader.ResolveTargetHost("localhost", isManaged: true, isPublic: true);
+            await Assert.That(host).IsEqualTo("host.docker.internal");
+        }
+
+        [Test]
+        public async Task RemoteHost_IsUntouched()
+        {
+            var host = InnerDatabaseTargetLoader.ResolveTargetHost("db.example.com", isManaged: false, isPublic: true);
+            await Assert.That(host).IsEqualTo("db.example.com");
+        }
+    }
+}


### PR DESCRIPTION
Translate localhost/127.0.0.1 to host.docker.internal for external instances in InnerDatabaseTargetLoader, matching the registration probe.

Closes #134