### PR TITLE
Hardened provisioning and backups across all supported engines

### DIFF
--- a/krint.yaml
+++ b/krint.yaml
@@ -34,3 +34,4 @@ krint:
     qdrant:         34000-34199
     valkey:         34200-34399
     seaweedfs:      34400-34599
+    pgvector:       34600-34799

--- a/src/KRINT.Application/Command/Database/CreateDatabaseCommand.cs
+++ b/src/KRINT.Application/Command/Database/CreateDatabaseCommand.cs
@@ -123,14 +123,30 @@ namespace KRINT.Application.Command.Database
                 await docker.StartContainerAsync(createResult.ID, cancellationToken);
                 await vault.StoreAsync(ConnectionStringBuilder.VaultKeyFor(containerName), password, cancellationToken);
 
+                // mssql and cockroachdb can't create the default database from an env var (unlike
+                // POSTGRES_DB / MYSQL_DATABASE / CLICKHOUSE_DB). For those, probe readiness against
+                // the engine's always-present system db (master / defaultdb) - otherwise the probe
+                // connects to a database that doesn't exist yet and the instance never comes ready -
+                // then CREATE the requested default database explicitly afterwards.
+                var needsExplicitDefaultDb =
+                    (string.Equals(command.Engine, "mssql", StringComparison.OrdinalIgnoreCase)
+                     || string.Equals(command.Engine, "cockroachdb", StringComparison.OrdinalIgnoreCase))
+                    && !string.Equals(databaseName, spec.DefaultDatabase, StringComparison.OrdinalIgnoreCase);
+                var probeDatabase = needsExplicitDefaultDb ? spec.DefaultDatabase : databaseName;
+
                 // Wait for the engine inside the container to accept connections. The returned
                 // target carries whichever probe host actually responded - init steps below
                 // must use it so they reach the same address.
                 var readinessTarget = await ReadinessProbe.WaitForReadyAsync(
                     innerDbs.Resolve(command.Engine),
-                    new InnerDatabaseTarget(command.Engine, ResolveProbeHost(command.IsPublic), hostPort, spec.DefaultUsername, password, databaseName),
+                    new InnerDatabaseTarget(command.Engine, ResolveProbeHost(command.IsPublic), hostPort, spec.DefaultUsername, password, probeDatabase),
                     command.IsPublic,
                     cancellationToken);
+
+                if (needsExplicitDefaultDb)
+                {
+                    await innerDbs.Resolve(command.Engine).CreateAsync(readinessTarget, databaseName, cancellationToken);
+                }
 
                 // pgvector engine entry: enable the extension once the container accepts connections.
                 if (string.Equals(command.Engine, "pgvector", StringComparison.OrdinalIgnoreCase))
@@ -212,9 +228,11 @@ namespace KRINT.Application.Command.Database
                 case "postgres":
                     // pg 18+ stores data in /var/lib/postgresql/<major>/docker - mount the parent.
                     // pg <=17 uses PGDATA=/var/lib/postgresql/data - mount that directly.
-                    var pgDataPath = TryGetMajorVersion(version) is { } major && major >= 18
-                        ? "/var/lib/postgresql"
-                        : "/var/lib/postgresql/data";
+                    // Unknown/"latest" tags resolve to the modern (18+) layout: "latest" is 18+ today
+                    // and every future release will be too, so only known <=17 majors use the legacy path.
+                    var pgDataPath = TryGetMajorVersion(version) is { } major && major <= 17
+                        ? "/var/lib/postgresql/data"
+                        : "/var/lib/postgresql";
                     return new EngineSpec("postgres", "pg", 5432, "postgres", "postgres", pgDataPath);
                 case "timescaledb":
                     // timescale/timescaledb tags use Postgres <=17 layout (PGDATA=/var/lib/postgresql/data).

