### PR TITLE
Added Azurite (Azure Blob) as an object-storage engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ KRINT is a self-hosted database-provisioning platform. Pick an engine, click Lau
 
 ## Features
 
-- **15 engines**: PostgreSQL, MariaDB, MongoDB, MySQL, SQL Server, CockroachDB, TimescaleDB, ClickHouse, Cassandra, CouchDB, Neo4j, Redis, Valkey, Elasticsearch, Qdrant.
+- **17 engines**: PostgreSQL, MariaDB, MongoDB, MySQL, SQL Server, CockroachDB, TimescaleDB, ClickHouse, Cassandra, CouchDB, Neo4j, Redis, Valkey, Elasticsearch, Qdrant, plus object storage via SeaweedFS (S3) and Azurite (Azure Blob).
 - **Plugins**: pgvector, PostGIS, pg_trgm, Redis Stack, APOC, Graph Data Science, and more, opt-in at provision time.
 - **Live dashboard**: KPI cards, per-engine breakdown, and recent activity stream in over SignalR so the homepage stays current without refreshes.
 - **Browse & query**: spreadsheet-style in-cell editing of rows + an ad-hoc SQL console for the SQL engines (Ctrl/Cmd+Enter to run).

--- a/krint.yaml
+++ b/krint.yaml
@@ -35,3 +35,4 @@ krint:
     valkey:         34200-34399
     seaweedfs:      34400-34599
     pgvector:       34600-34799
+    azurite:        34800-34999

--- a/src/KRINT.Application/Command/Database/CreateDatabaseCommand.cs
+++ b/src/KRINT.Application/Command/Database/CreateDatabaseCommand.cs
@@ -291,6 +291,12 @@ namespace KRINT.Application.Command.Database
                     // buckets are created on demand via the UI.
                     return new EngineSpec("chrislusf/seaweedfs", "weed", 8333, "krint", "default", "/data",
                         CmdFactory: _ => new[] { "server", "-s3", "-dir=/data" });
+                case "azurite":
+                    // Azure Storage emulator. We publish only the blob port (10000) and bind it to
+                    // 0.0.0.0 so the host can reach it; --skipApiVersionCheck keeps newer SDKs happy.
+                    // Uses the fixed dev account "devstoreaccount1" - the generated password is unused.
+                    return new EngineSpec("mcr.microsoft.com/azure-storage/azurite", "azurite", 10000, "devstoreaccount1", "default", "/data",
+                        CmdFactory: _ => new[] { "azurite-blob", "--blobHost", "0.0.0.0", "--blobPort", "10000", "--location", "/data", "--skipApiVersionCheck" });
                 default:
                     throw new ArgumentException($"Unsupported engine '{engine}'.", nameof(engine));
             }
@@ -418,6 +424,9 @@ namespace KRINT.Application.Command.Database
                         "AWS_ACCESS_KEY_ID=krint",
                         $"AWS_SECRET_ACCESS_KEY={password}",
                     };
+                case "azurite":
+                    // Azurite uses its built-in "devstoreaccount1" account - no env needed.
+                    return new List<string>();
                 default:
                     throw new ArgumentException($"Unsupported engine '{engine}'.", nameof(engine));
             }

--- a/src/KRINT.Application/ConnectionStringBuilder.cs
+++ b/src/KRINT.Application/ConnectionStringBuilder.cs
@@ -28,6 +28,7 @@ namespace KRINT.Application
                 "valkey" => $"redis://default:{password}@{host}:{port}/{database}",
                 "mssql" => $"Server={host},{port};User Id={username};Password={password};Database={database};TrustServerCertificate=true",
                 "seaweedfs" => $"http://{host}:{port} (S3 access-key: {username}, secret-key: {password})",
+                "azurite" => $"DefaultEndpointsProtocol=http;AccountName={username};AccountKey=<azurite-dev-key>;BlobEndpoint=http://{host}:{port}/{username};",
                 _ => throw new ArgumentException($"Unsupported engine '{engine}'.", nameof(engine)),
             };
         }

