### PR TITLE
Fix row edit/delete across engines

### DIFF
--- a/src/KRINT.Application/Queries/SupportedDatabase/GetSupportedDatabasesQuery.cs
+++ b/src/KRINT.Application/Queries/SupportedDatabase/GetSupportedDatabasesQuery.cs
@@ -34,13 +34,12 @@ namespace KRINT.Application.Queries.SupportedDatabase
             RowTerm = "document",
         };
 
-        // CockroachDB: Postgres-wire-compatible but no `ctid` and no pg_dump. We disable row
-        // edit/delete (those use ctid to enforce exactly-one-match) and disable backup until
-        // a cockroach-native dump path is added.
+        // CockroachDB: Postgres-wire-compatible but no `ctid` and no pg_dump. Row edit/delete work
+        // via a plain WHERE on the loaded values (the match-count guard already enforces exactly-one
+        // -match, so ctid isn't needed); the schema service overrides the ctid statements. Backup
+        // stays disabled until a cockroach-native dump path is added.
         private static readonly EngineCapabilitiesDto CockroachCaps = SqlCaps with
         {
-            SupportsRowEdit = false,
-            SupportsRowDelete = false,
             SupportsBackup = false,
         };
 

--- a/src/KRINT.Infrastructure/Services/CockroachDbServices.cs
+++ b/src/KRINT.Infrastructure/Services/CockroachDbServices.cs
@@ -6,9 +6,8 @@ namespace KRINT.Infrastructure.Services
     // information_schema / pg_catalog views are 1:1 enough that our list/select queries work.
     // Differences we have to override:
     //   - No DROP DATABASE … WITH (FORCE) clause syntax.
-    //   - No `ctid` MVCC handle, so the row edit/delete code that uses it doesn't work; caps
-    //     advertise SupportsRowEdit/Delete=false, so the schema service's defaults are simply
-    //     never invoked from the UI.
+    //   - No `ctid` MVCC handle, so the row edit/delete statements are overridden to pin the row
+    //     with a plain WHERE instead (the base match-count guard already enforces exactly-one-match).
     //   - No pg_dump compatibility; SupportsBackup=false until we wire `cockroach sql` /
     //     `EXPORT` flows. No backup-service registration here.
     public sealed class CockroachDbInnerDatabaseService : PostgresInnerDatabaseService
@@ -40,5 +39,13 @@ namespace KRINT.Infrastructure.Services
     public sealed class CockroachDbInnerSchemaService : PostgresInnerSchemaService
     {
         public override string Engine => "cockroachdb";
+
+        // CockroachDB has no ctid. The base class's match-count guard already proves exactly one row
+        // matches the WHERE, so pinning by a plain WHERE updates/deletes precisely that row.
+        protected override string BuildUpdateCommandText(string qualifiedTable, string setClause, string whereClause)
+            => $"UPDATE {qualifiedTable} SET {setClause} WHERE {whereClause}";
+
+        protected override string BuildDeleteCommandText(string qualifiedTable, string whereClause)
+            => $"DELETE FROM {qualifiedTable} WHERE {whereClause}";
     }
 }

--- a/src/KRINT.Infrastructure/Services/MsSqlServices.cs
+++ b/src/KRINT.Infrastructure/Services/MsSqlServices.cs
@@ -141,6 +141,20 @@ namespace KRINT.Infrastructure.Services
             return results;
         }
 
+        private static async Task<IReadOnlyList<string>> FetchColumnNamesAsync(SqlConnection conn, string table, CancellationToken cancellationToken)
+        {
+            var (schema, name) = SplitTable(table);
+            await using var cmd = new SqlCommand(
+                "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = @s AND TABLE_NAME = @t ORDER BY ORDINAL_POSITION",
+                conn);
+            cmd.Parameters.AddWithValue("@s", schema);
+            cmd.Parameters.AddWithValue("@t", name);
+            var names = new List<string>();
+            await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken)) names.Add(reader.GetString(0));
+            return names;
+        }
+
         public async Task<TableRows> FetchRowsAsync(InnerDatabaseTarget target, string database, string table, int limit, int offset, CancellationToken cancellationToken = default)
         {
             InnerDatabaseNameValidator.Require(database);
@@ -158,8 +172,17 @@ namespace KRINT.Infrastructure.Services
                 else if (raw is long l) total = l;
             }
 
