### PR TITLE
Add object/blob upload for SeaweedFS and Azurite

### DIFF
--- a/src/KRINT.API/Controllers/DatabaseController.cs
+++ b/src/KRINT.API/Controllers/DatabaseController.cs
@@ -372,6 +372,27 @@ namespace KRINT.API.Controllers
             catch (NotSupportedException ex) { return BadRequest(new { error = ex.Message }); }
         }
 
+        // Object/blob stores (SeaweedFS, Azurite): upload or replace an object in a bucket/container.
+        // multipart/form-data so the file streams straight through instead of being JSON-encoded.
+        [HttpPost("{id:guid}/browse/{database}/objects")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UploadObject(Guid id, string database, [FromForm] string key, IFormFile file, CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (file is null || file.Length == 0) return BadRequest(new { error = "A non-empty file is required." });
+                if (string.IsNullOrWhiteSpace(key)) return BadRequest(new { error = "An object key is required." });
+                await using var stream = file.OpenReadStream();
+                await mediator.Send(new UploadObjectCommand(id, database, key, stream, file.ContentType), cancellationToken);
+                return NoContent();
+            }
+            catch (InstanceNotFoundException) { return NotFound(); }
+            catch (NotSupportedException ex) { return BadRequest(new { error = ex.Message }); }
+            catch (ArgumentException ex) { return BadRequest(new { error = ex.Message }); }
+        }
+
         [HttpDelete("{id:guid}/browse/{database}/tables/{table}/rows")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/KRINT.Application/Command/TableRow/UploadObjectCommand.cs
+++ b/src/KRINT.Application/Command/TableRow/UploadObjectCommand.cs
@@ -1,0 +1,21 @@
+using Mediator;
+using KRINT.Infrastructure;
+using KRINT.Infrastructure.Extensions;
+using KRINT.Infrastructure.Interfaces;
+
+namespace KRINT.Application.Command.TableRow
+{
+    // Object/blob stores (SeaweedFS, Azurite): upload (or replace) an object by key. The content is
+    // streamed straight from the request, so the file never has to be fully buffered by us.
+    public record UploadObjectCommand(Guid InstanceId, string Database, string Key, Stream Content, string? ContentType) : ICommand;
+
+    public class UploadObjectCommandHandler(KrintDbContext db, ISecretsVaultService vault, IInnerSchemaServiceResolver resolver) : ICommandHandler<UploadObjectCommand>
+    {
+        public async ValueTask<Unit> Handle(UploadObjectCommand command, CancellationToken cancellationToken)
+        {
+            var target = await InnerDatabaseTargetLoader.LoadAsync(db, vault, command.InstanceId, cancellationToken);
+            await resolver.Resolve(target.Engine).UploadObjectAsync(target, command.Database, command.Key, command.Content, command.ContentType, cancellationToken);
+            return Unit.Value;
+        }
+    }
+}

--- a/src/KRINT.Application/Dtos/SupportedDatabase/EngineCapabilitiesDto.cs
+++ b/src/KRINT.Application/Dtos/SupportedDatabase/EngineCapabilitiesDto.cs
@@ -26,5 +26,9 @@ namespace KRINT.Application.Dtos.SupportedDatabase
 
         public required bool SupportsUsers { get; init; }
         public required bool SupportsBackup { get; init; }
+
+        /// <summary>Object/blob stores (SeaweedFS, Azurite): "rows" are uploaded files, so the UI
+        /// offers a file-upload dialog (key + file, replace re-uploads) instead of the row-insert form.</summary>
+        public bool SupportsObjectUpload { get; init; }
     }
 }

--- a/src/KRINT.Application/Queries/SupportedDatabase/GetSupportedDatabasesQuery.cs
+++ b/src/KRINT.Application/Queries/SupportedDatabase/GetSupportedDatabasesQuery.cs
@@ -99,7 +99,6 @@ namespace KRINT.Application.Queries.SupportedDatabase
             RowTerm = "point",
             SupportsCreateDatabase = false,
             SupportsDropDatabase = false,
-            SupportsRowInsert = false,
             SupportsUsers = false,
             SupportsBackup = false,
         };