--- a/src/KRINT.Application/Queries/SupportedDatabase/GetSupportedDatabasesQuery.cs
+++ b/src/KRINT.Application/Queries/SupportedDatabase/GetSupportedDatabasesQuery.cs
@@ -147,6 +147,14 @@ namespace KRINT.Application.Queries.SupportedDatabase
             SupportsBackup = false,
         };
 
+        // Azurite (Azure Blob emulator): containers = databases, one virtual "_all_blobs"
+        // collection per container, blobs = rows. Same shape as SeaweedFS but over the Blob API.
+        private static readonly EngineCapabilitiesDto AzuriteCaps = SeaweedFsCaps with
+        {
+            DatabaseTerm = "container",
+            RowTerm = "blob",
+        };
+
         // Redis: 16 fixed DB numbers, no logical-DB CRUD; key-value rows; no users in our model.
         private static readonly EngineCapabilitiesDto RedisCaps = new()
         {
@@ -283,6 +291,7 @@ namespace KRINT.Application.Queries.SupportedDatabase
             ("qdrant",      "Qdrant",      "qdrant/qdrant",         QdrantCaps),
             // Blob / object storage
             ("seaweedfs",   "SeaweedFS",   "chrislusf/seaweedfs",   SeaweedFsCaps),
+            ("azurite",     "Azure Blob (Azurite)", "mcr.microsoft.com/azure-storage/azurite", AzuriteCaps),
         };
 
         public async ValueTask<IReadOnlyList<SupportedDatabaseDto>> Handle(GetSupportedDatabasesQuery query, CancellationToken cancellationToken)

--- a/src/KRINT.Infrastructure/Extensions/InnerDatabasesExtensions.cs
+++ b/src/KRINT.Infrastructure/Extensions/InnerDatabasesExtensions.cs
@@ -25,6 +25,7 @@ namespace KRINT.Infrastructure.Extensions
             services.AddSingleton<IInnerDatabaseService, ValkeyInnerDatabaseService>();
             services.AddSingleton<IInnerDatabaseService, MsSqlInnerDatabaseService>();
             services.AddSingleton<IInnerDatabaseService, SeaweedFsInnerDatabaseService>();
+            services.AddSingleton<IInnerDatabaseService, AzuriteInnerDatabaseService>();
             services.AddSingleton<IInnerDatabaseServiceResolver, InnerDatabaseServiceResolver>();
 
             services.AddSingleton<IInnerUserService, PostgresInnerUserService>();
@@ -44,6 +45,7 @@ namespace KRINT.Infrastructure.Extensions
             services.AddSingleton<IInnerUserService, ValkeyInnerUserService>();
             services.AddSingleton<IInnerUserService, MsSqlInnerUserService>();
             services.AddSingleton<IInnerUserService, SeaweedFsInnerUserService>();
+            services.AddSingleton<IInnerUserService, AzuriteInnerUserService>();
             services.AddSingleton<IInnerUserServiceResolver, InnerUserServiceResolver>();
 
             services.AddSingleton<IInnerSchemaService, PostgresInnerSchemaService>();
@@ -63,6 +65,7 @@ namespace KRINT.Infrastructure.Extensions
             services.AddSingleton<IInnerSchemaService, ValkeyInnerSchemaService>();
             services.AddSingleton<IInnerSchemaService, MsSqlInnerSchemaService>();
             services.AddSingleton<IInnerSchemaService, SeaweedFsInnerSchemaService>();
+            services.AddSingleton<IInnerSchemaService, AzuriteInnerSchemaService>();
             services.AddSingleton<IInnerSchemaServiceResolver, InnerSchemaServiceResolver>();
 
             // Query console - SQL engines only for v1. Engines without an entry surface in the

--- a/src/KRINT.Infrastructure/KRINT.Infrastructure.csproj
+++ b/src/KRINT.Infrastructure/KRINT.Infrastructure.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="4.0.24.3" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.22.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
       <PrivateAssets>all</PrivateAssets>