+            // Render every column to text server-side with the same CAST(... AS NVARCHAR(MAX)) the
+            // row-identity WHERE clause uses, so the strings the grid loads round-trip exactly. Reading
+            // typed values and formatting them in .NET (bit -> "True", datetime -> .NET format) disagreed
+            // with SQL Server's CAST ("1", ISO dates), so edits/deletes matched zero rows.
+            var columnNames = await FetchColumnNamesAsync(conn, table, cancellationToken);
+            var selectList = columnNames.Count == 0
+                ? "*"
+                : string.Join(", ", columnNames.Select(c => $"CAST([{c}] AS NVARCHAR(MAX)) AS [{c}]"));
+
             // OFFSET/FETCH requires an ORDER BY; sort by the first column to get a stable page.
-            await using var cmd = new SqlCommand($"SELECT * FROM {qualified} ORDER BY (SELECT NULL) OFFSET {offset.ToString(CultureInfo.InvariantCulture)} ROWS FETCH NEXT {limit.ToString(CultureInfo.InvariantCulture)} ROWS ONLY", conn);
+            await using var cmd = new SqlCommand($"SELECT {selectList} FROM {qualified} ORDER BY (SELECT NULL) OFFSET {offset.ToString(CultureInfo.InvariantCulture)} ROWS FETCH NEXT {limit.ToString(CultureInfo.InvariantCulture)} ROWS ONLY", conn);
             await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
 
             var columns = new List<string>();

--- a/src/KRINT.Infrastructure/Services/MySqlInnerSchemaService.cs
+++ b/src/KRINT.Infrastructure/Services/MySqlInnerSchemaService.cs
@@ -45,7 +45,15 @@ namespace KRINT.Infrastructure.Services
 
             var columnInfos = await FetchColumnInfosAsync(conn, database, table, cancellationToken);
 
-            await using var cmd = new MySqlCommand($"SELECT * FROM `{table}` LIMIT {limit.ToString(CultureInfo.InvariantCulture)} OFFSET {offset.ToString(CultureInfo.InvariantCulture)}", conn);
+            // Render every column to text server-side with the same CAST(... AS CHAR) the row-identity
+            // WHERE clause uses, so the strings the grid loads round-trip exactly. Reading typed values
+            // and formatting them in .NET (tinyint(1) -> "True", DATETIME -> .NET format) disagreed with
+            // MySQL's CAST ("1", "2026-06-19 12:34:56"), so edits/deletes matched zero rows.
+            var selectList = columnInfos.Count == 0
+                ? "*"
+                : string.Join(", ", columnInfos.Select(c => $"CAST(`{c.Name}` AS CHAR) AS `{c.Name}`"));
+
+            await using var cmd = new MySqlCommand($"SELECT {selectList} FROM `{table}` LIMIT {limit.ToString(CultureInfo.InvariantCulture)} OFFSET {offset.ToString(CultureInfo.InvariantCulture)}", conn);
             await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
 
             var columns = new List<string>();

--- a/src/KRINT.Infrastructure/Services/PostgresInnerSchemaService.cs
+++ b/src/KRINT.Infrastructure/Services/PostgresInnerSchemaService.cs
@@ -45,17 +45,14 @@ namespace KRINT.Infrastructure.Services
 
             var columnInfos = await FetchColumnInfosAsync(conn, table, cancellationToken);
 
-            // Build an explicit SELECT list rather than SELECT *: extension types that Npgsql
-            // has no CLR mapping for (pgvector's `vector`, hstore without the plugin, etc.)
-            // throw InvalidCastException on GetValue. Casting those columns to text in SQL
-            // sidesteps the reader entirely - Postgres always knows how to render its own
-            // types as text, and the UI is a string grid anyway.
+            // Render every column to text server-side so the strings the grid loads are exactly what
+            // the row-identity WHERE clause compares against ("col"::text = @original). Reading typed
+            // values and formatting them in .NET (bool -> "True", timestamps -> .NET format, arrays ->
+            // "System.String[]") disagreed with Postgres's own ::text rendering ("true", ISO dates),
+            // so every later UPDATE/DELETE matched zero rows and failed with "Row not found".
             var selectList = columnInfos.Count == 0
                 ? "*"
-                : string.Join(", ", columnInfos.Select(c =>
-                    IsClientUnmappedType(c.Type)
-                        ? $"\"{c.Name}\"::text AS \"{c.Name}\""
-                        : $"\"{c.Name}\""));
+                : string.Join(", ", columnInfos.Select(c => $"\"{c.Name}\"::text AS \"{c.Name}\""));
 
             await using var cmd = new NpgsqlCommand($"SELECT {selectList} FROM {qualified} LIMIT {limit.ToString(CultureInfo.InvariantCulture)} OFFSET {offset.ToString(CultureInfo.InvariantCulture)}", conn);
             await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
