### PR TITLE
Added a portable single-exe Windows build

### DIFF
--- a/.github/workflows/desktop-release.yaml
+++ b/.github/workflows/desktop-release.yaml
@@ -74,15 +74,19 @@ jobs:
 
       # Linux: the AppImage produced above is already the portable build, so nothing more to do.
 
-      - name: Package portable archive (Windows)
+      # Single no-install exe: rebuild with the `portable` feature, which embeds the API sidecar
+      # + resources (already produced by the build step above) into krint-desktop.exe and
+      # self-extracts them on launch. One ~150 MB double-clickable file.
+      - name: Build & upload portable single exe (Windows)
         if: matrix.portable == 'zip' && runner.os == 'Windows'
         shell: pwsh
+        working-directory: src-tauri
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          $rel = "src-tauri/target/release"
-          $out = "KRINT-portable-${{ matrix.rid }}.zip"
-          Compress-Archive -Path "$rel/krint-desktop.exe", "$rel/krint-api.exe", "$rel/resources" -DestinationPath $out -Force
+          cargo build --release --features portable
+          $out = "KRINT-portable-${{ matrix.rid }}.exe"
+          Copy-Item target/release/krint-desktop.exe $out
           gh release upload "${{ github.event.release.tag_name }}" $out --clobber
 
       - name: Package portable archive (macOS)

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -64,6 +64,20 @@ bun run desktop:dev              # dev window
 bun run desktop:build            # installers under src-tauri/target/release/bundle/
 ```
 
+### Portable single exe (Windows)
+
+For a no-install build, compile with the `portable` Cargo feature. It embeds the API sidecar +
+resources into `krint-desktop.exe` and self-extracts them to
+`%APPDATA%/app.krint.desktop/runtime-<version>/` on first launch — one ~150 MB double-clickable file:
+
+```bash
+bun run publish:sidecar                                            # produce the sidecar + wwwroot to embed
+cargo build --release --features portable --manifest-path src-tauri/Cargo.toml
+# -> src-tauri/target/release/krint-desktop.exe  (rename to KRINT.exe)
+```
+
+The release workflow builds and uploads this as `KRINT-portable-win-x64.exe` alongside the NSIS installer.
+
 > First run also needs app icons. Generate them once with `bun run tauri icon path/to/icon.png`
 > (writes into `src-tauri/icons/`, which is gitignored).
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1759,6 +1759,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,6 +2002,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
+ "include_dir",
  "jsonwebtoken",
  "log",
  "rand",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,13 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 
+# "portable": embed the API sidecar + resources into the exe and self-extract on launch, for a
+# single no-install KRINT.exe. Off by default (the installer build uses Tauri's normal sidecar).
+[features]
+portable = ["dep:include_dir"]
+
 [dependencies]
+include_dir = { version = "0.7", optional = true }
 # devtools intentionally NOT enabled: the desktop app ships locked down (no inspector).
 tauri = { version = "2" }
 tauri-plugin-shell = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -162,18 +162,12 @@ fn start_backend(app: &tauri::AppHandle) -> Result<(), Box<dyn std::error::Error
     start_oidc(authority.clone(), oidc_port);
     let urls = format!("http://127.0.0.1:{api_port}");
     let conn = format!("Data Source={}", db_path.to_string_lossy());
-    let krint_yaml = app
-        .path()
-        .resolve("resources/krint.yaml", tauri::path::BaseDirectory::Resource)?;
-    // The SPA (wwwroot) is bundled under resources/; point the API's content root there so
-    // UseStaticFiles + MapFallbackToFile serve it. WebRoot defaults to {ContentRoot}/wwwroot.
-    let content_root = app
-        .path()
-        .resolve("resources", tauri::path::BaseDirectory::Resource)?;
+    // Where the API binary + its resources (krint.yaml + the SPA's wwwroot) come from: Tauri's
+    // bundled sidecar/resources for the installer build, or a self-extracted copy for the single
+    // portable exe. WebRoot defaults to {ContentRoot}/wwwroot, so content_root points at resources/.
+    let (program, content_root, krint_yaml) = resolve_runtime(app, &data_dir)?;
 
-    let sidecar = app
-        .shell()
-        .sidecar("krint-api")?
+    let sidecar = program
         .env("ASPNETCORE_ENVIRONMENT", "Production")
         .env("ASPNETCORE_URLS", &urls)
         .env("ASPNETCORE_CONTENTROOT", content_root.to_string_lossy().to_string())
@@ -243,6 +237,60 @@ fn start_backend(app: &tauri::AppHandle) -> Result<(), Box<dyn std::error::Error
     });
 
     Ok(())
+}
+
+/// Resolve the API program to spawn plus its content root and krint.yaml path.
+///
+/// Installer build: Tauri's bundled sidecar + `resources/` (resolved from the bundle).
+/// Portable build (`portable` feature): the sidecar + resources are embedded in this exe and
+/// self-extracted once into the app-data dir, so a single KRINT.exe runs with no install.
+#[cfg(not(feature = "portable"))]
+fn resolve_runtime(
+    app: &tauri::AppHandle,
+    _data_dir: &std::path::Path,
+) -> Result<(tauri_plugin_shell::process::Command, PathBuf, PathBuf), Box<dyn std::error::Error>> {
+    let content_root = app
+        .path()
+        .resolve("resources", tauri::path::BaseDirectory::Resource)?;
+    let krint_yaml = app
+        .path()
+        .resolve("resources/krint.yaml", tauri::path::BaseDirectory::Resource)?;
+    Ok((app.shell().sidecar("krint-api")?, content_root, krint_yaml))
+}
+
+#[cfg(feature = "portable")]
+fn resolve_runtime(
+    app: &tauri::AppHandle,
+    data_dir: &std::path::Path,
+) -> Result<(tauri_plugin_shell::process::Command, PathBuf, PathBuf), Box<dyn std::error::Error>> {
+    let runtime = extract_payload(data_dir)?;
+    let program = app
+        .shell()
+        .command(runtime.join("krint-api.exe").to_string_lossy().to_string());
+    let krint_yaml = runtime.join("krint.yaml");
+    Ok((program, runtime, krint_yaml))
+}
+
+/// Self-extract the embedded API sidecar + resources into `{app_data}/runtime-{version}/` once.
+/// Keyed by version so an upgraded exe re-extracts; reused as-is otherwise for a fast launch.
+#[cfg(feature = "portable")]
+fn extract_payload(data_dir: &std::path::Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    static RESOURCES: include_dir::Dir =
+        include_dir::include_dir!("$CARGO_MANIFEST_DIR/resources");
+    const SIDECAR: &[u8] = include_bytes!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/binaries/krint-api-x86_64-pc-windows-msvc.exe"
+    ));
+
+    let runtime = data_dir.join(concat!("runtime-", env!("CARGO_PKG_VERSION")));
+    let sidecar_exe = runtime.join("krint-api.exe");
+    // The sidecar is written last, so its presence means a previous extraction completed.
+    if !sidecar_exe.exists() {
+        std::fs::create_dir_all(&runtime)?;
+        RESOURCES.extract(&runtime)?;
+        std::fs::write(&sidecar_exe, SIDECAR)?;
+    }
+    Ok(runtime)
 }
 
 /// Put the sidecar in a Windows Job Object whose handle we hold for the life of the process.


### PR DESCRIPTION
Adds a portable Cargo feature that embeds the API sidecar + resources into krint-desktop.exe and self-extracts them on launch, producing one no-install KRINT.exe; the release workflow uploads it as KRINT-portable-win-x64.exe.

Closes #164