--- a/src/KRINT.Infrastructure/Services/AzuriteServices.cs
+++ b/src/KRINT.Infrastructure/Services/AzuriteServices.cs
@@ -1,0 +1,137 @@
+using System.Globalization;
+using Azure.Storage.Blobs;
+using KRINT.Infrastructure.Interfaces;
+
+namespace KRINT.Infrastructure.Services
+{
+    // Azurite - Microsoft's Azure Storage emulator - accessed over the Azure Blob API (Azurite
+    // does NOT speak S3, so this can't reuse the SeaweedFS/AWSSDK path). We run it with the
+    // built-in development account "devstoreaccount1" and its well-known key.
+    //
+    // Model mirrors SeaweedFS: containers = databases, a single virtual "_all_blobs" collection
+    // per container, blobs = rows (name / size / last-modified / etag). Deleting a row deletes
+    // the blob; upload/edit need a file UI - out of scope for v1.
+
+    internal static class AzuriteBlob
+    {
+        // Public, documented Azurite/Azure dev-storage account + key (not a secret).
+        private const string DevAccount = "devstoreaccount1";
+        private const string DevKey =
+            "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+
+        public static BlobServiceClient Build(InnerDatabaseTarget target)
+        {
+            // The instance username is the account name; the dev account uses the fixed well-known
+            // key (Azurite ignores the generated password, like cockroachdb's insecure mode).
+            var account = string.IsNullOrWhiteSpace(target.Username) ? DevAccount : target.Username;
+            var conn =
+                $"DefaultEndpointsProtocol=http;AccountName={account};AccountKey={DevKey};" +
+                $"BlobEndpoint=http://{target.Host}:{target.Port}/{account};";
+            return new BlobServiceClient(conn);
+        }
+    }
+
+    public class AzuriteInnerDatabaseService : IInnerDatabaseService
+    {
+        public string Engine => "azurite";
+
+        public async Task<IReadOnlyList<string>> ListAsync(InnerDatabaseTarget target, CancellationToken cancellationToken = default)
+        {
+            // Real call -> also serves as the readiness probe (Azurite/JVM-free but still needs a beat).
+            var client = AzuriteBlob.Build(target);
+            var names = new List<string>();
+            await foreach (var c in client.GetBlobContainersAsync(cancellationToken: cancellationToken))
+                names.Add(c.Name);
+            names.Sort(StringComparer.OrdinalIgnoreCase);
+            return names;
+        }
+
+        public async Task CreateAsync(InnerDatabaseTarget target, string name, CancellationToken cancellationToken = default)
+        {
+            InnerDatabaseNameValidator.Require(name);
+            var client = AzuriteBlob.Build(target);
+            await client.CreateBlobContainerAsync(name, cancellationToken: cancellationToken);
+        }
+
+        public async Task DropAsync(InnerDatabaseTarget target, string name, CancellationToken cancellationToken = default)
+        {
+            InnerDatabaseNameValidator.Require(name);
+            var client = AzuriteBlob.Build(target);
+            await client.DeleteBlobContainerAsync(name, cancellationToken: cancellationToken);
+        }
+    }
+
+    public class AzuriteInnerUserService : IInnerUserService
+    {
+        public string Engine => "azurite";
+        public Task<IReadOnlyList<string>> ListAsync(InnerDatabaseTarget target, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
+        public Task CreateAsync(InnerDatabaseTarget target, string name, string password, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Azurite uses a fixed development account; identity management is not exposed.");
+        public Task DeleteAsync(InnerDatabaseTarget target, string name, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Azurite uses a fixed development account; identity management is not exposed.");
+        public Task ResetPasswordAsync(InnerDatabaseTarget target, string name, string newPassword, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Azurite uses a fixed development account; identity management is not exposed.");
+        public Task GrantAccessAsync(InnerDatabaseTarget target, string user, string database, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Azurite uses a fixed development account; identity management is not exposed.");
+    }
+
+    public class AzuriteInnerSchemaService : IInnerSchemaService
+    {
+        public string Engine => "azurite";
+
+        private const string VirtualTable = "_all_blobs";
+
+        public Task<IReadOnlyList<TableSummary>> ListTablesAsync(InnerDatabaseTarget target, string database, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<TableSummary>>(new[] { new TableSummary(VirtualTable, "collection") });
+
+        public async Task<TableRows> FetchRowsAsync(InnerDatabaseTarget target, string database, string table, int limit, int offset, CancellationToken cancellationToken = default)
+        {
+            InnerDatabaseNameValidator.Require(database);
+            limit = Math.Clamp(limit, 1, 500);
+            offset = Math.Max(0, offset);
+
+            var container = AzuriteBlob.Build(target).GetBlobContainerClient(database);
+
+            // Azure Blob listing has no offset - page from the start and skip.
+            var rows = new List<IReadOnlyList<string?>>();
+            var skipped = 0;
+            await foreach (var blob in container.GetBlobsAsync(cancellationToken: cancellationToken))
+            {
+                if (skipped < offset) { skipped++; continue; }
+                if (rows.Count >= limit) break;
+                rows.Add(new[]
+                {
+                    blob.Name,
+                    blob.Properties.ContentLength?.ToString(CultureInfo.InvariantCulture),
+                    blob.Properties.LastModified?.ToString("o", CultureInfo.InvariantCulture),
+                    blob.Properties.ETag?.ToString().Trim('"'),
+                });
+            }
+
+            return new TableRows(new[] { "name", "size", "lastModified", "etag" }, rows, null);
+        }
+
+        public Task InsertRowAsync(InnerDatabaseTarget target, string database, string table, InsertRowRequest request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Uploading blobs is not exposed in this version.");
+        public Task UpdateRowAsync(InnerDatabaseTarget target, string database, string table, UpdateRowRequest request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Blobs cannot be edited in place.");
+
+        public async Task DeleteRowAsync(InnerDatabaseTarget target, string database, string table, DeleteRowRequest request, CancellationToken cancellationToken = default)
+        {
+            InnerDatabaseNameValidator.Require(database);
+            var nameIndex = -1;
+            for (var i = 0; i < request.Columns.Count; i++)
+                if (request.Columns[i] == "name") nameIndex = i;
+            var key = nameIndex >= 0 ? request.OriginalValues[nameIndex] : null;
+            if (string.IsNullOrEmpty(key))
+                throw new ArgumentException("Blob name is required to delete.", nameof(request));
+
+            var container = AzuriteBlob.Build(target).GetBlobContainerClient(database);
+            await container.DeleteBlobAsync(key, cancellationToken: cancellationToken);
+        }
+
+        public Task DropTableAsync(InnerDatabaseTarget target, string database, string table, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Azurite exposes a single virtual blob listing per container.");
+    }
+}

--- a/src/KRINT.Infrastructure/Services/DatabaseVersionService.cs
+++ b/src/KRINT.Infrastructure/Services/DatabaseVersionService.cs
@@ -46,6 +46,8 @@ namespace KRINT.Infrastructure.Services
             ["mssql"] = new[] { "2025-latest", "2022-latest", "2019-latest" },
             // SeaweedFS - 4.33 is current (verified on hub.docker.com 2026-06-12).
             ["seaweedfs"] = new[] { "4.33", "4.32", "4.31" },
+            // Azurite (Azure Storage emulator) on MCR - "latest" plus a couple of pinned 3.x tags.
+            ["azurite"] = new[] { "latest", "3.34.0", "3.33.0" },
         };
 
         private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(24);


### PR DESCRIPTION
Added Azurite (Azure Storage emulator) as a provisionable object-storage engine over the Azure Blob API — containers = databases, blobs = rows — mirroring the SeaweedFS engine.

Closes #176