@@ -276,17 +273,7 @@ namespace KRINT.Infrastructure.Services
             return $"\"{schema}\".\"{name}\"";
         }
 
-        // Postgres extension types Npgsql can't decode without a third-party plugin. We cast
-        // these to text in the SELECT so the reader gets a plain string back. udt_name comes
-        // from information_schema.columns and is lowercase.
-        private static bool IsClientUnmappedType(string udtName) => udtName switch
-        {
-            "vector" => true,
-            "halfvec" => true,
-            "sparsevec" => true,
-            _ => false,
-        };
-
+        // Every column comes back as text (cast in the SELECT), so the reader always yields strings.
         private static async Task<TableRows> ReadRowsAsync(NpgsqlDataReader reader, long? total, IReadOnlyList<ColumnInfo>? columnInfos, CancellationToken cancellationToken)
         {
             var columns = new List<string>();

--- a/src/KRINT.Infrastructure/Services/PostgresInnerSchemaService.cs
+++ b/src/KRINT.Infrastructure/Services/PostgresInnerSchemaService.cs
@@ -125,7 +125,16 @@ namespace KRINT.Infrastructure.Services
             await tx.CommitAsync(cancellationToken);
         }
 
-        private static async Task ApplyUpdateAsync(NpgsqlConnection conn, NpgsqlTransaction tx, string qualifiedTable, UpdateRowRequest request, CancellationToken cancellationToken)
+        // The actual UPDATE/DELETE statements that pin the single matched row. Postgres uses ctid
+        // (its physical row pointer); engines without ctid (CockroachDB) override these. Safe because
+        // the caller's match-count guard has already proven exactly one row matches the WHERE.
+        protected virtual string BuildUpdateCommandText(string qualifiedTable, string setClause, string whereClause)
+            => $"UPDATE {qualifiedTable} SET {setClause} WHERE ctid = (SELECT ctid FROM {qualifiedTable} WHERE {whereClause} LIMIT 2)";
+
+        protected virtual string BuildDeleteCommandText(string qualifiedTable, string whereClause)
+            => $"DELETE FROM {qualifiedTable} WHERE ctid = (SELECT ctid FROM {qualifiedTable} WHERE {whereClause} LIMIT 1)";
+
+        private async Task ApplyUpdateAsync(NpgsqlConnection conn, NpgsqlTransaction tx, string qualifiedTable, UpdateRowRequest request, CancellationToken cancellationToken)
         {
             var changedIndexes = new List<int>();
             for (var i = 0; i < request.Columns.Count; i++)
@@ -163,8 +172,7 @@ namespace KRINT.Infrastructure.Services
                 }
             }
 
-            cmd.CommandText = $"UPDATE {qualifiedTable} SET {string.Join(", ", setClauses)} " +
-                              $"WHERE ctid = (SELECT ctid FROM {qualifiedTable} WHERE {string.Join(" AND ", whereClauses)} LIMIT 2)";
+            cmd.CommandText = BuildUpdateCommandText(qualifiedTable, string.Join(", ", setClauses), string.Join(" AND ", whereClauses));
 
             // Two-step strategy: peek matches first to enforce "exactly one row".
             await using (var countCmd = new NpgsqlCommand($"SELECT COUNT(*) FROM (SELECT 1 FROM {qualifiedTable} WHERE {string.Join(" AND ", whereClauses)} LIMIT 2) s", conn, tx))
@@ -241,7 +249,7 @@ namespace KRINT.Infrastructure.Services
                 if (matches > 1) throw new InvalidOperationException("Ambiguous: more than one row matches. Refusing to delete.");
             }
 
-            cmd.CommandText = $"DELETE FROM {qualified} WHERE ctid = (SELECT ctid FROM {qualified} WHERE {string.Join(" AND ", whereClauses)} LIMIT 1)";
+            cmd.CommandText = BuildDeleteCommandText(qualified, string.Join(" AND ", whereClauses));
             var affected = await cmd.ExecuteNonQueryAsync(cancellationToken);
             if (affected != 1) throw new InvalidOperationException($"Expected to delete 1 row, got {affected}.");
             await tx.CommitAsync(cancellationToken);


### PR DESCRIPTION
Render row values to text server-side with the same cast the identity WHERE uses so edits/deletes match, and enable CockroachDB row edit/delete with a ctid-free WHERE. Verified live against all affected engines.

Closes #193