--- a/src/KRINT.Infrastructure/Services/CockroachDbServices.cs
+++ b/src/KRINT.Infrastructure/Services/CockroachDbServices.cs
@@ -1,3 +1,5 @@
+using KRINT.Infrastructure.Interfaces;
+
 namespace KRINT.Infrastructure.Services
 {
     // CockroachDB speaks the Postgres wire protocol - Npgsql talks to it natively, and the
@@ -19,6 +21,20 @@ namespace KRINT.Infrastructure.Services
     public sealed class CockroachDbInnerUserService : PostgresInnerUserService
     {
         public override string Engine => "cockroachdb";
+
+        // We run CockroachDB with `start-single-node --insecure`, which rejects any password
+        // operation ("setting or updating a password is not supported in insecure mode"). Create
+        // passwordless login roles instead - in insecure mode they authenticate without one.
+        public override async Task CreateAsync(InnerDatabaseTarget target, string name, string password, CancellationToken cancellationToken = default)
+        {
+            InnerDatabaseNameValidator.Require(name);
+            await using var conn = await OpenAsync(target, cancellationToken);
+            await using var cmd = new Npgsql.NpgsqlCommand($"CREATE ROLE \"{name}\" LOGIN", conn);
+            await cmd.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        public override Task ResetPasswordAsync(InnerDatabaseTarget target, string name, string newPassword, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("CockroachDB runs in insecure mode, which has no user passwords.");
     }
 
     public sealed class CockroachDbInnerSchemaService : PostgresInnerSchemaService

--- a/src/KRINT.Infrastructure/Services/DatabaseVersionService.cs
+++ b/src/KRINT.Infrastructure/Services/DatabaseVersionService.cs
@@ -3,10 +3,11 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using KRINT.Infrastructure.Interfaces;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 
 namespace KRINT.Infrastructure.Services
 {
-    public class DatabaseVersionService(HttpClient http, IMemoryCache cache) : IDatabaseVersionService
+    public class DatabaseVersionService(HttpClient http, IMemoryCache cache, ILogger<DatabaseVersionService> logger) : IDatabaseVersionService
     {
         private static readonly IReadOnlyDictionary<string, string> EngineToEndOfLifeSlug = new Dictionary<string, string>
         {
@@ -49,6 +50,10 @@ namespace KRINT.Infrastructure.Services
 
         private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(24);
 
+        // Used when the external version lookup can't be reached. "latest" exists as a rolling tag
+        // for every supported engine's image, so provisioning still works.
+        private static readonly IReadOnlyList<string> FallbackVersions = new[] { "latest" };
+
         public async Task<IReadOnlyList<string>> GetSupportedVersionsAsync(string engineKey, CancellationToken cancellationToken = default)
         {
             if (StaticEngineVersions.TryGetValue(engineKey, out var staticVersions))
@@ -68,10 +73,24 @@ namespace KRINT.Infrastructure.Services
             }
 
             var url = $"https://endoflife.date/api/{slug}.json";
-            var entries = await http.GetFromJsonAsync<EndOfLifeEntry[]>(url, cancellationToken);
+            EndOfLifeEntry[]? entries;
+            try
+            {
+                entries = await http.GetFromJsonAsync<EndOfLifeEntry[]>(url, cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // endoflife.date is an optional convenience lookup, not a hard dependency. If it's
+                // unreachable / rate-limited / down, fall back to Docker's rolling "latest" tag so
+                // the create-instance screen keeps working offline. Not cached, so it retries next time.
+                logger.LogWarning(ex, "Version lookup for '{Slug}' failed; falling back to 'latest'.", slug);
+                return FallbackVersions;
+            }
+
             if (entries is null)
             {
-                throw new InvalidOperationException($"endoflife.date returned no data for '{slug}'.");
+                logger.LogWarning("endoflife.date returned no data for '{Slug}'; falling back to 'latest'.", slug);
+                return FallbackVersions;
             }
 
             var today = DateOnly.FromDateTime(DateTime.UtcNow);

--- a/src/KRINT.Infrastructure/Services/ElasticServices.cs
+++ b/src/KRINT.Infrastructure/Services/ElasticServices.cs
@@ -42,8 +42,16 @@ namespace KRINT.Infrastructure.Services
         public virtual string Engine => "elasticsearch";
         protected virtual bool UseHttps => false;
 
-        public Task<IReadOnlyList<string>> ListAsync(InnerDatabaseTarget target, CancellationToken cancellationToken = default)
-            => Task.FromResult<IReadOnlyList<string>>(new[] { "_cluster" });
+        public async Task<IReadOnlyList<string>> ListAsync(InnerDatabaseTarget target, CancellationToken cancellationToken = default)
+        {
+            // ES exposes a single virtual "_cluster" database, but actually hit the cluster so this
+            // doubles as a real readiness probe - returning a constant would let provisioning report
+            // "ready" while the JVM is still starting, breaking the first query/browse.
+            using var http = ElasticHttp.Build(target, UseHttps);
+            using var resp = await http.GetAsync("/", cancellationToken);
+            resp.EnsureSuccessStatusCode();
+            return new[] { "_cluster" };
+        }
 
         public Task CreateAsync(InnerDatabaseTarget target, string name, CancellationToken cancellationToken = default)
             => throw new NotSupportedException("Elasticsearch/OpenSearch don't have logical databases - there's only the single cluster.");

--- a/src/KRINT.Infrastructure/Services/MySqlBackupService.cs
+++ b/src/KRINT.Infrastructure/Services/MySqlBackupService.cs
@@ -6,13 +6,23 @@ namespace KRINT.Infrastructure.Services
     {
         public virtual string Engine => "mysql";
 
+        // Dump/restore client binaries. MySQL ships `mysqldump`/`mysql`; MariaDB 11+ ships
+        // `mariadb-dump`/`mariadb` and dropped the mysql* names. Resolved at runtime with a
+        // fallback so both old and new images work; subclasses set the preferred name.
+        protected virtual string DumpBinary => "mysqldump";
+        protected virtual string DumpFallback => "mariadb-dump";
+        protected virtual string RestoreBinary => "mysql";
+        protected virtual string RestoreFallback => "mariadb";
+
         public async Task<BackupOutput> DumpAsync(BackupTarget target, CancellationToken cancellationToken = default)
         {
-            // mysqldump --all-databases, consistent snapshot via single-transaction.
+            // dump --all-databases, consistent snapshot via single-transaction. Pick whichever
+            // client binary the image actually has.
+            var bin = $"$(command -v {DumpBinary} || command -v {DumpFallback})";
             var cmd = new List<string>
             {
                 "bash", "-c",
-                $"mysqldump -h 127.0.0.1 -u {target.Username} -p'{target.Password}' --single-transaction --all-databases",
+                $"{bin} -h 127.0.0.1 -u {target.Username} -p'{target.Password}' --single-transaction --all-databases",
             };
             var bytes = await docker.ExecCaptureAsync(target.ContainerId, cmd, cancellationToken);
             return new BackupOutput(bytes, "sql");
@@ -20,11 +30,12 @@ namespace KRINT.Infrastructure.Services
 
         public async Task RestoreAsync(BackupTarget target, Stream dump, CancellationToken cancellationToken = default)
         {
-            // Pipe the SQL dump into `mysql` over stdin - it replays statements from --all-databases.
+            // Pipe the SQL dump into the client over stdin - it replays statements from --all-databases.
+            var bin = $"$(command -v {RestoreBinary} || command -v {RestoreFallback})";
             var cmd = new List<string>
             {
                 "bash", "-c",
-                $"mysql -h 127.0.0.1 -u {target.Username} -p'{target.Password}'",
+                $"{bin} -h 127.0.0.1 -u {target.Username} -p'{target.Password}'",
             };
             await docker.ExecWithStdinAsync(target.ContainerId, cmd, dump, cancellationToken);
         }

--- a/src/KRINT.Infrastructure/Services/Neo4jServices.cs
+++ b/src/KRINT.Infrastructure/Services/Neo4jServices.cs
@@ -32,8 +32,12 @@ namespace KRINT.Infrastructure.Services
                 var records = await result.ToListAsync(cancellationToken);
                 return records.Select(r => r["name"].As<string>()).Where(n => !string.Equals(n, "system", StringComparison.OrdinalIgnoreCase)).ToList();
             }
-            catch
+            catch (Neo4j.Driver.ClientException)
             {
+                // SHOW DATABASES is Enterprise-only; on Community it's a query-level ClientException,
+                // so fall back to the single "neo4j" db. Connection errors (ServiceUnavailable) are
+                // deliberately NOT caught - they must propagate so the readiness probe keeps waiting
+                // instead of treating a still-booting server as ready.
                 return new[] { "neo4j" };
             }
         }

--- a/src/KRINT.Infrastructure/Services/PostgresInnerUserService.cs
+++ b/src/KRINT.Infrastructure/Services/PostgresInnerUserService.cs
@@ -18,7 +18,7 @@ namespace KRINT.Infrastructure.Services
             return results;
         }
 
-        public async Task CreateAsync(InnerDatabaseTarget target, string name, string password, CancellationToken cancellationToken = default)
+        public virtual async Task CreateAsync(InnerDatabaseTarget target, string name, string password, CancellationToken cancellationToken = default)
         {
             InnerDatabaseNameValidator.Require(name);
             SafePasswordGuard.Require(password);
@@ -61,7 +61,7 @@ namespace KRINT.Infrastructure.Services
             await dropCmd.ExecuteNonQueryAsync(cancellationToken);
         }
 
-        public async Task ResetPasswordAsync(InnerDatabaseTarget target, string name, string newPassword, CancellationToken cancellationToken = default)
+        public virtual async Task ResetPasswordAsync(InnerDatabaseTarget target, string name, string newPassword, CancellationToken cancellationToken = default)
         {
             InnerDatabaseNameValidator.Require(name);
             SafePasswordGuard.Require(newPassword);
@@ -79,7 +79,7 @@ namespace KRINT.Infrastructure.Services
             await cmd.ExecuteNonQueryAsync(cancellationToken);
         }
 
-        private static async Task<NpgsqlConnection> OpenAsync(InnerDatabaseTarget target, CancellationToken cancellationToken)
+        protected static async Task<NpgsqlConnection> OpenAsync(InnerDatabaseTarget target, CancellationToken cancellationToken)
         {
             var csb = new NpgsqlConnectionStringBuilder
             {


### PR DESCRIPTION
End-to-end testing of all supported engines surfaced and fixed 8 provisioning/backup bugs.

Closes #167
Closes #168
Closes #169
Closes #170
Closes #171
Closes #172
Closes #173
Closes #174