### PR TITLE
Sorted browse table list with underscore-prefixed tables first

### DIFF
--- a/src/KRINT.Application/Queries/Browse/ListTablesQuery.cs
+++ b/src/KRINT.Application/Queries/Browse/ListTablesQuery.cs
@@ -15,7 +15,13 @@ namespace KRINT.Application.Queries.Browse
         {
             var target = await InnerDatabaseTargetLoader.LoadAsync(db, vault, query.InstanceId, cancellationToken);
             var tables = await resolver.Resolve(target.Engine).ListTablesAsync(target, query.Database, cancellationToken);
-            return tables.Select(t => t.ToDto()).ToList();
+            // Engine collations disagree on where '_' sorts; pin the order here so
+            // underscore-prefixed tables (__EFMigrationsHistory etc.) always come first.
+            return tables
+                .OrderBy(t => t.Name.StartsWith('_') ? 0 : 1)
+                .ThenBy(t => t.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(t => t.ToDto())
+                .ToList();
         }
     }
 }


### PR DESCRIPTION
Pin table ordering in ListTablesQueryHandler so underscore-prefixed tables like __EFMigrationsHistory always come first, independent of engine collation.

Closes #140