### PR TITLE
Fixed Elasticsearch/CouchDB/Neo4j advertising unsupported row insert

### DIFF
--- a/src/KRINT.Application/Queries/SupportedDatabase/GetSupportedDatabasesQuery.cs
+++ b/src/KRINT.Application/Queries/SupportedDatabase/GetSupportedDatabasesQuery.cs
@@ -80,6 +80,7 @@ namespace KRINT.Application.Queries.SupportedDatabase
             RowTerm = "document",
             SupportsCreateDatabase = false,   // there's just one "_cluster"
             SupportsDropDatabase = false,
+            SupportsRowInsert = false,
             SupportsRowEdit = false,
             SupportsRowDelete = false,
             SupportsUsers = false,
@@ -95,6 +96,7 @@ namespace KRINT.Application.Queries.SupportedDatabase
             RowTerm = "document",
             SupportsListTables = true,
             SupportsDropTable = false,
+            SupportsRowInsert = false,
             SupportsRowEdit = false,
             SupportsRowDelete = false,
             SupportsUsers = false,
@@ -110,6 +112,7 @@ namespace KRINT.Application.Queries.SupportedDatabase
             RowTerm = "node",
             SupportsCreateDatabase = false,  // Neo4j Community is single-database
             SupportsDropDatabase = false,
+            SupportsRowInsert = false,
             SupportsRowEdit = false,
             SupportsRowDelete = false,
             SupportsUsers = false,


### PR DESCRIPTION
Elasticsearch, CouchDB, and Neo4j inherited `SupportsRowInsert = true` from `SqlCaps` (their caps override edit/delete but not insert), while their schema services throw `NotSupportedException` — so the browser showed an "add row" button that 500s. Set `SupportsRowInsert = false` on those three so the UI matches reality.

Closes #179