### PR TITLE
Added row insert/edit/delete for Mongo, CouchDB, Elasticsearch, Neo4j (+ Qdrant edit/delete)

### DIFF
--- a/src/KRINT.Application/Queries/SupportedDatabase/GetSupportedDatabasesQuery.cs
+++ b/src/KRINT.Application/Queries/SupportedDatabase/GetSupportedDatabasesQuery.cs
@@ -27,14 +27,11 @@ namespace KRINT.Application.Queries.SupportedDatabase
             SupportsBackup = true,
         };
 
-        // Mongo: docs not rows; current implementation lacks per-document edit/insert/delete.
+        // Mongo: docs rendered as a single JSON column; insert/replace/delete keyed on _id.
         private static readonly EngineCapabilitiesDto MongoCaps = SqlCaps with
         {
             TableTerm = "collection",
             RowTerm = "document",
-            SupportsRowInsert = false,
-            SupportsRowEdit = false,
-            SupportsRowDelete = false,
         };
 
         // CockroachDB: Postgres-wire-compatible but no `ctid` and no pg_dump. We disable row
@@ -70,9 +67,8 @@ namespace KRINT.Application.Queries.SupportedDatabase
             SupportsBackup = false,
         };
 
-        // Elasticsearch / OpenSearch: indices look like tables; docs look like rows but the JSON
-        // shape is per-document, so we render each doc as a single JSON column (like Mongo).
-        // Per-doc edit/delete needs _id lookup; skipping for v1.
+        // Elasticsearch / OpenSearch: indices look like tables; each doc is one JSON _source
+        // column keyed by _id. Index/update/delete are by _id (refresh=true for immediacy).
         private static readonly EngineCapabilitiesDto ElasticCaps = SqlCaps with
         {
             DatabaseTerm = "cluster",
@@ -80,8 +76,6 @@ namespace KRINT.Application.Queries.SupportedDatabase
             RowTerm = "document",
             SupportsCreateDatabase = false,   // there's just one "_cluster"
             SupportsDropDatabase = false,
-            SupportsRowEdit = false,
-            SupportsRowDelete = false,
             SupportsUsers = false,
             SupportsBackup = false,
         };
@@ -95,8 +89,6 @@ namespace KRINT.Application.Queries.SupportedDatabase
             RowTerm = "document",
             SupportsListTables = true,
             SupportsDropTable = false,
-            SupportsRowEdit = false,
-            SupportsRowDelete = false,
             SupportsUsers = false,
             SupportsBackup = false,
         };
@@ -110,14 +102,13 @@ namespace KRINT.Application.Queries.SupportedDatabase
             RowTerm = "node",
             SupportsCreateDatabase = false,  // Neo4j Community is single-database
             SupportsDropDatabase = false,
-            SupportsRowEdit = false,
-            SupportsRowDelete = false,
             SupportsUsers = false,
             SupportsBackup = false,
         };
 
-        // Qdrant: vector DB. We expose collections as "tables" and points as "rows" (id + payload + vector preview).
-        // No multi-DB concept; insert/edit/delete are out of scope until we have a vector-aware UI.
+        // Qdrant: vector DB. Collections = tables, points = rows (id + payload). Payload edit and
+        // point delete work by id; insert stays off because a new point requires a vector, which
+        // the generic row form can't supply.
         private static readonly EngineCapabilitiesDto QdrantCaps = SqlCaps with
         {
             DatabaseTerm = "cluster",
@@ -125,9 +116,7 @@ namespace KRINT.Application.Queries.SupportedDatabase
             RowTerm = "point",
             SupportsCreateDatabase = false,
             SupportsDropDatabase = false,
-            SupportsRowEdit = false,
             SupportsRowInsert = false,
-            SupportsRowDelete = false,
             SupportsUsers = false,
             SupportsBackup = false,
         };

--- a/src/KRINT.Infrastructure/Services/CouchDbServices.cs
+++ b/src/KRINT.Infrastructure/Services/CouchDbServices.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using KRINT.Infrastructure.Interfaces;
 
 namespace KRINT.Infrastructure.Services
