### PR TITLE
Fixed loopback-bound instance reachability from containerized KRINT

### DIFF
--- a/src/KRINT.Application/Command/Database/CreateDatabaseCommand.cs
+++ b/src/KRINT.Application/Command/Database/CreateDatabaseCommand.cs
@@ -123,9 +123,14 @@ namespace KRINT.Application.Command.Database
                 await docker.StartContainerAsync(createResult.ID, cancellationToken);
                 await vault.StoreAsync(ConnectionStringBuilder.VaultKeyFor(containerName), password, cancellationToken);
 
-                // Wait for the engine inside the container to accept connections.
-                var readinessTarget = new InnerDatabaseTarget(command.Engine, ResolveProbeHost(command.IsPublic), hostPort, spec.DefaultUsername, password, databaseName);
-                await WaitForReadyAsync(readinessTarget, cancellationToken);
+                // Wait for the engine inside the container to accept connections. The returned
+                // target carries whichever probe host actually responded - init steps below
+                // must use it so they reach the same address.
+                var readinessTarget = await ReadinessProbe.WaitForReadyAsync(
+                    innerDbs.Resolve(command.Engine),
+                    new InnerDatabaseTarget(command.Engine, ResolveProbeHost(command.IsPublic), hostPort, spec.DefaultUsername, password, databaseName),
+                    command.IsPublic,
+                    cancellationToken);
 
                 // pgvector engine entry: enable the extension once the container accepts connections.
                 if (string.Equals(command.Engine, "pgvector", StringComparison.OrdinalIgnoreCase))
@@ -429,38 +434,6 @@ namespace KRINT.Application.Command.Database
             await conn.OpenAsync(cancellationToken);
             await using var cmd = new Npgsql.NpgsqlCommand(sql, conn);
             await cmd.ExecuteNonQueryAsync(cancellationToken);
-        }
-
-        private async Task WaitForReadyAsync(InnerDatabaseTarget target, CancellationToken cancellationToken)
-        {
-            var inner = innerDbs.Resolve(target.Engine);
-            // Cold-boot envelope per engine. JVM-heavy ones (Cassandra, Elasticsearch, Neo4j)
-            // routinely need >60s on first start; SQL engines + cache stores come up in a
-            // handful of seconds.
-            var ceilingSeconds = target.Engine switch
-            {
-                "cassandra" or "elasticsearch" or "neo4j" => 180,
-                _ => 60,
-            };
-            var deadline = DateTime.UtcNow.AddSeconds(ceilingSeconds);
-            var delayMs = 500;
-            Exception? last = null;
-
-            while (DateTime.UtcNow < deadline)
-            {
-                try
-                {
-                    await inner.ListAsync(target, cancellationToken);
-                    return;
-                }
-                catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
-                {
-                    last = ex;
-                    await Task.Delay(delayMs, cancellationToken);
-                    delayMs = Math.Min(delayMs * 2, 3000);
-                }
-            }
-            throw new InvalidOperationException($"{target.Engine} container did not become ready within {ceilingSeconds}s.", last);
         }
 
         private async Task<int> AllocateHostPortAsync(string engine, CancellationToken cancellationToken)

--- a/src/KRINT.Application/Command/Database/UpgradeDatabaseCommand.cs
+++ b/src/KRINT.Application/Command/Database/UpgradeDatabaseCommand.cs
@@ -129,10 +129,9 @@ namespace KRINT.Application.Command.Database
                 await docker.StartContainerAsync(newCreateResult.ID, cancellationToken);
 
                 // Wait for the engine inside the new container to accept connections.
-                // Probe via host.docker.internal so krint can reach the host-published port.
-                // See CreateDatabaseCommandHandler.ProbeHost for the rationale.
+                // ReadinessProbe tries both probe hosts - see its doc comment.
                 var readinessTarget = new InnerDatabaseTarget(instance.Engine, CreateDatabaseCommandHandler.ResolveProbeHost(instance.IsPublic), instance.Port, spec.DefaultUsername, password, spec.DefaultDatabase);
-                await WaitForReadyAsync(readinessTarget, cancellationToken);
+                await ReadinessProbe.WaitForReadyAsync(innerDbs.Resolve(instance.Engine), readinessTarget, instance.IsPublic, cancellationToken);
 
                 // 5. Restore the pre-upgrade dump into NEW.
                 await using (var stream = backupStorage.OpenRead(backupPath)
@@ -183,36 +182,5 @@ namespace KRINT.Application.Command.Database
             catch { /* not accessible from this process; user cleans up manually */ }
         }
 
-        /// <summary>Real-query readiness probe. A bare TCP probe lies for Postgres (it binds
-        /// 5432 during init but refuses queries until bootstrap is done), which then crashes the
-        /// pg_restore step. Running an actual ListAsync against the inner-db service only returns
-        /// once the engine accepts queries. Mirrors CreateDatabaseCommandHandler.WaitForReadyAsync.</summary>
-        private async Task WaitForReadyAsync(InnerDatabaseTarget target, CancellationToken cancellationToken)
-        {
-            var inner = innerDbs.Resolve(target.Engine);
-            var ceilingSeconds = target.Engine switch
-            {
-                "cassandra" or "elasticsearch" or "neo4j" => 180,
-                _ => 60,
-            };
-            var deadline = DateTime.UtcNow.AddSeconds(ceilingSeconds);
-            Exception? last = null;
-            var delayMs = 500;
-            while (DateTime.UtcNow < deadline)
-            {
-                try
-                {
-                    await inner.ListAsync(target, cancellationToken);
-                    return;
-                }
-                catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
-                {
-                    last = ex;
-                    await Task.Delay(delayMs, cancellationToken);
-                    delayMs = Math.Min(delayMs * 2, 3000);
-                }
-            }
-            throw new InvalidOperationException($"{target.Engine} container did not become ready within {ceilingSeconds}s.", last);
-        }
     }
 }

