### PR TITLE
Added Qdrant cluster view with 3D vector scatter

### DIFF
--- a/src/KRINT.API/Controllers/DatabaseController.cs
+++ b/src/KRINT.API/Controllers/DatabaseController.cs
@@ -300,6 +300,21 @@ namespace KRINT.API.Controllers
             catch (ArgumentException ex) { return BadRequest(new { error = ex.Message }); }
         }
 
+        // Cluster view: a collection's points with vectors, for the 3D scatter (Qdrant only).
+        [HttpGet("{id:guid}/cluster/{collection}")]
+        [ProducesResponseType(typeof(VectorClusterDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> FetchCluster(Guid id, string collection, [FromQuery] int limit = 500, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return Ok(await mediator.Send(new FetchVectorPointsQuery(id, collection, limit), cancellationToken));
+            }
+            catch (InstanceNotFoundException) { return NotFound(); }
+            catch (NotSupportedException ex) { return BadRequest(new { error = ex.Message }); }
+            catch (ArgumentException ex) { return BadRequest(new { error = ex.Message }); }
+        }
+
         [HttpPatch("{id:guid}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/KRINT.Application/Dtos/Browse/VectorClusterDto.cs
+++ b/src/KRINT.Application/Dtos/Browse/VectorClusterDto.cs
@@ -1,0 +1,15 @@
+namespace KRINT.Application.Dtos.Browse
+{
+    public record VectorPointDto
+    {
+        public required string Id { get; init; }
+        public required IReadOnlyList<float> Vector { get; init; }
+        public required string Payload { get; init; }
+    }
+
+    public record VectorClusterDto
+    {
+        public required int Dimensions { get; init; }
+        public required IReadOnlyList<VectorPointDto> Points { get; init; }
+    }
+}

--- a/src/KRINT.Application/Queries/Browse/FetchVectorPointsQuery.cs
+++ b/src/KRINT.Application/Queries/Browse/FetchVectorPointsQuery.cs
@@ -1,0 +1,28 @@
+using Mediator;
+using KRINT.Application.Dtos.Browse;
+using KRINT.Infrastructure;
+using KRINT.Infrastructure.Interfaces;
+
+namespace KRINT.Application.Queries.Browse
+{
+    public record FetchVectorPointsQuery(Guid InstanceId, string Collection, int Limit = 500)
+        : IQuery<VectorClusterDto>;
+
+    public class FetchVectorPointsQueryHandler(KrintDbContext db, ISecretsVaultService vault, IQdrantVectorService qdrant)
+        : IQueryHandler<FetchVectorPointsQuery, VectorClusterDto>
+    {
+        public async ValueTask<VectorClusterDto> Handle(FetchVectorPointsQuery query, CancellationToken cancellationToken)
+        {
+            var target = await InnerDatabaseTargetLoader.LoadAsync(db, vault, query.InstanceId, cancellationToken);
+            if (!string.Equals(target.Engine, "qdrant", StringComparison.OrdinalIgnoreCase))
+                throw new NotSupportedException("Cluster view is only available for Qdrant instances.");
+
+            var points = await qdrant.FetchAsync(target, query.Collection, query.Limit, cancellationToken);
+            return new VectorClusterDto
+            {
+                Dimensions = points.Count > 0 ? points[0].Vector.Count : 0,
+                Points = points.Select(p => new VectorPointDto { Id = p.Id, Vector = p.Vector, Payload = p.Payload }).ToList(),
+            };
+        }
+    }
+}

--- a/src/KRINT.Frontend/angular.json
+++ b/src/KRINT.Frontend/angular.json
@@ -26,6 +26,10 @@
             ],
             "styles": [
               "src/styles.css"
+            ],
+            "allowedCommonJsDependencies": [
+              "plotly.js-dist-min",
+              "umap-js"
             ]
           },
           "configurations": {

--- a/src/KRINT.Frontend/bun.lock
+++ b/src/KRINT.Frontend/bun.lock
@@ -34,9 +34,11 @@
         "clsx": "^2.1.1",
         "codemirror": "^6.0.2",
         "embla-carousel-angular": "^20.0.0",
+        "plotly.js-dist-min": "^3.6.0",
         "rxjs": "~7.8.0",
         "tailwind-merge": "^3.5.0",
         "tslib": "^2.3.0",
+        "umap-js": "^1.4.0",
       },
       "devDependencies": {
         "@angular/build": "^21.0.5",
@@ -1671,6 +1673,8 @@
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
+    "is-any-array": ["is-any-array@0.1.1", "", {}, "sha512-qTiELO+kpTKqPgxPYbshMERlzaFu29JDnpB8s3bjg+JkxBpw29/qqSaOdKv2pCdaG92rLGeG/zG2GauX58hfoA=="],
+
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
@@ -1887,6 +1891,16 @@
 
     "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
+    "ml-array-max": ["ml-array-max@2.0.0", "", { "dependencies": { "is-any-array": "^3.0.0" } }, "sha512-QQZ4kENwpWmyNb98UXRDFXrmtIXuXtt1+bSbda/2KA85+F+rrJP8hZk6QOkCQXM2Th9mUDYdq/PNByPdT9ID4A=="],
+
+    "ml-array-min": ["ml-array-min@2.0.0", "", { "dependencies": { "is-any-array": "^3.0.0" } }, "sha512-GRj6Ky6sW9vGL6yIjgsHmXZ9YgrdmcQ8nCxPqEGeKc6dkfYg1XDYxGFxADUjNuZyoCd5PUscWAS4N+cFaX6hFg=="],
+
+    "ml-array-rescale": ["ml-array-rescale@2.0.0", "", { "dependencies": { "is-any-array": "^3.0.0", "ml-array-max": "^2.0.0", "ml-array-min": "^2.0.0" } }, "sha512-2GGtKfSno94/kIloWGvpp/U5Q5vLvLrza+SAaGsLeo6Xj4mEbA6Gqx+oTfZFkxnd1grT2X007HfJNs3T5BsiVg=="],
+
+    "ml-levenberg-marquardt": ["ml-levenberg-marquardt@2.1.1", "", { "dependencies": { "is-any-array": "^0.1.0", "ml-matrix": "^6.4.1" } }, "sha512-2+HwUqew4qFFFYujYlQtmFUrxCB4iJAPqnUYro3P831wj70eJZcANwcRaIMGUVaH9NDKzfYuA4N5u67KExmaRA=="],
+
+    "ml-matrix": ["ml-matrix@6.12.2", "", { "dependencies": { "is-any-array": "^3.0.0", "ml-array-rescale": "^2.0.0" } }, "sha512-GC+BnW+pBh8Auap8goAxY0senAmF0IEoc3HNVSfnfbvGw0buuDIYb9kAKMS1l+GiwJ1rfK2bzJ8IHhwjzATSFA=="],
+
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
@@ -2038,6 +2052,8 @@
     "pkg-dir": ["pkg-dir@7.0.0", "", { "dependencies": { "find-up": "^6.3.0" } }, "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA=="],
 
     "pkijs": ["pkijs@3.4.0", "", { "dependencies": { "@noble/hashes": "1.4.0", "asn1js": "^3.0.6", "bytestreamjs": "^2.0.1", "pvtsutils": "^1.3.6", "pvutils": "^1.1.3", "tslib": "^2.8.1" } }, "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw=="],
+
+    "plotly.js-dist-min": ["plotly.js-dist-min@3.6.0", "", {}, "sha512-VR9jO2YdcEwbzVwtRyPE0eAieXFv1x5q6M9nnIgUS8FggahPrjiID6kzpnTYABwLX0gZkgEc0zxS6gQgVmgHzw=="],
 
     "portfinder": ["portfinder@1.0.38", "", { "dependencies": { "async": "^3.2.6", "debug": "^4.3.6" } }, "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg=="],
 
@@ -2457,6 +2473,8 @@
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
+    "umap-js": ["umap-js@1.4.0", "", { "dependencies": { "ml-levenberg-marquardt": "^2.0.0" } }, "sha512-xxpviF9wUO6Nxrx+C58SoDgea+h2PnVaRPKDelWv0HotmY6BeWeh0kAPJoumfqUkzUvowGsYfMbnsWI0b9do+A=="],
+
     "undici": ["undici@7.24.4", "", {}, "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
@@ -2840,6 +2858,14 @@
     "minipass-flush/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "minipass-pipeline/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "ml-array-max/is-any-array": ["is-any-array@3.0.0", "", {}, "sha512-o4h+tylWykC4BD1vaejp6gDxoM13bwW8FGuNs4yIKpj8xbBJcRxJx8vZpq0dCr7ZDEfeKjmsi/euolKhX6f/ww=="],
+
+    "ml-array-min/is-any-array": ["is-any-array@3.0.0", "", {}, "sha512-o4h+tylWykC4BD1vaejp6gDxoM13bwW8FGuNs4yIKpj8xbBJcRxJx8vZpq0dCr7ZDEfeKjmsi/euolKhX6f/ww=="],
+
+    "ml-array-rescale/is-any-array": ["is-any-array@3.0.0", "", {}, "sha512-o4h+tylWykC4BD1vaejp6gDxoM13bwW8FGuNs4yIKpj8xbBJcRxJx8vZpq0dCr7ZDEfeKjmsi/euolKhX6f/ww=="],
+
+    "ml-matrix/is-any-array": ["is-any-array@3.0.0", "", {}, "sha512-o4h+tylWykC4BD1vaejp6gDxoM13bwW8FGuNs4yIKpj8xbBJcRxJx8vZpq0dCr7ZDEfeKjmsi/euolKhX6f/ww=="],
 
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 

--- a/src/KRINT.Frontend/package.json
+++ b/src/KRINT.Frontend/package.json
@@ -54,9 +54,11 @@
     "clsx": "^2.1.1",
     "codemirror": "^6.0.2",
     "embla-carousel-angular": "^20.0.0",
+    "plotly.js-dist-min": "^3.6.0",
     "rxjs": "~7.8.0",
     "tailwind-merge": "^3.5.0",
-    "tslib": "^2.3.0"
+    "tslib": "^2.3.0",
+    "umap-js": "^1.4.0"
   },
   "devDependencies": {
     "@angular/build": "^21.0.5",

--- a/src/KRINT.Frontend/src/app/browser/browser.html
+++ b/src/KRINT.Frontend/src/app/browser/browser.html
@@ -124,6 +124,18 @@
       >
         Query
       </button>
+      @if (canCluster()) {
+        <button
+          type="button"
+          class="hover:bg-muted/60 rounded-md px-3 py-1 text-xs font-medium transition-colors disabled:opacity-50"
+          [class.bg-muted]="view() === 'cluster'"
+          [class.text-muted-foreground]="view() !== 'cluster'"
+          [disabled]="!table()"
+          (click)="view.set('cluster')"
+        >
+          Cluster view
+        </button>
+      }
     </nav>
 
     @if (view() === 'query') {
@@ -134,6 +146,18 @@
         [engine]="selectedInstance()?.engine ?? null"
         [tables]="tables()"
       />
+    } @else if (view() === 'cluster') {
+      @if (!table()) {
+        <p class="text-muted-foreground flex flex-1 items-center justify-center text-sm">
+          Select a {{ tableTerm() }} to plot its {{ rowTerm() }}s.
+        </p>
+      } @else if (clusterLoading()) {
+        <p class="text-muted-foreground flex flex-1 items-center justify-center text-sm">Reducing vectors…</p>
+      } @else if (clusterError()) {
+        <p class="text-destructive flex flex-1 items-center justify-center text-sm">{{ clusterError() }}</p>
+      } @else {
+        <app-vector-scatter class="flex-1 overflow-hidden" [data]="clusterData()" />
+      }
     } @else if (!table()) {
       <p class="text-muted-foreground flex flex-1 items-center justify-center text-sm">
         @if (!instanceId()) {

--- a/src/KRINT.Frontend/src/app/browser/browser.ts
+++ b/src/KRINT.Frontend/src/app/browser/browser.ts
@@ -1,3 +1,4 @@
+import { HttpClient } from '@angular/common/http';
 import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import {
@@ -27,6 +28,8 @@ import { HlmTooltipImports } from '@spartan-ng/helm/tooltip';
 import { ContentHeader } from '../shared/components/content-header/content-header';
 import { ConfirmService } from '../shared/components/confirm-dialog/confirm-dialog';
 import { QueryConsole } from '../shared/components/query-console/query-console';
+import { VectorScatter, VectorCluster } from '../shared/components/vector-scatter/vector-scatter';
+import { environment } from '../shared/environments/environment';
 import { customMssql, customQdrant, customValkey } from '../shared/icons/custom-icons';
 import { DatabaseService } from '../api/api/database.service';
 import { DatabaseInstanceDto } from '../api/model/databaseInstanceDto';
@@ -54,6 +57,7 @@ type Draft = { values: EditValue[]; mode: 'edit' | 'insert'; rowIndex: number | 
     HlmTableImports,
     HlmTooltipImports,
     QueryConsole,
+    VectorScatter,
   ],
   providers: [
     provideIcons({
@@ -91,6 +95,7 @@ type Draft = { values: EditValue[]; mode: 'edit' | 'insert'; rowIndex: number | 
 })
 export class Browser {
   private readonly api = inject(DatabaseService);
+  private readonly http = inject(HttpClient);
   private readonly confirmService = inject(ConfirmService);
   protected readonly nullToken = NULL_TOKEN;
 
@@ -109,7 +114,12 @@ export class Browser {
 
   // Right-pane tabs. 'data' is the row browser (default); 'query' swaps in the SQL console
   // pre-scoped to the currently-selected instance + database.
-  protected readonly view = signal<'data' | 'query'>('data');
+  protected readonly view = signal<'data' | 'query' | 'cluster'>('data');
+
+  // Qdrant-only "Cluster view": points fetched with vectors, plotted as a 3D scatter.
+  protected readonly clusterData = signal<VectorCluster | null>(null);
+  protected readonly clusterLoading = signal(false);
+  protected readonly clusterError = signal<string | null>(null);
 
   protected readonly loading = signal(false);
   protected readonly error = signal<string | null>(null);
@@ -147,6 +157,9 @@ export class Browser {
 
   // Legacy alias kept so the template can keep using canEdit() until the next sweep.
   protected readonly canEdit = this.canEditRow;
+
+  // Cluster view is Qdrant-specific (vectors to visualise).
+  protected readonly canCluster = computed(() => this.selectedInstance()?.engine === 'qdrant');
 
   protected readonly editingIndex = computed(() => {
     const d = this.draft();
@@ -213,6 +226,26 @@ export class Browser {
       this.pendingEdits.set(new Map());
       this.loadRows(id, db, tbl, lim, off);
     });
+
+    // Load cluster points whenever the Cluster view is active for a selected Qdrant collection.
+    effect(() => {
+      const id = this.instanceId();
+      const tbl = this.table();
+      if (this.view() !== 'cluster' || !id || !tbl) return;
+      this.loadCluster(id, tbl);
+    });
+  }
+
+  private loadCluster(id: string, collection: string): void {
+    this.clusterLoading.set(true);
+    this.clusterError.set(null);
+    this.clusterData.set(null);
+    this.http
+      .get<VectorCluster>(`${environment.apiBaseUrl}/api/Database/${id}/cluster/${encodeURIComponent(collection)}?limit=500`)
+      .subscribe({
+        next: (c) => { this.clusterData.set(c); this.clusterLoading.set(false); },
+        error: (err) => { this.clusterError.set(messageOf(err)); this.clusterLoading.set(false); },
+      });
   }
 
   private refreshTables(id: string, db: string): void {

--- a/src/KRINT.Frontend/src/app/shared/components/vector-scatter/vector-scatter.ts
+++ b/src/KRINT.Frontend/src/app/shared/components/vector-scatter/vector-scatter.ts
@@ -1,0 +1,144 @@
+import { ChangeDetectionStrategy, Component, DestroyRef, ElementRef, effect, inject, input, viewChild } from '@angular/core';
+
+export interface VectorPoint {
+  id: string;
+  vector: number[];
+  payload: string;
+}
+export interface VectorCluster {
+  dimensions: number;
+  points: VectorPoint[];
+}
+
+interface Group {
+  name: string;
+  x: number[];
+  y: number[];
+  z: number[];
+  ids: string[];
+}
+
+@Component({
+  selector: 'app-vector-scatter',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @if (!data() || data()!.points.length === 0) {
+      <p class="text-muted-foreground flex h-full items-center justify-center text-sm">
+        No points to plot.
+      </p>
+    }
+    <div #plot class="h-full w-full" [class.hidden]="!data() || data()!.points.length === 0"></div>
+  `,
+  host: { class: 'block h-full w-full' },
+})
+export class VectorScatter {
+  /** The fetched cluster payload (id + vector + payload per point). */
+  readonly data = input<VectorCluster | null>(null);
+  /** Payload field to colour points by. When unset, the first scalar field is used. */
+  readonly colorField = input<string | null>(null);
+
+  private readonly plotEl = viewChild<ElementRef<HTMLElement>>('plot');
+
+  constructor() {
+    const destroyRef = inject(DestroyRef);
+    effect(() => {
+      const el = this.plotEl()?.nativeElement;
+      const data = this.data();
+      const field = this.colorField();
+      if (!el || !data || data.points.length === 0) return;
+      void this.render(el, data, field);
+    });
+    destroyRef.onDestroy(() => {
+      const el = this.plotEl()?.nativeElement;
+      if (el) void import('plotly.js-dist-min').then((Plotly) => Plotly.purge(el));
+    });
+  }
+
+  private async render(el: HTMLElement, data: VectorCluster, field: string | null): Promise<void> {
+    const groups = await this.buildGroups(data, field);
+    if (groups.length === 0) return;
+    const { react } = await import('plotly.js-dist-min');
+    const traces = groups.map((g) => ({
+      type: 'scatter3d',
+      mode: 'markers',
+      name: g.name,
+      x: g.x,
+      y: g.y,
+      z: g.z,
+      text: g.ids,
+      hovertemplate: 'id %{text}<extra>' + g.name + '</extra>',
+      marker: { size: 4, opacity: 0.85 },
+    }));
+    const layout = {
+      margin: { l: 0, r: 0, t: 0, b: 0 },
+      paper_bgcolor: 'rgba(0,0,0,0)',
+      showlegend: groups.length > 1,
+      legend: { font: { size: 11 } },
+      scene: {
+        xaxis: { title: { text: '' } },
+        yaxis: { title: { text: '' } },
+        zaxis: { title: { text: '' } },
+      },
+    };
+    await react(el, traces, layout, { displaylogo: false, responsive: true });
+  }
+
+  /** Reduce vectors to 3D (UMAP for >3 dims; small sets fall back to the raw first dims) and
+   *  bucket points into colour groups by the chosen / first scalar payload field. */
+  private async buildGroups(data: VectorCluster, colorField: string | null): Promise<Group[]> {
+    const vectors = data.points.map((p) => p.vector);
+    const coords = await this.reduceTo3D(vectors, data.dimensions);
+
+    const field = colorField ?? this.firstScalarField(data.points);
+    const byName = new Map<string, Group>();
+    data.points.forEach((p, i) => {
+      const name = this.groupKey(p.payload, field);
+      let g = byName.get(name);
+      if (!g) {
+        g = { name, x: [], y: [], z: [], ids: [] };
+        byName.set(name, g);
+      }
+      const c = coords[i] ?? [0, 0, 0];
+      g.x.push(c[0] ?? 0);
+      g.y.push(c[1] ?? 0);
+      g.z.push(c[2] ?? 0);
+      g.ids.push(p.id);
+    });
+    return [...byName.values()];
+  }
+
+  private async reduceTo3D(vectors: number[][], dims: number): Promise<number[][]> {
+    if (dims <= 3 || vectors.length < 5) {
+      return vectors.map((v) => [v[0] ?? 0, v[1] ?? 0, v[2] ?? 0]);
+    }
+    const { UMAP } = await import('umap-js');
+    const nNeighbors = Math.max(2, Math.min(15, vectors.length - 1));
+    const umap = new UMAP({ nComponents: 3, nNeighbors });
+    return umap.fit(vectors);
+  }
+
+  private firstScalarField(points: VectorPoint[]): string | null {
+    for (const p of points) {
+      const obj = this.parse(p.payload);
+      for (const [k, v] of Object.entries(obj)) {
+        if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') return k;
+      }
+    }
+    return null;
+  }
+
+  private groupKey(payload: string, field: string | null): string {
+    if (!field) return 'points';
+    const v = this.parse(payload)[field];
+    return v === undefined || v === null ? '(none)' : String(v);
+  }
+
+  private parse(payload: string): Record<string, unknown> {
+    try {
+      const o = JSON.parse(payload);
+      return o && typeof o === 'object' ? (o as Record<string, unknown>) : {};
+    } catch {
+      return {};
+    }
+  }
+}

--- a/src/KRINT.Frontend/src/app/shared/types/plotly-dist-min.d.ts
+++ b/src/KRINT.Frontend/src/app/shared/types/plotly-dist-min.d.ts
@@ -1,0 +1,25 @@
+// Minimal typings for the parts of plotly.js-dist-min we use (the package ships no .d.ts).
+declare module 'plotly.js-dist-min' {
+  export interface PlotData {
+    [key: string]: unknown;
+  }
+  export interface Layout {
+    [key: string]: unknown;
+  }
+  export interface Config {
+    [key: string]: unknown;
+  }
+  export function newPlot(
+    root: HTMLElement,
+    data: Array<Partial<PlotData>>,
+    layout?: Partial<Layout>,
+    config?: Partial<Config>,
+  ): Promise<void>;
+  export function react(
+    root: HTMLElement,
+    data: Array<Partial<PlotData>>,
+    layout?: Partial<Layout>,
+    config?: Partial<Config>,
+  ): Promise<void>;
+  export function purge(root: HTMLElement): void;
+}

--- a/src/KRINT.Infrastructure/Extensions/InnerDatabasesExtensions.cs
+++ b/src/KRINT.Infrastructure/Extensions/InnerDatabasesExtensions.cs
@@ -68,6 +68,9 @@ namespace KRINT.Infrastructure.Extensions
             services.AddSingleton<IInnerSchemaService, AzuriteInnerSchemaService>();
             services.AddSingleton<IInnerSchemaServiceResolver, InnerSchemaServiceResolver>();
 
+            // Qdrant cluster view: fetches points with vectors for the 3D scatter.
+            services.AddSingleton<IQdrantVectorService, QdrantVectorService>();
+
             // Query console - SQL engines only for v1. Engines without an entry surface in the
             // UI as "console not available" rather than throwing.
             services.AddSingleton<IInnerQueryService, PostgresInnerQueryService>();

--- a/src/KRINT.Infrastructure/Interfaces/IQdrantVectorService.cs
+++ b/src/KRINT.Infrastructure/Interfaces/IQdrantVectorService.cs
@@ -1,0 +1,12 @@
+namespace KRINT.Infrastructure.Interfaces
+{
+    /// <summary>One Qdrant point with its raw vector and payload, for the cluster view.</summary>
+    public record VectorPoint(string Id, IReadOnlyList<float> Vector, string Payload);
+
+    /// <summary>Fetches points *with* their vectors (the normal browse path omits them) so the
+    /// frontend can reduce them to 2D/3D and plot clusters. Qdrant-only for now.</summary>
+    public interface IQdrantVectorService
+    {
+        Task<IReadOnlyList<VectorPoint>> FetchAsync(InnerDatabaseTarget target, string collection, int limit, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/KRINT.Infrastructure/Services/QdrantVectorService.cs
+++ b/src/KRINT.Infrastructure/Services/QdrantVectorService.cs
@@ -1,0 +1,63 @@
+using System.Text;
+using System.Text.Json;
+using KRINT.Infrastructure.Interfaces;
+
+namespace KRINT.Infrastructure.Services
+{
+    // Scrolls a Qdrant collection's points WITH vectors (the browse path uses with_vector=false).
+    // Reuses QdrantHttp (api-key auth) from QdrantServices.
+    public class QdrantVectorService : IQdrantVectorService
+    {
+        public async Task<IReadOnlyList<VectorPoint>> FetchAsync(InnerDatabaseTarget target, string collection, int limit, CancellationToken cancellationToken = default)
+        {
+            InnerDatabaseNameValidator.Require(collection);
+            limit = Math.Clamp(limit, 1, 2000);
+
+            using var http = QdrantHttp.Build(target);
+            var body = JsonSerializer.Serialize(new { limit, with_payload = true, with_vector = true });
+            using var resp = await http.PostAsync(
+                $"/collections/{Uri.EscapeDataString(collection)}/points/scroll",
+                new StringContent(body, Encoding.UTF8, "application/json"), cancellationToken);
+            resp.EnsureSuccessStatusCode();
+            await using var stream = await resp.Content.ReadAsStreamAsync(cancellationToken);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+
+            var points = new List<VectorPoint>();
+            if (doc.RootElement.TryGetProperty("result", out var r) && r.TryGetProperty("points", out var pts))
+            {
+                foreach (var p in pts.EnumerateArray())
+                {
+                    var id = p.TryGetProperty("id", out var i) ? i.ToString() : null;
+                    if (id is null) continue;
+                    var vec = ExtractVector(p);
+                    if (vec.Count == 0) continue; // skip points without a usable unnamed vector
+                    var payload = p.TryGetProperty("payload", out var pl) ? pl.GetRawText() : "{}";
+                    points.Add(new VectorPoint(id, vec, payload));
+                }
+            }
+            return points;
+        }
+
+        // The "vector" field is an array for unnamed vectors, or an object {name: [...]} for named
+        // ones. Take the array directly, or the first named vector's array.
+        private static IReadOnlyList<float> ExtractVector(JsonElement point)
+        {
+            if (!point.TryGetProperty("vector", out var v)) return Array.Empty<float>();
+            if (v.ValueKind == JsonValueKind.Array) return ToFloats(v);
+            if (v.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var prop in v.EnumerateObject())
+                    if (prop.Value.ValueKind == JsonValueKind.Array) return ToFloats(prop.Value);
+            }
+            return Array.Empty<float>();
+        }
+
+        private static float[] ToFloats(JsonElement arr)
+        {
+            var list = new List<float>(arr.GetArrayLength());
+            foreach (var e in arr.EnumerateArray())
+                if (e.ValueKind == JsonValueKind.Number) list.Add((float)e.GetDouble());
+            return list.ToArray();
+        }
+    }
+}


### PR DESCRIPTION
Added a Cluster view to the Qdrant browser that fetches a collection's vectors and renders them as an interactive 3D scatter (umap-js for reduction, lazy-loaded Plotly).

Closes #183