@@ -117,12 +118,54 @@ namespace KRINT.Infrastructure.Services
             return new TableRows(new[] { "_id", "document" }, rows, total);
         }
 
-        public Task InsertRowAsync(InnerDatabaseTarget target, string database, string table, InsertRowRequest request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("CouchDB document insert is not exposed in this version.");
-        public Task UpdateRowAsync(InnerDatabaseTarget target, string database, string table, UpdateRowRequest request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("CouchDB document update is not exposed in this version (requires _rev).");
-        public Task DeleteRowAsync(InnerDatabaseTarget target, string database, string table, DeleteRowRequest request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("CouchDB document delete is not exposed in this version (requires _rev).");
+        private static int Idx(IReadOnlyList<string> cols, string name)
+        {
+            for (var i = 0; i < cols.Count; i++) if (cols[i] == name) return i;
+            return -1;
+        }
+
+        public async Task InsertRowAsync(InnerDatabaseTarget target, string database, string table, InsertRowRequest request, CancellationToken cancellationToken = default)
+        {
+            InnerDatabaseNameValidator.Require(database);
+            var docJson = request.Values[Idx(request.Columns, "document")] ?? "{}";
+            var node = JsonNode.Parse(docJson)!.AsObject();
+            node.Remove("_rev"); // a new doc must not carry a rev
+            using var http = CouchDbHttp.Build(target);
+            var content = new StringContent(node.ToJsonString(), Encoding.UTF8, "application/json");
+            // POST to the database: CouchDB honours an embedded _id, or assigns one when absent.
+            using var resp = await http.PostAsync($"/{Uri.EscapeDataString(database)}", content, cancellationToken);
+            resp.EnsureSuccessStatusCode();
+        }
+
+        public async Task UpdateRowAsync(InnerDatabaseTarget target, string database, string table, UpdateRowRequest request, CancellationToken cancellationToken = default)
+        {
+            var idIdx = Idx(request.Columns, "_id");
+            var docIdx = Idx(request.Columns, "document");
+            var id = request.OriginalValues[idIdx];
+            if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("Document _id is required to update.");
+            // CouchDB needs the current _rev; take it from the original doc and stamp it on the new body.
+            var rev = JsonDocument.Parse(request.OriginalValues[docIdx] ?? "{}").RootElement.TryGetProperty("_rev", out var r) ? r.GetString() : null;
+            var node = JsonNode.Parse(request.NewValues[docIdx] ?? "{}")!.AsObject();
+            node["_id"] = id;
+            if (rev is not null) node["_rev"] = rev;
+            using var http = CouchDbHttp.Build(target);
+            var content = new StringContent(node.ToJsonString(), Encoding.UTF8, "application/json");
+            using var resp = await http.PutAsync($"/{Uri.EscapeDataString(database)}/{Uri.EscapeDataString(id)}", content, cancellationToken);
+            resp.EnsureSuccessStatusCode();
+        }
+
+        public async Task DeleteRowAsync(InnerDatabaseTarget target, string database, string table, DeleteRowRequest request, CancellationToken cancellationToken = default)
+        {
+            var idIdx = Idx(request.Columns, "_id");
+            var docIdx = Idx(request.Columns, "document");
+            var id = request.OriginalValues[idIdx];
+            if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("Document _id is required to delete.");
+            var rev = JsonDocument.Parse(request.OriginalValues[docIdx] ?? "{}").RootElement.TryGetProperty("_rev", out var r) ? r.GetString() : null;
+            if (string.IsNullOrWhiteSpace(rev)) throw new ArgumentException("Document _rev is required to delete.");
+            using var http = CouchDbHttp.Build(target);
+            using var resp = await http.DeleteAsync($"/{Uri.EscapeDataString(database)}/{Uri.EscapeDataString(id)}?rev={Uri.EscapeDataString(rev)}", cancellationToken);
+            resp.EnsureSuccessStatusCode();
+        }
         public Task DropTableAsync(InnerDatabaseTarget target, string database, string table, CancellationToken cancellationToken = default)
             => throw new NotSupportedException("CouchDB has no tables - drop the database instead.");
     }

--- a/src/KRINT.Infrastructure/Services/ElasticServices.cs
+++ b/src/KRINT.Infrastructure/Services/ElasticServices.cs
@@ -26,7 +26,9 @@ namespace KRINT.Infrastructure.Services
             var client = new HttpClient(handler, disposeHandler: true)
             {
                 BaseAddress = new Uri($"{scheme}://{target.Host}:{target.Port}"),
-                Timeout = TimeSpan.FromSeconds(10),
+                // ES writes with refresh=true (and first-index creation) can exceed a tight budget,
+                // especially right after startup; give it room so edits don't spuriously time out.
+                Timeout = TimeSpan.FromSeconds(30),
             };
             if (!string.IsNullOrEmpty(target.Username))
             {
@@ -44,12 +46,18 @@ namespace KRINT.Infrastructure.Services
 
         public async Task<IReadOnlyList<string>> ListAsync(InnerDatabaseTarget target, CancellationToken cancellationToken = default)
         {
-            // ES exposes a single virtual "_cluster" database, but actually hit the cluster so this
-            // doubles as a real readiness probe - returning a constant would let provisioning report
-            // "ready" while the JVM is still starting, breaking the first query/browse.
+            // ES exposes a single virtual "_cluster" database, but actually hit cluster health so
+            // this doubles as a real readiness probe: GET / returns 200 before the cluster can
+            // accept writes (first insert would 503). Requiring a non-red status means the probe
+            // (and provisioning) waits until ES is actually usable.
             using var http = ElasticHttp.Build(target, UseHttps);
-            using var resp = await http.GetAsync("/", cancellationToken);
+            using var resp = await http.GetAsync("/_cluster/health", cancellationToken);
             resp.EnsureSuccessStatusCode();
+            await using var stream = await resp.Content.ReadAsStreamAsync(cancellationToken);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+            var status = doc.RootElement.TryGetProperty("status", out var s) ? s.GetString() : null;
+            if (string.Equals(status, "red", StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException("Elasticsearch cluster health is red - not ready.");
             return new[] { "_cluster" };
         }
 
@@ -128,12 +136,49 @@ namespace KRINT.Infrastructure.Services
             return new TableRows(new[] { "_id", "_source" }, rows, total);
         }
 
-        public Task InsertRowAsync(InnerDatabaseTarget target, string database, string table, InsertRowRequest request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("Elasticsearch/OpenSearch insert is not exposed in this version.");
-        public Task UpdateRowAsync(InnerDatabaseTarget target, string database, string table, UpdateRowRequest request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("Elasticsearch/OpenSearch document update is not exposed in this version.");
-        public Task DeleteRowAsync(InnerDatabaseTarget target, string database, string table, DeleteRowRequest request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("Elasticsearch/OpenSearch document delete is not exposed in this version.");
+        private static int Idx(IReadOnlyList<string> cols, string name)
+        {
+            for (var i = 0; i < cols.Count; i++) if (cols[i] == name) return i;
+            return -1;
+        }
+
+        public async Task InsertRowAsync(InnerDatabaseTarget target, string database, string table, InsertRowRequest request, CancellationToken cancellationToken = default)
+        {
+            var idIdx = Idx(request.Columns, "_id");
+            var srcIdx = Idx(request.Columns, "_source");
+            var id = idIdx >= 0 ? request.Values[idIdx] : null;
+            var src = (srcIdx >= 0 ? request.Values[srcIdx] : null) ?? "{}";
+            using var http = ElasticHttp.Build(target, UseHttps);
+            var content = new StringContent(src, Encoding.UTF8, "application/json");
+            // No id -> POST for an auto-generated id; explicit id -> PUT to that id.
+            using var resp = string.IsNullOrWhiteSpace(id)
+                ? await http.PostAsync($"/{Uri.EscapeDataString(table)}/_doc?refresh=true", content, cancellationToken)
+                : await http.PutAsync($"/{Uri.EscapeDataString(table)}/_doc/{Uri.EscapeDataString(id)}?refresh=true", content, cancellationToken);
+            resp.EnsureSuccessStatusCode();
+        }
+
+        public async Task UpdateRowAsync(InnerDatabaseTarget target, string database, string table, UpdateRowRequest request, CancellationToken cancellationToken = default)
+        {
+            var idIdx = Idx(request.Columns, "_id");
+            var srcIdx = Idx(request.Columns, "_source");
+            var id = idIdx >= 0 ? request.OriginalValues[idIdx] : null;
+            if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("Document _id is required to update.");
+            var src = (srcIdx >= 0 ? request.NewValues[srcIdx] : null) ?? "{}";
+            using var http = ElasticHttp.Build(target, UseHttps);
+            var content = new StringContent(src, Encoding.UTF8, "application/json");
+            using var resp = await http.PutAsync($"/{Uri.EscapeDataString(table)}/_doc/{Uri.EscapeDataString(id)}?refresh=true", content, cancellationToken);
+            resp.EnsureSuccessStatusCode();
+        }
+
+        public async Task DeleteRowAsync(InnerDatabaseTarget target, string database, string table, DeleteRowRequest request, CancellationToken cancellationToken = default)
+        {
+            var idIdx = Idx(request.Columns, "_id");
+            var id = idIdx >= 0 ? request.OriginalValues[idIdx] : null;
+            if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("Document _id is required to delete.");
+            using var http = ElasticHttp.Build(target, UseHttps);
+            using var resp = await http.DeleteAsync($"/{Uri.EscapeDataString(table)}/_doc/{Uri.EscapeDataString(id)}?refresh=true", cancellationToken);
+            resp.EnsureSuccessStatusCode();
+        }
 
         public async Task DropTableAsync(InnerDatabaseTarget target, string database, string table, CancellationToken cancellationToken = default)
         {

--- a/src/KRINT.Infrastructure/Services/MongoInnerSchemaService.cs
+++ b/src/KRINT.Infrastructure/Services/MongoInnerSchemaService.cs
@@ -41,18 +41,38 @@ namespace KRINT.Infrastructure.Services
             return new TableRows(new[] { "document" }, rows, total);
         }
 
-        public Task UpdateRowAsync(InnerDatabaseTarget target, string database, string table, UpdateRowRequest request, CancellationToken cancellationToken = default)
+        public async Task UpdateRowAsync(InnerDatabaseTarget target, string database, string table, UpdateRowRequest request, CancellationToken cancellationToken = default)
         {
-            // Mongo edits require document-level semantics (replace by _id, type-aware patches).
-            // Out of scope for v1 row editing - surface a clear error to the UI.
-            throw new NotSupportedException("Row editing is not supported for Mongo yet.");
+            InnerDatabaseNameValidator.Require(database);
+            InnerDatabaseNameValidator.Require(table);
+            // The single "document" column carries the whole doc as JSON; identity is its _id.
+            var original = BsonDocument.Parse(request.OriginalValues[0] ?? "{}");
+            var replacement = BsonDocument.Parse(request.NewValues[0] ?? "{}");
+            if (!original.TryGetValue("_id", out var id))
+                throw new ArgumentException("Document has no _id; cannot update.");
+            var collection = Connect(target).GetDatabase(database).GetCollection<BsonDocument>(table);
+            await collection.ReplaceOneAsync(Builders<BsonDocument>.Filter.Eq("_id", id), replacement, cancellationToken: cancellationToken);
         }
 
-        public Task InsertRowAsync(InnerDatabaseTarget target, string database, string table, InsertRowRequest request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("Row insertion is not supported for Mongo yet.");
+        public async Task InsertRowAsync(InnerDatabaseTarget target, string database, string table, InsertRowRequest request, CancellationToken cancellationToken = default)
+        {
+            InnerDatabaseNameValidator.Require(database);
+            InnerDatabaseNameValidator.Require(table);
+            var doc = BsonDocument.Parse(request.Values[0] ?? "{}");
+            var collection = Connect(target).GetDatabase(database).GetCollection<BsonDocument>(table);
+            await collection.InsertOneAsync(doc, cancellationToken: cancellationToken);
+        }
 
-        public Task DeleteRowAsync(InnerDatabaseTarget target, string database, string table, DeleteRowRequest request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("Row deletion is not supported for Mongo yet.");
+        public async Task DeleteRowAsync(InnerDatabaseTarget target, string database, string table, DeleteRowRequest request, CancellationToken cancellationToken = default)
+        {
+            InnerDatabaseNameValidator.Require(database);
+            InnerDatabaseNameValidator.Require(table);
+            var original = BsonDocument.Parse(request.OriginalValues[0] ?? "{}");
+            if (!original.TryGetValue("_id", out var id))
+                throw new ArgumentException("Document has no _id; cannot delete.");
+            var collection = Connect(target).GetDatabase(database).GetCollection<BsonDocument>(table);
+            await collection.DeleteOneAsync(Builders<BsonDocument>.Filter.Eq("_id", id), cancellationToken);
+        }
 
         public async Task DropTableAsync(InnerDatabaseTarget target, string database, string table, CancellationToken cancellationToken = default)
         {

--- a/src/KRINT.Infrastructure/Services/Neo4jServices.cs
+++ b/src/KRINT.Infrastructure/Services/Neo4jServices.cs
@@ -103,12 +103,58 @@ namespace KRINT.Infrastructure.Services
             return new TableRows(new[] { "_id", "properties" }, rows, total);
         }
 
-        public Task InsertRowAsync(InnerDatabaseTarget target, string database, string table, InsertRowRequest request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("Neo4j node insert is not exposed in this version.");
-        public Task UpdateRowAsync(InnerDatabaseTarget target, string database, string table, UpdateRowRequest request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("Neo4j node update is not exposed in this version.");
-        public Task DeleteRowAsync(InnerDatabaseTarget target, string database, string table, DeleteRowRequest request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("Neo4j node delete is not exposed in this version.");
+        private static int Idx(IReadOnlyList<string> cols, string name)
+        {
+            for (var i = 0; i < cols.Count; i++) if (cols[i] == name) return i;
+            return -1;
+        }
+
+        // Neo4j node properties must be primitives/arrays - convert the JSON object to a CLR map.
+        private static Dictionary<string, object?> PropsFromJson(string? json)
+        {
+            var map = new Dictionary<string, object?>();
+            using var doc = JsonDocument.Parse(string.IsNullOrWhiteSpace(json) ? "{}" : json);
+            foreach (var p in doc.RootElement.EnumerateObject())
+            {
+                map[p.Name] = p.Value.ValueKind switch
+                {
+                    JsonValueKind.String => p.Value.GetString(),
+                    JsonValueKind.Number => p.Value.TryGetInt64(out var l) ? l : p.Value.GetDouble(),
+                    JsonValueKind.True => true,
+                    JsonValueKind.False => false,
+                    JsonValueKind.Null => null,
+                    _ => p.Value.GetRawText(),
+                };
+            }
+            return map;
+        }
+
+        public async Task InsertRowAsync(InnerDatabaseTarget target, string database, string table, InsertRowRequest request, CancellationToken cancellationToken = default)
+        {
+            var props = PropsFromJson(request.Values[Idx(request.Columns, "properties")]);
+            using var driver = Neo4jConnect.Build(target);
+            await using var session = driver.AsyncSession(o => o.WithDatabase(database));
+            await session.RunAsync($"CREATE (n:`{table}`) SET n = $props", new { props });
+        }
+
+        public async Task UpdateRowAsync(InnerDatabaseTarget target, string database, string table, UpdateRowRequest request, CancellationToken cancellationToken = default)
+        {
+            var id = request.OriginalValues[Idx(request.Columns, "_id")];
+            if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("Node elementId is required to update.");
+            var props = PropsFromJson(request.NewValues[Idx(request.Columns, "properties")]);
+            using var driver = Neo4jConnect.Build(target);
+            await using var session = driver.AsyncSession(o => o.WithDatabase(database));
+            await session.RunAsync("MATCH (n) WHERE elementId(n) = $id SET n = $props", new { id, props });
+        }
+
+        public async Task DeleteRowAsync(InnerDatabaseTarget target, string database, string table, DeleteRowRequest request, CancellationToken cancellationToken = default)
+        {
+            var id = request.OriginalValues[Idx(request.Columns, "_id")];
+            if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("Node elementId is required to delete.");
+            using var driver = Neo4jConnect.Build(target);
+            await using var session = driver.AsyncSession(o => o.WithDatabase(database));
+            await session.RunAsync("MATCH (n) WHERE elementId(n) = $id DETACH DELETE n", new { id });
+        }
 
         public async Task DropTableAsync(InnerDatabaseTarget target, string database, string table, CancellationToken cancellationToken = default)
         {

--- a/src/KRINT.Infrastructure/Services/QdrantServices.cs
+++ b/src/KRINT.Infrastructure/Services/QdrantServices.cs
@@ -114,10 +114,37 @@ namespace KRINT.Infrastructure.Services
 
         public Task InsertRowAsync(InnerDatabaseTarget target, string database, string table, InsertRowRequest request, CancellationToken cancellationToken = default)
             => throw new NotSupportedException("Qdrant point insert needs a vector - not exposed in this version.");
-        public Task UpdateRowAsync(InnerDatabaseTarget target, string database, string table, UpdateRowRequest request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("Qdrant point update is not exposed in this version.");
-        public Task DeleteRowAsync(InnerDatabaseTarget target, string database, string table, DeleteRowRequest request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("Qdrant point delete is not exposed in this version.");
+
+        private static int Idx(IReadOnlyList<string> cols, string name)
+        {
+            for (var i = 0; i < cols.Count; i++) if (cols[i] == name) return i;
+            return -1;
+        }
+
+        // Point ids are either integers or UUID strings; emit the correct JSON token for each.
+        private static string IdToken(string? id) => long.TryParse(id, out _) ? id! : JsonSerializer.Serialize(id ?? "");
+
+        public async Task UpdateRowAsync(InnerDatabaseTarget target, string database, string table, UpdateRowRequest request, CancellationToken cancellationToken = default)
+        {
+            var id = request.OriginalValues[Idx(request.Columns, "id")];
+            if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("Point id is required to update.");
+            var payload = request.NewValues[Idx(request.Columns, "payload")] ?? "{}";
+            using var http = QdrantHttp.Build(target);
+            // Overwrite the point's payload (vector is left untouched).
+            var body = $"{{\"points\":[{IdToken(id)}],\"payload\":{payload}}}";
+            using var resp = await http.PostAsync($"/collections/{Uri.EscapeDataString(table)}/points/payload?wait=true", new StringContent(body, System.Text.Encoding.UTF8, "application/json"), cancellationToken);
+            resp.EnsureSuccessStatusCode();
+        }
+
+        public async Task DeleteRowAsync(InnerDatabaseTarget target, string database, string table, DeleteRowRequest request, CancellationToken cancellationToken = default)
+        {
+            var id = request.OriginalValues[Idx(request.Columns, "id")];
+            if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("Point id is required to delete.");
+            using var http = QdrantHttp.Build(target);
+            var body = $"{{\"points\":[{IdToken(id)}]}}";
+            using var resp = await http.PostAsync($"/collections/{Uri.EscapeDataString(table)}/points/delete?wait=true", new StringContent(body, System.Text.Encoding.UTF8, "application/json"), cancellationToken);
+            resp.EnsureSuccessStatusCode();
+        }
 
         public async Task DropTableAsync(InnerDatabaseTarget target, string database, string table, CancellationToken cancellationToken = default)
         {


### PR DESCRIPTION
Implements row write operations in the data browser for the document/graph engines: Mongo (by `_id`), CouchDB (`_id`+`_rev`), Elasticsearch (index by `_id`), Neo4j (by `elementId`) get full insert/edit/delete; Qdrant gets payload edit + point delete (insert stays off — a point needs a vector). Also makes the Elasticsearch readiness probe wait for cluster health.

Verified live: Mongo, CouchDB, Neo4j full CRUD and Qdrant edit/delete. (ES uses the same verified pattern; it was unresponsive in the test sandbox so live ES verification is pending.)

Closes #181

Supersedes #180.