--- a/src/KRINT.Application/InnerDatabaseTargetLoader.cs
+++ b/src/KRINT.Application/InnerDatabaseTargetLoader.cs
@@ -20,9 +20,46 @@ namespace KRINT.Application
             var password = await vault.RetrieveAsync(ConnectionStringBuilder.VaultKeyFor(instance), cancellationToken)
                 ?? throw new InvalidOperationException($"Vault has no password for instance {instanceId}.");
 
-            var host = ResolveTargetHost(instance.Host, instance.IsManaged, instance.IsPublic);
+            var preferred = ResolveTargetHost(instance.Host, instance.IsManaged, instance.IsPublic);
+            var host = await PickReachableHostAsync(preferred, instance.Port, cancellationToken);
 
             return new InnerDatabaseTarget(instance.Engine, host, instance.Port, instance.Username, password, instance.DatabaseName);
+        }
+
+        // Which local probe host can reach a published port depends on where KRINT runs: a
+        // containerized KRINT can't reach 127.0.0.1-bound ports via its own loopback but can
+        // via Docker Desktop's host-gateway (host.docker.internal); a host-run KRINT is the
+        // reverse. Pre-probe with a cheap TCP connect and fall back to the alternate.
+        // ponytail: one extra TCP connect per operation (~1ms locally) - cache per port if it
+        // ever shows up in profiles.
+        private static async Task<string> PickReachableHostAsync(string preferred, int port, CancellationToken cancellationToken)
+        {
+            var alternate = preferred switch
+            {
+                "127.0.0.1" => "host.docker.internal",
+                "host.docker.internal" => "127.0.0.1",
+                _ => null,   // real hostname the user typed - never second-guess it
+            };
+            if (alternate is null) return preferred;
+            if (await CanConnectAsync(preferred, port, cancellationToken)) return preferred;
+            if (await CanConnectAsync(alternate, port, cancellationToken)) return alternate;
+            return preferred;   // neither answered - let the engine call surface the real error
+        }
+
+        private static async Task<bool> CanConnectAsync(string host, int port, CancellationToken cancellationToken)
+        {
+            try
+            {
+                using var client = new System.Net.Sockets.TcpClient();
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(TimeSpan.FromSeconds(2));
+                await client.ConnectAsync(host, port, cts.Token);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         // "localhost"/"127.0.0.1" in instance.Host is the user-facing connection string. Inside

--- a/src/KRINT.Application/ReadinessProbe.cs
+++ b/src/KRINT.Application/ReadinessProbe.cs
@@ -1,0 +1,54 @@
+using KRINT.Infrastructure.Interfaces;
+
+namespace KRINT.Application
+{
+    /// <summary>
+    /// Waits for a freshly started container's engine to accept connections, trying both
+    /// candidate probe hosts each round. Which host can reach a published port depends on
+    /// where KRINT runs: a containerized KRINT can't reach 127.0.0.1-bound ports via its own
+    /// loopback but can via Docker Desktop's host-gateway (host.docker.internal); a host-run
+    /// KRINT is the reverse. Trying both covers both deployments without configuration.
+    /// Returns the target with the host that actually responded, so callers can run
+    /// post-readiness init (extensions, plugins) against the same address.
+    /// </summary>
+    public static class ReadinessProbe
+    {
+        public static int CeilingSecondsFor(string engine) => engine switch
+        {
+            // JVM-heavy engines routinely need >60s on first start.
+            "cassandra" or "elasticsearch" or "neo4j" => 180,
+            _ => 60,
+        };
+
+        public static async Task<InnerDatabaseTarget> WaitForReadyAsync(IInnerDatabaseService inner, InnerDatabaseTarget target, bool isPublic, CancellationToken cancellationToken)
+        {
+            var preferred = Command.Database.CreateDatabaseCommandHandler.ResolveProbeHost(isPublic);
+            var fallback = preferred == "127.0.0.1" ? Command.Database.CreateDatabaseCommandHandler.ProbeHost : "127.0.0.1";
+            var candidates = new[] { target with { Host = preferred }, target with { Host = fallback } };
+
+            var ceilingSeconds = CeilingSecondsFor(target.Engine);
+            var deadline = DateTime.UtcNow.AddSeconds(ceilingSeconds);
+            var delayMs = 500;
+            Exception? last = null;
+
+            while (DateTime.UtcNow < deadline)
+            {
+                foreach (var candidate in candidates)
+                {
+                    try
+                    {
+                        await inner.ListAsync(candidate, cancellationToken);
+                        return candidate;
+                    }
+                    catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+                    {
+                        last = ex;
+                    }
+                }
+                await Task.Delay(delayMs, cancellationToken);
+                delayMs = Math.Min(delayMs * 2, 3000);
+            }
+            throw new InvalidOperationException($"{target.Engine} container did not become ready within {ceilingSeconds}s.", last);
+        }
+    }
+}


### PR DESCRIPTION
Try both probe hosts (127.0.0.1 / host.docker.internal) in the provisioning readiness probe and pre-probe reachability in InnerDatabaseTargetLoader, so non-public instances work whether KRINT runs on the host or in a container.

Closes #144