### PR TITLE
Fixed Windows portable archive paths in desktop release

### DIFF
--- a/.github/workflows/desktop-release.yaml
+++ b/.github/workflows/desktop-release.yaml
@@ -82,7 +82,7 @@ jobs:
         run: |
           $rel = "src-tauri/target/release"
           $out = "KRINT-portable-${{ matrix.rid }}.zip"
-          Compress-Archive -Path "$rel/KRINT.exe", "$rel/resources", "$rel/binaries" -DestinationPath $out -Force
+          Compress-Archive -Path "$rel/krint-desktop.exe", "$rel/krint-api.exe", "$rel/resources" -DestinationPath $out -Force
           gh release upload "${{ github.event.release.tag_name }}" $out --clobber
 
       - name: Package portable archive (macOS)


### PR DESCRIPTION
Zips the actual build outputs (krint-desktop.exe, krint-api.exe, resources/) instead of the non-existent KRINT.exe and binaries/ folder.

Closes #162