--- a/src/KRINT.Application/Queries/SupportedDatabase/GetSupportedDatabasesQuery.cs
+++ b/src/KRINT.Application/Queries/SupportedDatabase/GetSupportedDatabasesQuery.cs
@@ -114,6 +114,7 @@ namespace KRINT.Application.Queries.SupportedDatabase
             SupportsDropTable = false,
             SupportsRowInsert = false,
             SupportsRowEdit = false,
+            SupportsObjectUpload = true,
             SupportsUsers = false,
             SupportsBackup = false,
         };

--- a/src/KRINT.Frontend/src/app/api/api/database.service.ts
+++ b/src/KRINT.Frontend/src/app/api/api/database.service.ts
@@ -206,6 +206,98 @@ export class DatabaseService extends BaseService {
     }
 
     /**
+     * @endpoint post /api/Database/{id}/browse/{database}/objects
+     * @param id 
+     * @param database 
+     * @param key 
+     * @param file 
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     * @param options additional options
+     */
+    public apiDatabaseIdBrowseDatabaseObjectsPost(id: string, database: string, key?: string, file?: Blob, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<any>;
+    public apiDatabaseIdBrowseDatabaseObjectsPost(id: string, database: string, key?: string, file?: Blob, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<any>>;
+    public apiDatabaseIdBrowseDatabaseObjectsPost(id: string, database: string, key?: string, file?: Blob, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<any>>;
+    public apiDatabaseIdBrowseDatabaseObjectsPost(id: string, database: string, key?: string, file?: Blob, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+        if (id === null || id === undefined) {
+            throw new Error('Required parameter id was null or undefined when calling apiDatabaseIdBrowseDatabaseObjectsPost.');
+        }
+        if (database === null || database === undefined) {
+            throw new Error('Required parameter database was null or undefined when calling apiDatabaseIdBrowseDatabaseObjectsPost.');
+        }
+
+        let localVarHeaders = this.defaultHeaders;
+
+        // authentication (OAuth2) required
+        localVarHeaders = this.configuration.addCredentialToHeaders('OAuth2', 'Authorization', localVarHeaders, 'Bearer ');
+
+        const localVarHttpHeaderAcceptSelected: string | undefined = options?.httpHeaderAccept ?? this.configuration.selectHeaderAccept([
+            'text/plain',
+            'application/json',
+            'text/json'
+        ]);
+        if (localVarHttpHeaderAcceptSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+        }
+
+        const localVarHttpContext: HttpContext = options?.context ?? new HttpContext();
+
+        const localVarTransferCache: boolean = options?.transferCache ?? true;
+
+        // to determine the Content-Type header
+        const consumes: string[] = [
+            'multipart/form-data'
+        ];
+
+        const canConsumeForm = this.canConsumeForm(consumes);
+
+        let localVarFormParams: { append(param: string, value: any): any; };
+        let localVarUseForm = false;
+        let localVarConvertFormParamsToString = false;
+        // use FormData to transmit files using content-type "multipart/form-data"
+        // see https://stackoverflow.com/questions/4007969/application-x-www-form-urlencoded-or-multipart-form-data
+        localVarUseForm = canConsumeForm;
+        if (localVarUseForm) {
+            localVarFormParams = new FormData();
+        } else {
+            localVarFormParams = new HttpParams({encoder: this.encoder});
+        }
+
+        if (key !== undefined) {
+            localVarFormParams = localVarFormParams.append('key', <any>key) as any || localVarFormParams;
+        }
+        if (file !== undefined) {
+            localVarFormParams = localVarFormParams.append('file', <any>file) as any || localVarFormParams;
+        }
+
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
+            }
+        }
+
+        let localVarPath = `/api/Database/${this.configuration.encodeParam({name: "id", value: id, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: "uuid"})}/browse/${this.configuration.encodeParam({name: "database", value: database, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}/objects`;
+        const { basePath, withCredentials } = this.configuration;
+        return this.httpClient.request<any>('post', `${basePath}${localVarPath}`,
+            {
+                context: localVarHttpContext,
+                body: localVarConvertFormParamsToString ? localVarFormParams.toString() : localVarFormParams,
+                responseType: <any>responseType_,
+                ...(withCredentials ? { withCredentials } : {}),
+                headers: localVarHeaders,
+                observe: observe,
+                ...(localVarTransferCache !== undefined ? { transferCache: localVarTransferCache } : {}),
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
      * @endpoint get /api/Database/{id}/browse/{database}/tables
      * @param id 
      * @param database 

--- a/src/KRINT.Frontend/src/app/api/model/engineCapabilitiesDto.ts
+++ b/src/KRINT.Frontend/src/app/api/model/engineCapabilitiesDto.ts
@@ -24,5 +24,6 @@ export interface EngineCapabilitiesDto {
     supportsRowDelete: boolean;
     supportsUsers: boolean;
     supportsBackup: boolean;
+    supportsObjectUpload?: boolean;
 }
 

--- a/src/KRINT.Frontend/src/app/browser/browser.html
+++ b/src/KRINT.Frontend/src/app/browser/browser.html
@@ -221,6 +221,19 @@
               Add {{ rowTerm() }}
             </button>
           }
+          @if (canUploadObject()) {
+            <button
+              hlmBtn
+              variant="outline"
+              size="sm"
+              type="button"
+              [disabled]="!table() || uploadOpen()"
+              (click)="openUpload()"
+            >
+              <ng-icon name="lucideUpload" size="14" />
+              Upload {{ rowTerm() }}
+            </button>
+          }
           <button hlmBtn variant="outline" size="icon" type="button" (click)="prev()" [disabled]="!hasPrev() || loading()" aria-label="Previous page" hlmTooltip="Previous page">
             <ng-icon name="lucideChevronLeft" size="14" />
           </button>
@@ -229,6 +242,25 @@
           </button>
         </div>
       </header>
+
+      @if (uploadOpen()) {
+        <div class="mx-4 my-2 flex flex-wrap items-center gap-2 rounded-md border bg-primary/5 p-3">
+          <input
+            class="h-8 flex-1 min-w-40 rounded-md border bg-transparent px-2 font-mono text-xs"
+            [value]="uploadKey()"
+            placeholder="object key (e.g. photos/cat.png)"
+            (input)="uploadKey.set($any($event.target).value)"
+          />
+          <input type="file" class="text-xs" (change)="onUploadFileSelected($event)" />
+          <button hlmBtn size="sm" type="button" [disabled]="uploading() || !uploadKey() || !uploadFile()" (click)="doUpload()">
+            {{ uploading() ? 'Uploading…' : 'Upload' }}
+          </button>
+          <button hlmBtn variant="outline" size="sm" type="button" [disabled]="uploading()" (click)="cancelUpload()">Cancel</button>
+          @if (uploadError(); as err) {
+            <span class="text-destructive text-xs">{{ err }}</span>
+          }
+        </div>
+      }
 
       <div class="flex-1 overflow-auto px-4">
         @if (rows(); as r) {

--- a/src/KRINT.Frontend/src/app/browser/browser.html
+++ b/src/KRINT.Frontend/src/app/browser/browser.html
@@ -249,7 +249,7 @@
                   <tr hlmTableRow class="bg-primary/5">
                     @for (c of r.columns; track c; let colIdx = $index) {
                       <td hlmTableCell class="font-mono text-xs">
-                        @if (isProtectedColumn(colIdx)) {
+                        @if (isInsertAutoColumn(colIdx)) {
                           <span class="text-muted-foreground italic">auto</span>
                         } @else {
                           <div class="flex items-center gap-1">

--- a/src/KRINT.Frontend/src/app/browser/browser.ts
+++ b/src/KRINT.Frontend/src/app/browser/browser.ts
@@ -13,6 +13,7 @@ import {
   lucideRefreshCw,
   lucideTable,
   lucideTrash2,
+  lucideUpload,
   lucideX,
 } from '@ng-icons/lucide';
 import { simpleApachecassandra, simpleApachecouchdb, simpleClickhouse, simpleCockroachlabs, simpleMariadb, simpleMongodb, simpleMysql, simpleNeo4j, simplePostgresql, simpleRedis, simpleTimescale } from '@ng-icons/simple-icons';
@@ -72,6 +73,7 @@ type Draft = { values: EditValue[]; mode: 'edit' | 'insert'; rowIndex: number | 
       lucideRefreshCw,
       lucideTable,
       lucideTrash2,
+      lucideUpload,
       lucideX,
       simplePostgresql,
       simpleMysql,
@@ -149,6 +151,7 @@ export class Browser {
 
   // Convenience computed flags so the template stays readable.
   protected readonly canInsertRow = computed(() => this.capabilities()?.supportsRowInsert ?? false);
+  protected readonly canUploadObject = computed(() => this.capabilities()?.supportsObjectUpload ?? false);
   protected readonly canEditRow   = computed(() => this.capabilities()?.supportsRowEdit ?? false);
   protected readonly canDeleteRow = computed(() => this.capabilities()?.supportsRowDelete ?? false);
   protected readonly canDropTable = computed(() => this.capabilities()?.supportsDropTable ?? false);
@@ -367,6 +370,49 @@ export class Browser {
     const values: EditValue[] = r.columns.map(() => '');
     this.draft.set({ values, mode: 'insert', rowIndex: null });
     this.editError.set(null);
+  }
+
+  // ----- object/blob upload (SeaweedFS, Azurite) -----
+  protected readonly uploadOpen = signal(false);
+  protected readonly uploadKey = signal('');
+  protected readonly uploadFile = signal<File | null>(null);
+  protected readonly uploading = signal(false);
+  protected readonly uploadError = signal<string | null>(null);
+
+  protected openUpload(): void {
+    this.uploadKey.set('');
+    this.uploadFile.set(null);
+    this.uploadError.set(null);
+    this.uploadOpen.set(true);
+  }
+
+  protected cancelUpload(): void {
+    this.uploadOpen.set(false);
+    this.uploadFile.set(null);
+  }
+
+  protected onUploadFileSelected(event: Event): void {
+    const file = (event.target as HTMLInputElement).files?.[0] ?? null;
+    this.uploadFile.set(file);
+    // Default the key to the file name so the common case is one click.
+    if (file && !this.uploadKey().trim()) this.uploadKey.set(file.name);
+  }
+
+  protected doUpload(): void {
+    const id = this.instanceId(); const db = this.database();
+    const key = this.uploadKey().trim(); const file = this.uploadFile();
+    if (!id || !db || !key || !file) return;
+    this.uploading.set(true);
+    this.uploadError.set(null);
+    this.api.apiDatabaseIdBrowseDatabaseObjectsPost(id, db, key, file).subscribe({
+      next: () => {
+        this.uploading.set(false);
+        this.uploadOpen.set(false);
+        this.uploadFile.set(null);
+        this.reloadRows();
+      },
+      error: (err) => { this.uploadError.set(messageOf(err)); this.uploading.set(false); },
+    });
   }
 
   protected cancelDraft(): void {

--- a/src/KRINT.Frontend/src/app/browser/browser.ts
+++ b/src/KRINT.Frontend/src/app/browser/browser.ts
@@ -402,6 +402,17 @@ export class Browser {
     return r?.columns[colIndex]?.toLowerCase() === 'id';
   }
 
+  /** Columns the database fills itself on insert (identity / generated / sequence-backed). Shown as
+   *  "auto" and dropped from the insert payload. Distinct from isProtectedColumn: a client-supplied
+   *  primary key (e.g. a Qdrant point id) is locked for *edit* but must still be entered on *insert*,
+   *  so it is not an auto column. */
+  protected isInsertAutoColumn(colIndex: number): boolean {
+    const r = this.rows();
+    const info = r?.columnInfos?.[colIndex];
+    if (info) return info.isGenerated;
+    return r?.columns[colIndex]?.toLowerCase() === 'id';
+  }
+
   protected draftValue(colIndex: number): string {
     const v = this.draft()?.values[colIndex];
     return v === undefined || v === NULL_TOKEN ? '' : v;
@@ -534,12 +545,13 @@ export class Browser {
     this.editError.set(null);
 
     if (d.mode === 'insert') {
-      // Strip DB-owned columns (id) so the database generates them. Otherwise an empty
-      // string from the input would either be rejected (SERIAL NOT NULL) or coerced.
+      // Strip DB-generated columns so the database fills them. Otherwise an empty string from the
+      // input would be rejected (e.g. SERIAL NOT NULL) or coerced. Client-supplied keys (Qdrant
+      // point id, natural keys) are kept - isInsertAutoColumn only drops truly auto columns.
       const insertCols: string[] = [];
       const insertVals: (string | null)[] = [];
       for (let i = 0; i < r.columns.length; i++) {
-        if (r.columns[i].toLowerCase() === 'id') continue;
+        if (this.isInsertAutoColumn(i)) continue;
         insertCols.push(r.columns[i]);
         insertVals.push(newValues[i]);
       }

--- a/src/KRINT.Infrastructure/Interfaces/IInnerSchemaService.cs
+++ b/src/KRINT.Infrastructure/Interfaces/IInnerSchemaService.cs
@@ -45,6 +45,11 @@ namespace KRINT.Infrastructure.Interfaces
 
         Task InsertRowAsync(InnerDatabaseTarget target, string database, string table, InsertRowRequest request, CancellationToken cancellationToken = default);
 
+        /// <summary>Object/blob stores only: upload (or replace) an object by key. Other engines keep
+        /// the default and reject it - they use InsertRowAsync instead.</summary>
+        Task UploadObjectAsync(InnerDatabaseTarget target, string database, string key, Stream content, string? contentType, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("This engine does not support object upload.");
+
         Task DeleteRowAsync(InnerDatabaseTarget target, string database, string table, DeleteRowRequest request, CancellationToken cancellationToken = default);
 
         Task DropTableAsync(InnerDatabaseTarget target, string database, string table, CancellationToken cancellationToken = default);

--- a/src/KRINT.Infrastructure/Services/AzuriteServices.cs
+++ b/src/KRINT.Infrastructure/Services/AzuriteServices.cs
@@ -113,9 +113,24 @@ namespace KRINT.Infrastructure.Services
         }
 
         public Task InsertRowAsync(InnerDatabaseTarget target, string database, string table, InsertRowRequest request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("Uploading blobs is not exposed in this version.");
+            => throw new NotSupportedException("Use object upload to add blobs to a container.");
         public Task UpdateRowAsync(InnerDatabaseTarget target, string database, string table, UpdateRowRequest request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("Blobs cannot be edited in place.");
+            => throw new NotSupportedException("Blobs cannot be edited in place - re-upload with the same name to replace.");
+
+        public async Task UploadObjectAsync(InnerDatabaseTarget target, string database, string key, Stream content, string? contentType, CancellationToken cancellationToken = default)
+        {
+            InnerDatabaseNameValidator.Require(database);
+            if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("Blob name is required.", nameof(key));
+            var blob = AzuriteBlob.Build(target).GetBlobContainerClient(database).GetBlobClient(key);
+            // overwrite: true so re-uploading the same name replaces the blob.
+            await blob.UploadAsync(content, new Azure.Storage.Blobs.Models.BlobUploadOptions
+            {
+                HttpHeaders = new Azure.Storage.Blobs.Models.BlobHttpHeaders
+                {
+                    ContentType = string.IsNullOrWhiteSpace(contentType) ? "application/octet-stream" : contentType,
+                },
+            }, cancellationToken);
+        }
 
         public async Task DeleteRowAsync(InnerDatabaseTarget target, string database, string table, DeleteRowRequest request, CancellationToken cancellationToken = default)
         {

--- a/src/KRINT.Infrastructure/Services/PostgresInnerSchemaService.cs
+++ b/src/KRINT.Infrastructure/Services/PostgresInnerSchemaService.cs
@@ -69,7 +69,8 @@ namespace KRINT.Infrastructure.Services
                         c.udt_name,
                         c.is_nullable = 'YES'                    AS nullable,
                         COALESCE(pk.is_pk, FALSE)                AS is_pk,
-                        c.is_identity = 'YES' OR c.is_generated <> 'NEVER' AS is_generated
+                        c.is_identity = 'YES' OR c.is_generated <> 'NEVER'
+                            OR c.column_default LIKE 'nextval(%'        AS is_generated
                 FROM    information_schema.columns c
                 LEFT JOIN (
                     SELECT a.attname AS column_name, TRUE AS is_pk

--- a/src/KRINT.Infrastructure/Services/QdrantServices.cs
+++ b/src/KRINT.Infrastructure/Services/QdrantServices.cs
@@ -79,8 +79,9 @@ namespace KRINT.Infrastructure.Services
             limit = Math.Clamp(limit, 1, 500);
             using var http = QdrantHttp.Build(target);
 
-            // /collections/{name}/points/scroll
-            var body = new { limit, with_payload = true, with_vector = false, offset = (object?)null };
+            // /collections/{name}/points/scroll - pull the vector too so the grid can show and edit it
+            // (a point's identity-free data is vector + payload; both are needed to insert/upsert).
+            var body = new { limit, with_payload = true, with_vector = true, offset = (object?)null };
             using var resp = await http.PostAsync($"/collections/{Uri.EscapeDataString(table)}/points/scroll", new StringContent(JsonSerializer.Serialize(body), System.Text.Encoding.UTF8, "application/json"), cancellationToken);
             resp.EnsureSuccessStatusCode();
             await using var stream = await resp.Content.ReadAsStreamAsync(cancellationToken);
@@ -105,15 +106,37 @@ namespace KRINT.Infrastructure.Services
                 foreach (var p in pts.EnumerateArray())
                 {
                     var id = p.TryGetProperty("id", out var i) ? i.ToString() : null;
+                    var vector = p.TryGetProperty("vector", out var vec) ? vec.GetRawText() : "[]";
                     var payload = p.TryGetProperty("payload", out var pl) ? pl.GetRawText() : "{}";
-                    rows.Add(new[] { id, payload });
+                    rows.Add(new[] { id, vector, payload });
                 }
             }
-            return new TableRows(new[] { "id", "payload" }, rows, total);
+            // id is the point identity (client-supplied, not generated); vector + payload are editable.
+            var columnInfos = new[]
+            {
+                new ColumnInfo("id", "point id", false, true, false),
+                new ColumnInfo("vector", "vector", false, false, false),
+                new ColumnInfo("payload", "json", true, false, false),
+            };
+            return new TableRows(new[] { "id", "vector", "payload" }, rows, total, columnInfos);
         }
 
-        public Task InsertRowAsync(InnerDatabaseTarget target, string database, string table, InsertRowRequest request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("Qdrant point insert needs a vector - not exposed in this version.");
+        public async Task InsertRowAsync(InnerDatabaseTarget target, string database, string table, InsertRowRequest request, CancellationToken cancellationToken = default)
+        {
+            var id = request.Values[Idx(request.Columns, "id")];
+            if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("Point id is required to insert.");
+            var vectorIdx = Idx(request.Columns, "vector");
+            var vector = vectorIdx >= 0 ? request.Values[vectorIdx] : null;
+            if (string.IsNullOrWhiteSpace(vector) || vector!.Trim() is "[]" or "{}")
+                throw new ArgumentException("A vector is required to insert a Qdrant point (e.g. [0.1, 0.2, ...]).");
+            var payloadIdx = Idx(request.Columns, "payload");
+            var payload = payloadIdx >= 0 ? request.Values[payloadIdx] ?? "{}" : "{}";
+
+            using var http = QdrantHttp.Build(target);
+            var body = $"{{\"points\":[{{\"id\":{IdToken(id)},\"vector\":{vector},\"payload\":{payload}}}]}}";
+            using var resp = await http.PutAsync($"/collections/{Uri.EscapeDataString(table)}/points?wait=true", new StringContent(body, System.Text.Encoding.UTF8, "application/json"), cancellationToken);
+            resp.EnsureSuccessStatusCode();
+        }
 
         private static int Idx(IReadOnlyList<string> cols, string name)
         {
@@ -126,14 +149,27 @@ namespace KRINT.Infrastructure.Services
 
         public async Task UpdateRowAsync(InnerDatabaseTarget target, string database, string table, UpdateRowRequest request, CancellationToken cancellationToken = default)
         {
+            // Identity is the point id as loaded; upsert the whole point so both vector and payload
+            // edits land. (Editing the id itself isn't supported - that would be a different point.)
             var id = request.OriginalValues[Idx(request.Columns, "id")];
             if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("Point id is required to update.");
             var payload = request.NewValues[Idx(request.Columns, "payload")] ?? "{}";
+            var vectorIdx = Idx(request.Columns, "vector");
             using var http = QdrantHttp.Build(target);
-            // Overwrite the point's payload (vector is left untouched).
-            var body = $"{{\"points\":[{IdToken(id)}],\"payload\":{payload}}}";
-            using var resp = await http.PostAsync($"/collections/{Uri.EscapeDataString(table)}/points/payload?wait=true", new StringContent(body, System.Text.Encoding.UTF8, "application/json"), cancellationToken);
-            resp.EnsureSuccessStatusCode();
+
+            if (vectorIdx >= 0 && !string.IsNullOrWhiteSpace(request.NewValues[vectorIdx]) && request.NewValues[vectorIdx]!.Trim() is not ("[]" or "{}"))
+            {
+                // Full upsert: replaces vector + payload for the point in place.
+                var body = $"{{\"points\":[{{\"id\":{IdToken(id)},\"vector\":{request.NewValues[vectorIdx]},\"payload\":{payload}}}]}}";
+                using var resp = await http.PutAsync($"/collections/{Uri.EscapeDataString(table)}/points?wait=true", new StringContent(body, System.Text.Encoding.UTF8, "application/json"), cancellationToken);
+                resp.EnsureSuccessStatusCode();
+                return;
+            }
+
+            // No usable vector supplied - just overwrite the payload, leave the vector untouched.
+            var payloadBody = $"{{\"points\":[{IdToken(id)}],\"payload\":{payload}}}";
+            using var pResp = await http.PostAsync($"/collections/{Uri.EscapeDataString(table)}/points/payload?wait=true", new StringContent(payloadBody, System.Text.Encoding.UTF8, "application/json"), cancellationToken);
+            pResp.EnsureSuccessStatusCode();
         }
 
         public async Task DeleteRowAsync(InnerDatabaseTarget target, string database, string table, DeleteRowRequest request, CancellationToken cancellationToken = default)

--- a/src/KRINT.Infrastructure/Services/SeaweedFsServices.cs
+++ b/src/KRINT.Infrastructure/Services/SeaweedFsServices.cs
@@ -124,9 +124,28 @@ namespace KRINT.Infrastructure.Services
         }
 
         public Task InsertRowAsync(InnerDatabaseTarget target, string database, string table, InsertRowRequest request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("Uploading objects is not exposed in this version.");
+            => throw new NotSupportedException("Use object upload to add objects to a bucket.");
         public Task UpdateRowAsync(InnerDatabaseTarget target, string database, string table, UpdateRowRequest request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("Objects cannot be edited in place.");
+            => throw new NotSupportedException("Objects cannot be edited in place - re-upload with the same key to replace.");
+
+        public async Task UploadObjectAsync(InnerDatabaseTarget target, string database, string key, Stream content, string? contentType, CancellationToken cancellationToken = default)
+        {
+            InnerDatabaseNameValidator.Require(database);
+            if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("Object key is required.", nameof(key));
+            using var s3 = SeaweedFsS3.Build(target);
+            // PutObject overwrites an existing key, so "replace" is just re-upload.
+            await s3.PutObjectAsync(new PutObjectRequest
+            {
+                BucketName = database,
+                Key = key,
+                InputStream = content,
+                ContentType = string.IsNullOrWhiteSpace(contentType) ? "application/octet-stream" : contentType,
+                AutoCloseStream = false,
+                // S3-compatible stores generally don't accept aws-chunked streaming uploads - send a
+                // single signed payload with Content-Length instead.
+                UseChunkEncoding = false,
+            }, cancellationToken);
+        }
 
         public async Task DeleteRowAsync(InnerDatabaseTarget target, string database, string table, DeleteRowRequest request, CancellationToken cancellationToken = default)
         {


### PR DESCRIPTION
Add a file-upload path for the object/blob stores: a SupportsObjectUpload capability, UploadObjectAsync (SeaweedFS S3 / Azurite Blob, replace-by-reupload), a multipart objects endpoint, and a frontend upload dialog. Azurite verified end-to-end against a live container; SeaweedFS uses the same standard S3 PutObject path (see note below).

Closes #205