### PR TITLE
Fixed slow desktop data loads by caching reachable-host probe

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -158,7 +158,10 @@ fn start_backend(app: &tauri::AppHandle) -> Result<(), Box<dyn std::error::Error
     let api_port = free_port()?;
     let oidc_port = free_port()?;
 
-    let authority = format!("http://localhost:{oidc_port}");
+    // Use 127.0.0.1 (not "localhost"): the issuer binds to 127.0.0.1, and on Windows
+    // "localhost" resolves to ::1 first, so metadata/token fetches would eat a failed-IPv6
+    // -then-IPv4 fallback delay on every call.
+    let authority = format!("http://127.0.0.1:{oidc_port}");
     start_oidc(authority.clone(), oidc_port);
     let urls = format!("http://127.0.0.1:{api_port}");
     let conn = format!("Data Source={}", db_path.to_string_lossy());

--- a/src/KRINT.Application/InnerDatabaseTargetLoader.cs
+++ b/src/KRINT.Application/InnerDatabaseTargetLoader.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.EntityFrameworkCore;
 using KRINT.Infrastructure;
 using KRINT.Infrastructure.Interfaces;
@@ -26,12 +27,18 @@ namespace KRINT.Application
             return new InnerDatabaseTarget(instance.Engine, host, instance.Port, instance.Username, password, instance.DatabaseName);
         }
 
+        // Resolved (preferred, port) -> reachable host, so the probe runs once per instance
+        // instead of once per operation. Without this every browse/list/rows call paid the
+        // probe cost; on a host-run KRINT (e.g. the desktop app) the first-choice host can be
+        // unreachable, so each request burned the full connect timeout before falling back -
+        // which made the desktop app feel sluggish versus the in-container deployment.
+        private static readonly ConcurrentDictionary<string, string> ReachableHostCache = new();
+
         // Which local probe host can reach a published port depends on where KRINT runs: a
         // containerized KRINT can't reach 127.0.0.1-bound ports via its own loopback but can
         // via Docker Desktop's host-gateway (host.docker.internal); a host-run KRINT is the
-        // reverse. Pre-probe with a cheap TCP connect and fall back to the alternate.
-        // ponytail: one extra TCP connect per operation (~1ms locally) - cache per port if it
-        // ever shows up in profiles.
+        // reverse. Pre-probe with a cheap TCP connect and fall back to the alternate, then
+        // cache the answer per (preferred, port) so we only probe once.
         public static async Task<string> PickReachableHostAsync(string preferred, int port, CancellationToken cancellationToken)
         {
             var alternate = preferred switch
@@ -41,9 +48,15 @@ namespace KRINT.Application
                 _ => null,   // real hostname the user typed - never second-guess it
             };
             if (alternate is null) return preferred;
-            if (await CanConnectAsync(preferred, port, cancellationToken)) return preferred;
-            if (await CanConnectAsync(alternate, port, cancellationToken)) return alternate;
-            return preferred;   // neither answered - let the engine call surface the real error
+
+            var cacheKey = $"{preferred}:{port}";
+            if (ReachableHostCache.TryGetValue(cacheKey, out var cached)) return cached;
+
+            if (await CanConnectAsync(preferred, port, cancellationToken))
+                return ReachableHostCache[cacheKey] = preferred;
+            if (await CanConnectAsync(alternate, port, cancellationToken))
+                return ReachableHostCache[cacheKey] = alternate;
+            return preferred;   // neither answered - let the engine call surface the real error (don't cache a guess)
         }
 
         private static async Task<bool> CanConnectAsync(string host, int port, CancellationToken cancellationToken)
@@ -52,7 +65,9 @@ namespace KRINT.Application
             {
                 using var client = new System.Net.Sockets.TcpClient();
                 using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                cts.CancelAfter(TimeSpan.FromSeconds(2));
+                // Loopback / host-gateway answers immediately or not at all, so a short timeout
+                // keeps a miss cheap (the result is cached, so this is paid once per instance).
+                cts.CancelAfter(TimeSpan.FromMilliseconds(500));
                 await client.ConnectAsync(host, port, cts.Token);
                 return true;
             }


### PR DESCRIPTION
Cache the reachable-host probe per (host, port) so it runs once per instance instead of on every inner-DB request, shorten the probe timeout to 500ms, and point the desktop OIDC authority at 127.0.0.1 to avoid the Windows IPv6-first delay. Fixes the desktop app feeling sluggish on data loads.

Closes #186