### PR TITLE
Added SeaweedFS engine

### DIFF
--- a/krint.yaml
+++ b/krint.yaml
@@ -33,3 +33,4 @@ krint:
     neo4j:          33200-33399
     qdrant:         34000-34199
     valkey:         34200-34399
+    seaweedfs:      34400-34599

--- a/src/KRINT.Application/Command/Database/CreateDatabaseCommand.cs
+++ b/src/KRINT.Application/Command/Database/CreateDatabaseCommand.cs
@@ -261,6 +261,13 @@ namespace KRINT.Application.Command.Database
                 case "mssql":
                     // SA password must be ≥8 chars, mixed case, digit, special. SecretGenerator already does this.
                     return new EngineSpec("mcr.microsoft.com/mssql/server", "mssql", 1433, "sa", "master", "/var/opt/mssql");
+                case "seaweedfs":
+                    // `server -s3` runs master+volume+filer+S3 gateway in one process; we publish
+                    // only the S3 port (8333). Username is the S3 access key; the AWS_* env vars
+                    // seed it as an admin identity. "default" is just the recorded bucket name -
+                    // buckets are created on demand via the UI.
+                    return new EngineSpec("chrislusf/seaweedfs", "weed", 8333, "krint", "default", "/data",
+                        CmdFactory: _ => new[] { "server", "-s3", "-dir=/data" });
                 default:
                     throw new ArgumentException($"Unsupported engine '{engine}'.", nameof(engine));
             }
@@ -380,6 +387,13 @@ namespace KRINT.Application.Command.Database
                         "ACCEPT_EULA=Y",
                         $"MSSQL_SA_PASSWORD={password}",
                         "MSSQL_PID=Developer",
+                    };
+                case "seaweedfs":
+                    // SeaweedFS reads these as a fallback admin identity when no s3 config exists.
+                    return new List<string>
+                    {
+                        "AWS_ACCESS_KEY_ID=krint",
+                        $"AWS_SECRET_ACCESS_KEY={password}",
                     };
                 default:
                     throw new ArgumentException($"Unsupported engine '{engine}'.", nameof(engine));

--- a/src/KRINT.Application/ConnectionStringBuilder.cs
+++ b/src/KRINT.Application/ConnectionStringBuilder.cs
@@ -27,6 +27,7 @@ namespace KRINT.Application
                 "qdrant" => $"http://{host}:{port} (api-key: {password})",
                 "valkey" => $"redis://default:{password}@{host}:{port}/{database}",
                 "mssql" => $"Server={host},{port};User Id={username};Password={password};Database={database};TrustServerCertificate=true",
+                "seaweedfs" => $"http://{host}:{port} (S3 access-key: {username}, secret-key: {password})",
                 _ => throw new ArgumentException($"Unsupported engine '{engine}'.", nameof(engine)),
             };
         }

--- a/src/KRINT.Application/Queries/SupportedDatabase/GetSupportedDatabasesQuery.cs
+++ b/src/KRINT.Application/Queries/SupportedDatabase/GetSupportedDatabasesQuery.cs
@@ -132,6 +132,21 @@ namespace KRINT.Application.Queries.SupportedDatabase
             SupportsBackup = false,
         };
 
+        // SeaweedFS: blob store via its S3 gateway. Buckets = databases, one virtual
+        // "_all_objects" collection per bucket, objects = rows (key/size/modified/etag).
+        // Deleting a row deletes the object; upload/edit need a file UI - out of scope for v1.
+        private static readonly EngineCapabilitiesDto SeaweedFsCaps = SqlCaps with
+        {
+            DatabaseTerm = "bucket",
+            TableTerm = "collection",
+            RowTerm = "object",
+            SupportsDropTable = false,
+            SupportsRowInsert = false,
+            SupportsRowEdit = false,
+            SupportsUsers = false,
+            SupportsBackup = false,
+        };
+
         // Redis: 16 fixed DB numbers, no logical-DB CRUD; key-value rows; no users in our model.
         private static readonly EngineCapabilitiesDto RedisCaps = new()
         {
@@ -266,6 +281,8 @@ namespace KRINT.Application.Queries.SupportedDatabase
             ("elasticsearch", "Elasticsearch", "elasticsearch",     ElasticCaps),
             // Vector
             ("qdrant",      "Qdrant",      "qdrant/qdrant",         QdrantCaps),
+            // Blob / object storage
+            ("seaweedfs",   "SeaweedFS",   "chrislusf/seaweedfs",   SeaweedFsCaps),
         };
 
         public async ValueTask<IReadOnlyList<SupportedDatabaseDto>> Handle(GetSupportedDatabasesQuery query, CancellationToken cancellationToken)

--- a/src/KRINT.Infrastructure/Extensions/InnerDatabasesExtensions.cs
+++ b/src/KRINT.Infrastructure/Extensions/InnerDatabasesExtensions.cs
@@ -24,6 +24,7 @@ namespace KRINT.Infrastructure.Extensions
             services.AddSingleton<IInnerDatabaseService, QdrantInnerDatabaseService>();
             services.AddSingleton<IInnerDatabaseService, ValkeyInnerDatabaseService>();
             services.AddSingleton<IInnerDatabaseService, MsSqlInnerDatabaseService>();
