### PR TITLE
Stamp desktop bundles with the release version

### DIFF
--- a/.github/workflows/desktop-release.yaml
+++ b/.github/workflows/desktop-release.yaml
@@ -59,6 +59,28 @@ jobs:
       - name: Install Tauri CLI
         run: bun install
 
+      # The committed tauri.conf.json / Cargo.toml versions are not the release version, so
+      # stamp the bundles (and the binary) with the tag instead - otherwise every installer is
+      # named after the placeholder version. Runs on all three runners (bash is available on
+      # the Windows runner via Git Bash).
+      - name: Stamp desktop version from release tag
+        shell: bash
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          export VERSION="${TAG#v}"
+          node -e "
+            const fs = require('fs');
+            const conf = 'src-tauri/tauri.conf.json';
+            const c = JSON.parse(fs.readFileSync(conf, 'utf8'));
+            c.version = process.env.VERSION;
+            fs.writeFileSync(conf, JSON.stringify(c, null, 2) + '\n');
+            const cargo = 'src-tauri/Cargo.toml';
+            const t = fs.readFileSync(cargo, 'utf8').replace(/^version = \".*\"/m, 'version = \"' + process.env.VERSION + '\"');
+            fs.writeFileSync(cargo, t);
+          "
+          echo "Stamped desktop version: $VERSION"
+
       # tauri-action runs the beforeBuildCommand (scripts/publish-sidecar.mjs), which builds
       # the SPA and publishes KRINT.API self-contained for this runner's RID, then builds the
       # installers (.deb/.rpm/.AppImage, .msi/.exe, .dmg/.app) and uploads them to the release.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "krint-desktop"
-version = "0.1.0"
+version = "2.3.0"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krint-desktop"
-version = "0.1.0"
+version = "2.3.0"
 description = "KRINT desktop app"
 authors = ["KRINT"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "KRINT",
-  "version": "0.1.0",
+  "version": "2.3.0",
   "identifier": "app.krint.desktop",
   "build": {
     "beforeBuildCommand": "node scripts/publish-sidecar.mjs",


### PR DESCRIPTION
Stamps the Tauri config with the release-tag version at build time in desktop-release.yaml so installers are named after the real version instead of the placeholder, and bumps the committed tauri.conf.json/Cargo.toml/Cargo.lock to match.

Closes #188