+            services.AddSingleton<IInnerDatabaseService, SeaweedFsInnerDatabaseService>();
             services.AddSingleton<IInnerDatabaseServiceResolver, InnerDatabaseServiceResolver>();
 
             services.AddSingleton<IInnerUserService, PostgresInnerUserService>();
@@ -42,6 +43,7 @@ namespace KRINT.Infrastructure.Extensions
             services.AddSingleton<IInnerUserService, QdrantInnerUserService>();
             services.AddSingleton<IInnerUserService, ValkeyInnerUserService>();
             services.AddSingleton<IInnerUserService, MsSqlInnerUserService>();
+            services.AddSingleton<IInnerUserService, SeaweedFsInnerUserService>();
             services.AddSingleton<IInnerUserServiceResolver, InnerUserServiceResolver>();
 
             services.AddSingleton<IInnerSchemaService, PostgresInnerSchemaService>();
@@ -60,6 +62,7 @@ namespace KRINT.Infrastructure.Extensions
             services.AddSingleton<IInnerSchemaService, QdrantInnerSchemaService>();
             services.AddSingleton<IInnerSchemaService, ValkeyInnerSchemaService>();
             services.AddSingleton<IInnerSchemaService, MsSqlInnerSchemaService>();
+            services.AddSingleton<IInnerSchemaService, SeaweedFsInnerSchemaService>();
             services.AddSingleton<IInnerSchemaServiceResolver, InnerSchemaServiceResolver>();
 
             // Query console - SQL engines only for v1. Engines without an entry surface in the

--- a/src/KRINT.Infrastructure/KRINT.Infrastructure.csproj
+++ b/src/KRINT.Infrastructure/KRINT.Infrastructure.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.S3" Version="4.0.24.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
       <PrivateAssets>all</PrivateAssets>

--- a/src/KRINT.Infrastructure/Services/DatabaseVersionService.cs
+++ b/src/KRINT.Infrastructure/Services/DatabaseVersionService.cs
@@ -43,6 +43,8 @@ namespace KRINT.Infrastructure.Services
             ["cockroachdb"] = new[] { "v26.2.0", "latest-v26.2", "v26.1.4", "v25.4.10", "v24.1.29" },
             // SQL Server uses Microsoft-curated marketing tags. 2025 is the current GA.
             ["mssql"] = new[] { "2025-latest", "2022-latest", "2019-latest" },
+            // SeaweedFS - 4.33 is current (verified on hub.docker.com 2026-06-12).
+            ["seaweedfs"] = new[] { "4.33", "4.32", "4.31" },
         };
 
         private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(24);

--- a/src/KRINT.Infrastructure/Services/SeaweedFsServices.cs
+++ b/src/KRINT.Infrastructure/Services/SeaweedFsServices.cs
@@ -1,0 +1,148 @@
+using System.Globalization;
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Model;
+using KRINT.Infrastructure.Interfaces;
+
+namespace KRINT.Infrastructure.Services
+{
+    // SeaweedFS blob store, accessed via its S3-compatible gateway. The instance's Username is
+    // the S3 access key and Password the secret key (seeded through AWS_ACCESS_KEY_ID /
+    // AWS_SECRET_ACCESS_KEY on the container, which SeaweedFS picks up as an admin identity).
+    //
+    // Model: buckets = databases, a single virtual "_all_objects" collection per bucket,
+    // objects = rows (key / size / last-modified / etag). Deleting a row deletes the object.
+
+    internal static class SeaweedFsS3
+    {
+        public static AmazonS3Client Build(InnerDatabaseTarget target)
+        {
+            var config = new AmazonS3Config
+            {
+                ServiceURL = $"http://{target.Host}:{target.Port}",
+                ForcePathStyle = true,
+                AuthenticationRegion = "us-east-1",
+                Timeout = TimeSpan.FromSeconds(10),
+                MaxErrorRetry = 0,
+                // SDK v4 defaults to always sending CRC checksum headers, which not every
+                // S3-compatible store accepts. WHEN_REQUIRED keeps requests plain.
+                RequestChecksumCalculation = RequestChecksumCalculation.WHEN_REQUIRED,
+                ResponseChecksumValidation = ResponseChecksumValidation.WHEN_REQUIRED,
+            };
+            return new AmazonS3Client(new BasicAWSCredentials(target.Username, target.Password), config);
+        }
+    }
+
+    public class SeaweedFsInnerDatabaseService : IInnerDatabaseService
+    {
+        public string Engine => "seaweedfs";
+
+        public async Task<IReadOnlyList<string>> ListAsync(InnerDatabaseTarget target, CancellationToken cancellationToken = default)
+        {
+            using var s3 = SeaweedFsS3.Build(target);
+            var resp = await s3.ListBucketsAsync(cancellationToken);
+            return (resp.Buckets ?? []).Select(b => b.BucketName).OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToList();
+        }
+
+        public async Task CreateAsync(InnerDatabaseTarget target, string name, CancellationToken cancellationToken = default)
+        {
+            InnerDatabaseNameValidator.Require(name);
+            using var s3 = SeaweedFsS3.Build(target);
+            await s3.PutBucketAsync(name, cancellationToken);
+        }
+
+        public async Task DropAsync(InnerDatabaseTarget target, string name, CancellationToken cancellationToken = default)
+        {
+            InnerDatabaseNameValidator.Require(name);
+            using var s3 = SeaweedFsS3.Build(target);
+            await s3.DeleteBucketAsync(name, cancellationToken);
+        }
+    }
+
+    public class SeaweedFsInnerUserService : IInnerUserService
+    {
+        public string Engine => "seaweedfs";
+        public Task<IReadOnlyList<string>> ListAsync(InnerDatabaseTarget target, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
+        public Task CreateAsync(InnerDatabaseTarget target, string name, string password, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("SeaweedFS identity management is not exposed in this version.");
+        public Task DeleteAsync(InnerDatabaseTarget target, string name, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("SeaweedFS identity management is not exposed in this version.");
+        public Task ResetPasswordAsync(InnerDatabaseTarget target, string name, string newPassword, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("SeaweedFS identity management is not exposed in this version.");
+        public Task GrantAccessAsync(InnerDatabaseTarget target, string user, string database, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("SeaweedFS identity management is not exposed in this version.");
+    }
+
+    public class SeaweedFsInnerSchemaService : IInnerSchemaService
+    {
+        public string Engine => "seaweedfs";
+
+        private const string VirtualTable = "_all_objects";
+
+        public Task<IReadOnlyList<TableSummary>> ListTablesAsync(InnerDatabaseTarget target, string database, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<TableSummary>>(new[] { new TableSummary(VirtualTable, "collection") });
+
+        public async Task<TableRows> FetchRowsAsync(InnerDatabaseTarget target, string database, string table, int limit, int offset, CancellationToken cancellationToken = default)
+        {
+            InnerDatabaseNameValidator.Require(database);
+            limit = Math.Clamp(limit, 1, 500);
+            offset = Math.Max(0, offset);
+
+            using var s3 = SeaweedFsS3.Build(target);
+
+            // ponytail: S3 has no offset - page from the start and skip. O(offset) per request;
+            // switch to continuation-token caching if anyone browses huge buckets.
+            var rows = new List<IReadOnlyList<string?>>();
+            var toSkip = offset;
+            string? token = null;
+            do
+            {
+                var resp = await s3.ListObjectsV2Async(new ListObjectsV2Request
+                {
+                    BucketName = database,
+                    MaxKeys = Math.Min(1000, toSkip + limit - rows.Count),
+                    ContinuationToken = token,
+                }, cancellationToken);
+
+                foreach (var obj in resp.S3Objects ?? [])
+                {
+                    if (toSkip > 0) { toSkip--; continue; }
+                    if (rows.Count >= limit) break;
+                    rows.Add(new[]
+                    {
+                        obj.Key,
+                        obj.Size?.ToString(CultureInfo.InvariantCulture),
+                        obj.LastModified?.ToString("o", CultureInfo.InvariantCulture),
+                        obj.ETag?.Trim('"'),
+                    });
+                }
+                token = resp.IsTruncated == true ? resp.NextContinuationToken : null;
+            } while (token is not null && rows.Count < limit);
+
+            return new TableRows(new[] { "key", "size", "lastModified", "etag" }, rows, null);
+        }
+
+        public Task InsertRowAsync(InnerDatabaseTarget target, string database, string table, InsertRowRequest request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Uploading objects is not exposed in this version.");
+        public Task UpdateRowAsync(InnerDatabaseTarget target, string database, string table, UpdateRowRequest request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Objects cannot be edited in place.");
+
+        public async Task DeleteRowAsync(InnerDatabaseTarget target, string database, string table, DeleteRowRequest request, CancellationToken cancellationToken = default)
+        {
+            InnerDatabaseNameValidator.Require(database);
+            var keyIndex = -1;
+            for (var i = 0; i < request.Columns.Count; i++)
+                if (request.Columns[i] == "key") keyIndex = i;
+            var key = keyIndex >= 0 ? request.OriginalValues[keyIndex] : null;
+            if (string.IsNullOrEmpty(key))
+                throw new ArgumentException("Object key is required to delete.", nameof(request));
+
+            using var s3 = SeaweedFsS3.Build(target);
+            await s3.DeleteObjectAsync(database, key, cancellationToken);
+        }
+
+        public Task DropTableAsync(InnerDatabaseTarget target, string database, string table, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("SeaweedFS exposes a single virtual object listing per bucket.");
+    }
+}


### PR DESCRIPTION
Add SeaweedFS as a managed engine via its S3 gateway: buckets as databases, a virtual _all_objects collection per bucket, object rows with key/size/modified/etag, and object delete.

Closes #142