### PR TITLE
Route provisioning and database operations to nodes over SignalR

### DIFF
--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -1,12 +1,21 @@
 # Nodes (experimental)
 
-> Phase 1 — connectivity foundation. A node connects, registers and answers pings, and shows up
-> on the **Nodes** page. Routing actual database provisioning to a node is not wired up yet.
+> A node is a stateless worker that runs database containers on a remote host. You can provision a
+> database onto a node and browse / query / manage it entirely through the control plane — **every
+> operation travels over the one SignalR connection**, and nodes expose no ports. Streaming features
+> (logs, interactive console, backups/restore, version upgrade) are not routed to nodes yet and are
+> blocked with a clear message for node-hosted instances.
 
 KRINT normally provisions database containers on its own Docker daemon. A **node** is the *same*
-KRINT image started in a stripped role that does nothing but execute Docker work on its own host. It
-dials **out** to the control plane over SignalR (so it works behind NAT/firewalls — only the control
-plane needs to be reachable) and authenticates with a pre-shared token.
+KRINT image started in a stripped role that does nothing but execute Docker (and database) work on
+its own host. It dials **out** to the control plane over SignalR (so it works behind NAT/firewalls —
+only the control plane needs to be reachable) and authenticates with a pre-shared token.
+
+The control plane keeps **all** state (the single KRINT database and the secrets vault); the node
+holds nothing. For a node-hosted instance, the control plane sends commands ("create this container",
+"list these tables", "run this query") and the node runs them locally — against the container on its
+own loopback — and returns the result. Nothing connects to a node directly, so the node's containers
+bind to localhost only and never publish a port.
 
 ## How it works
 
@@ -28,7 +37,12 @@ Set these on the node process (environment variables; `__` maps to nested config
 | `Krint__Role=node` | Boot in node role. |
 | `Node__ControlPlaneUrl` | Base URL of the control plane, e.g. `https://krint.example.com`. |
 | `Node__Token` | A token present in the control plane's `Node__Tokens` allow-list. |
+| `Node__Id` | A stable GUID identifying this node. Pin it so provisioned instances keep pointing at the node across restarts; if unset, one is generated per run (and logged). |
 | `Node__Name` | Display name for the node (defaults to the machine name). |
+
+Provision onto a node from the create wizard's **Target node** dropdown (it appears once a node is
+online), or pass `nodeId` in the provision request. The instance then shows a node badge on the
+instances list.
 
 On the **control plane**, list the accepted tokens:
 
@@ -49,6 +63,7 @@ services:
       Krint__Role: "node"
       Node__ControlPlaneUrl: "https://krint.example.com"
       Node__Token: "a-long-random-shared-secret"
+      Node__Id: "11111111-1111-1111-1111-111111111111"
       Node__Name: "node-eu-1"
     volumes:
       # The node drives this host's Docker daemon.

--- a/src/KRINT.API/Controllers/NodesController.cs
+++ b/src/KRINT.API/Controllers/NodesController.cs
@@ -1,27 +1,43 @@
 using System.Diagnostics;
 using KRINT.API.Hubs;
 using KRINT.API.Nodes;
+using KRINT.Infrastructure;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
 
 namespace KRINT.API.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
-    public class NodesController(INodeRegistry registry, IHubContext<NodeHub> hub) : ControllerBase
+    public class NodesController(KrintDbContext db, INodeRegistry registry, IHubContext<NodeHub> hub) : ControllerBase
     {
         [HttpGet]
         [ProducesResponseType(typeof(IReadOnlyList<NodeDto>), StatusCodes.Status200OK)]
-        public IActionResult List() => Ok(registry.Snapshot());
+        public async Task<IActionResult> List(CancellationToken cancellationToken)
+        {
+            var online = registry.OnlineLastSeen();
+            var nodes = await db.Nodes.OrderBy(n => n.Name).ToListAsync(cancellationToken);
+            var result = nodes.Select(n => new NodeDto(
+                n.Id,
+                n.Name,
+                n.MachineName,
+                n.Os,
+                n.DockerVersion,
+                Online: online.ContainsKey(n.Id),
+                FirstSeenAt: n.CreatedAt,
+                LastSeenAt: online.TryGetValue(n.Id, out var seen) ? seen.UtcDateTime : n.LastSeenAt));
+            return Ok(result);
+        }
 
         /// <summary>Round-trips a ping to the node to prove the channel is live. Returns the node's
-        /// reply and the measured round-trip time.</summary>
-        [HttpPost("{connectionId}/ping")]
+        /// reply and the measured round-trip time. 404 if the node is offline.</summary>
+        [HttpPost("{id:guid}/ping")]
         [ProducesResponseType(typeof(NodePingResultDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<IActionResult> Ping(string connectionId, CancellationToken cancellationToken)
+        public async Task<IActionResult> Ping(Guid id, CancellationToken cancellationToken)
         {
-            if (!registry.Contains(connectionId))
+            if (!registry.TryGetConnectionId(id, out var connectionId))
                 return NotFound();
 
             var stopwatch = Stopwatch.StartNew();
@@ -33,7 +49,7 @@ namespace KRINT.API.Controllers
             }
             catch (IOException)
             {
-                // Connection dropped between the Contains check and the invoke.
+                // Connection dropped between the lookup and the invoke.
                 return NotFound();
             }
         }

--- a/src/KRINT.API/Hubs/NodeHub.cs
+++ b/src/KRINT.API/Hubs/NodeHub.cs
@@ -1,16 +1,23 @@
 using KRINT.API.Nodes;
+using KRINT.Domain;
+using KRINT.Infrastructure;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
 
 namespace KRINT.API.Hubs
 {
     /// <summary>Control-plane endpoint that nodes dial into. Nodes authenticate with a pre-shared
     /// token (not OIDC), so the hub is AllowAnonymous and validates the token itself in
     /// OnConnectedAsync against the <c>Node:Tokens</c> allow-list. The control plane invokes
-    /// <c>Ping</c>/etc. back on the node connection; the node invokes <c>Register</c>/<c>Heartbeat</c>
+    /// Docker/DB operations back on the node connection; the node invokes <c>Register</c>/<c>Heartbeat</c>
     /// here.</summary>
     [AllowAnonymous]
-    public class NodeHub(INodeRegistry registry, IConfiguration configuration, ILogger<NodeHub> logger) : Hub
+    public class NodeHub(
+        INodeRegistry registry,
+        IConfiguration configuration,
+        IServiceScopeFactory scopeFactory,
+        ILogger<NodeHub> logger) : Hub
     {
         public override Task OnConnectedAsync()
         {
@@ -28,12 +35,44 @@ namespace KRINT.API.Hubs
         }
 
         /// <summary>Called by the node right after connecting (and after every reconnect) to report
-        /// who it is.</summary>
-        public Task Register(NodeRegistrationDto registration)
+        /// who it is. Persists/refreshes the Node row and records the live connection.</summary>
+        public async Task Register(NodeRegistrationDto registration)
         {
-            registry.Register(Context.ConnectionId, registration);
-            logger.LogInformation("Node {Name} ({Machine}) registered on {ConnectionId}.", registration.Name, registration.MachineName, Context.ConnectionId);
-            return Task.CompletedTask;
+            if (!Guid.TryParse(registration.Id, out var nodeId))
+            {
+                logger.LogWarning("Node on {ConnectionId} sent an invalid Id '{Id}'; aborting.", Context.ConnectionId, registration.Id);
+                Context.Abort();
+                return;
+            }
+
+            registry.Register(nodeId, Context.ConnectionId);
+
+            await using var scope = scopeFactory.CreateAsyncScope();
+            var db = scope.ServiceProvider.GetRequiredService<KrintDbContext>();
+            var node = await db.Nodes.FirstOrDefaultAsync(n => n.Id == nodeId);
+            if (node is null)
+            {
+                db.Nodes.Add(new Node
+                {
+                    Id = nodeId,
+                    Name = registration.Name,
+                    MachineName = registration.MachineName,
+                    Os = registration.Os,
+                    DockerVersion = registration.DockerVersion,
+                    LastSeenAt = DateTime.UtcNow,
+                });
+            }
+            else
+            {
+                node.Name = registration.Name;
+                node.MachineName = registration.MachineName;
+                node.Os = registration.Os;
+                node.DockerVersion = registration.DockerVersion;
+                node.LastSeenAt = DateTime.UtcNow;
+            }
+            await db.SaveChangesAsync();
+
+            logger.LogInformation("Node {Name} ({NodeId}) registered on {ConnectionId}.", registration.Name, nodeId, Context.ConnectionId);
         }
 
         /// <summary>Periodic liveness ping from the node.</summary>

--- a/src/KRINT.API/Nodes/DockerServiceResolver.cs
+++ b/src/KRINT.API/Nodes/DockerServiceResolver.cs
@@ -1,0 +1,15 @@
+using KRINT.API.Hubs;
+using KRINT.Infrastructure.Interfaces;
+using Microsoft.AspNetCore.SignalR;
+
+namespace KRINT.API.Nodes
+{
+    /// <summary>Returns the local <see cref="IDockerService"/> for null (control-plane) instances, or
+    /// a <see cref="RemoteDockerService"/> bound to the target node otherwise.</summary>
+    public class DockerServiceResolver(IDockerService local, IHubContext<NodeHub> hub, INodeRegistry registry)
+        : IDockerServiceResolver
+    {
+        public IDockerService Resolve(Guid? nodeId)
+            => nodeId is null ? local : new RemoteDockerService(nodeId.Value, hub, registry);
+    }
+}

--- a/src/KRINT.API/Nodes/INodeRegistry.cs
+++ b/src/KRINT.API/Nodes/INodeRegistry.cs
@@ -1,24 +1,24 @@
 namespace KRINT.API.Nodes
 {
-    /// <summary>Tracks the nodes currently connected to this control plane over <c>/hubs/node</c>.
-    /// Live in-memory state keyed by SignalR connection id - analogous to ContainerExecRegistry,
-    /// and like it, read directly by the controller rather than through MediatR. Phase 1 keeps no
-    /// persisted node identity, so a node disappears from here the moment its connection drops.</summary>
+    /// <summary>Tracks which nodes are currently connected over <c>/hubs/node</c>, keyed by the
+    /// node's stable id (not the ephemeral SignalR connection id). Persistent node details live in
+    /// the database (the <c>Nodes</c> table); this only holds live-connection state so the control
+    /// plane can route an RPC to the right open socket and tell online from offline.</summary>
     public interface INodeRegistry
     {
         /// <summary>Record (or refresh) a node that just registered on the given connection.</summary>
-        void Register(string connectionId, NodeRegistrationDto registration);
+        void Register(Guid nodeId, string connectionId);
 
-        /// <summary>Bump a node's last-seen timestamp (heartbeat).</summary>
+        /// <summary>Bump a node's last-seen timestamp (heartbeat), found by connection id.</summary>
         void Touch(string connectionId);
 
-        /// <summary>Drop a node whose connection closed.</summary>
+        /// <summary>Drop a node whose connection closed, found by connection id.</summary>
         void Remove(string connectionId);
 
-        /// <summary>Current view of all connected nodes.</summary>
-        IReadOnlyList<NodeDto> Snapshot();
+        /// <summary>Resolve a node's current live connection id, or false if it is offline.</summary>
+        bool TryGetConnectionId(Guid nodeId, out string connectionId);
 
-        /// <summary>True if the connection id belongs to a registered node.</summary>
-        bool Contains(string connectionId);
+        /// <summary>Map of currently-online node id -> last-seen timestamp.</summary>
+        IReadOnlyDictionary<Guid, DateTimeOffset> OnlineLastSeen();
     }
 }

--- a/src/KRINT.API/Nodes/NodeAgentHostedService.cs
+++ b/src/KRINT.API/Nodes/NodeAgentHostedService.cs
@@ -1,4 +1,6 @@
 using System.Runtime.InteropServices;
+using Docker.DotNet.Models;
+using KRINT.Infrastructure.Extensions;
 using KRINT.Infrastructure.Interfaces;
 using Microsoft.AspNetCore.SignalR.Client;
 
@@ -15,6 +17,7 @@ namespace KRINT.API.Nodes
         ILogger<NodeAgentHostedService> logger) : IHostedService, IAsyncDisposable
     {
         private HubConnection? _connection;
+        private string _nodeId = "";
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
@@ -26,6 +29,15 @@ namespace KRINT.API.Nodes
                 logger.LogError("Node role is active but Node:ControlPlaneUrl and/or Node:Token are not set. The agent will not connect.");
                 return Task.CompletedTask;
             }
+
+            // A stable id identifies this node across reconnects so provisioned instances keep pointing
+            // at it. Pin it via Node:Id; if unset we generate one but it won't survive a restart.
+            if (!Guid.TryParse(configuration["Node:Id"], out var nodeId))
+            {
+                nodeId = Guid.NewGuid();
+                logger.LogWarning("Node:Id is not set; generated {NodeId} for this run. Set Node:Id to keep a stable identity across restarts.", nodeId);
+            }
+            _nodeId = nodeId.ToString();
 
             var name = configuration["Node:Name"];
             if (string.IsNullOrWhiteSpace(name)) name = Environment.MachineName;
@@ -39,6 +51,8 @@ namespace KRINT.API.Nodes
 
             // Server -> node calls. Ping is the phase-1 channel proof.
             _connection.On("Ping", () => "pong");
+            RegisterDockerHandlers(_connection);
+            RegisterInnerDbHandlers(_connection);
 
             // Re-register after every (re)connect, since the registry is keyed by connection id and a
             // reconnect yields a fresh one.
@@ -87,6 +101,7 @@ namespace KRINT.API.Nodes
             }
 
             var registration = new NodeRegistrationDto(
+                Id: _nodeId,
                 Name: name,
                 MachineName: Environment.MachineName,
                 Os: RuntimeInformation.OSDescription,
@@ -101,6 +116,93 @@ namespace KRINT.API.Nodes
             {
                 logger.LogWarning("Node agent failed to register: {Message}", ex.Message);
             }
+        }
+
+        // The control plane invokes these on the node's connection (RemoteDockerService); each runs
+        // against the node's local Docker daemon and returns the result. Void Docker ops return a
+        // bool because SignalR client-result invocations must return a value.
+        private void RegisterDockerHandlers(HubConnection c)
+        {
+            c.On("GetVersion", () => WithDocker(d => d.GetVersionAsync()));
+            c.On<bool, IList<ContainerListResponse>>("ListContainers", all => WithDocker(d => d.ListContainersAsync(all)));
+            c.On<string, ContainerInspectResponse>("InspectContainer", id => WithDocker(d => d.InspectContainerAsync(id)));
+            c.On<string, string, bool>("PullImage", (image, tag) => WithDocker(async d => { await d.PullImageAsync(image, tag); return true; }));
+            c.On<CreateContainerSpec, CreateContainerResponse>("CreateContainer", spec => WithDocker(d => d.CreateContainerAsync(ToParameters(spec))));
+            c.On<string, bool>("StartContainer", id => WithDocker(d => d.StartContainerAsync(id)));
+            c.On<string, bool>("StopContainer", id => WithDocker(async d => { await d.StopContainerAsync(id); return true; }));
+            c.On<string, bool, bool>("RemoveContainer", (id, force) => WithDocker(async d => { await d.RemoveContainerAsync(id, force); return true; }));
+            c.On<string, bool, bool>("RemoveVolume", (name, force) => WithDocker(async d => { await d.RemoveVolumeAsync(name, force); return true; }));
+            c.On<string, IList<string>, byte[]>("ExecCapture", (id, cmd) => WithDocker(d => d.ExecCaptureAsync(id, cmd)));
+        }
+
+        private async Task<T> WithDocker<T>(Func<IDockerService, Task<T>> work)
+        {
+            using var scope = services.CreateScope();
+            return await work(scope.ServiceProvider.GetRequiredService<IDockerService>());
+        }
+
+        // Inner-DB operations dispatched from the control plane. Each runs the node's local engine
+        // service (the target arrives with no NodeId, so the routing resolver runs it in-process)
+        // against the container on this node's loopback, and returns the same DTO the UI consumes.
+        private void RegisterInnerDbHandlers(HubConnection c)
+        {
+            c.On<InnerDatabaseTarget, IReadOnlyList<string>>("Db.List", t => Inner(s => s.GetRequiredService<IInnerDatabaseServiceResolver>().Resolve(t.Engine).ListAsync(t)));
+            c.On<InnerDatabaseTarget, string, bool>("Db.Create", (t, n) => Inner(async s => { await s.GetRequiredService<IInnerDatabaseServiceResolver>().Resolve(t.Engine).CreateAsync(t, n); return true; }));
+            c.On<InnerDatabaseTarget, string, bool>("Db.Drop", (t, n) => Inner(async s => { await s.GetRequiredService<IInnerDatabaseServiceResolver>().Resolve(t.Engine).DropAsync(t, n); return true; }));
+
+            c.On<InnerDatabaseTarget, IReadOnlyList<string>>("User.List", t => Inner(s => s.GetRequiredService<IInnerUserServiceResolver>().Resolve(t.Engine).ListAsync(t)));
+            c.On<InnerDatabaseTarget, string, string, bool>("User.Create", (t, n, p) => Inner(async s => { await s.GetRequiredService<IInnerUserServiceResolver>().Resolve(t.Engine).CreateAsync(t, n, p); return true; }));
+            c.On<InnerDatabaseTarget, string, bool>("User.Delete", (t, n) => Inner(async s => { await s.GetRequiredService<IInnerUserServiceResolver>().Resolve(t.Engine).DeleteAsync(t, n); return true; }));
+            c.On<InnerDatabaseTarget, string, string, bool>("User.ResetPassword", (t, n, p) => Inner(async s => { await s.GetRequiredService<IInnerUserServiceResolver>().Resolve(t.Engine).ResetPasswordAsync(t, n, p); return true; }));
+            c.On<InnerDatabaseTarget, string, string, bool>("User.GrantAccess", (t, u, d) => Inner(async s => { await s.GetRequiredService<IInnerUserServiceResolver>().Resolve(t.Engine).GrantAccessAsync(t, u, d); return true; }));
+
+            c.On<InnerDatabaseTarget, string, string, int, QueryResult>("Query.Run", (t, db, sql, lim) => Inner(s =>
+            {
+                var svc = s.GetRequiredService<IInnerQueryServiceResolver>().TryResolve(t.Engine)
+                          ?? throw new NotSupportedException($"Query console not available for engine '{t.Engine}'.");
+                return svc.RunAsync(t, db, sql, lim);
+            }));
+
+            c.On<InnerDatabaseTarget, string, IReadOnlyList<TableSummary>>("Schema.ListTables", (t, db) => Inner(s => s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(t.Engine).ListTablesAsync(t, db)));
+            c.On<InnerDatabaseTarget, string, string, int, int, TableRows>("Schema.FetchRows", (t, db, table, lim, off) => Inner(s => s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(t.Engine).FetchRowsAsync(t, db, table, lim, off)));
+            c.On<InnerDatabaseTarget, string, string, UpdateRowRequest, bool>("Schema.UpdateRow", (t, db, table, r) => Inner(async s => { await s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(t.Engine).UpdateRowAsync(t, db, table, r); return true; }));
+            c.On<InnerDatabaseTarget, string, string, BulkUpdateRowsRequest, bool>("Schema.BulkUpdateRows", (t, db, table, r) => Inner(async s => { await s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(t.Engine).BulkUpdateRowsAsync(t, db, table, r); return true; }));
+            c.On<InnerDatabaseTarget, string, string, InsertRowRequest, bool>("Schema.InsertRow", (t, db, table, r) => Inner(async s => { await s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(t.Engine).InsertRowAsync(t, db, table, r); return true; }));
+            c.On<InnerDatabaseTarget, string, string, DeleteRowRequest, bool>("Schema.DeleteRow", (t, db, table, r) => Inner(async s => { await s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(t.Engine).DeleteRowAsync(t, db, table, r); return true; }));
+            c.On<InnerDatabaseTarget, string, string, bool>("Schema.DropTable", (t, db, table) => Inner(async s => { await s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(t.Engine).DropTableAsync(t, db, table); return true; }));
+        }
+
+        private async Task<T> Inner<T>(Func<IServiceProvider, Task<T>> work)
+        {
+            using var scope = services.CreateScope();
+            return await work(scope.ServiceProvider);
+        }
+
+        private static CreateContainerParameters ToParameters(CreateContainerSpec spec)
+        {
+            var portBindings = spec.PortBindings
+                .GroupBy(b => b.ContainerPort)
+                .ToDictionary(
+                    g => g.Key,
+                    g => (IList<PortBinding>)g.Select(b => new PortBinding { HostPort = b.HostPort, HostIP = b.HostIp }).ToList());
+
+            Enum.TryParse<RestartPolicyKind>(spec.RestartPolicy, out var restartKind);
+
+            return new CreateContainerParameters
+            {
+                Image = spec.Image,
+                Name = spec.Name,
+                Env = spec.Env,
+                Cmd = spec.Cmd,
+                ExposedPorts = spec.ExposedPorts.ToDictionary(p => p, _ => default(EmptyStruct)),
+                HostConfig = new HostConfig
+                {
+                    PortBindings = portBindings,
+                    Binds = spec.Binds,
+                    RestartPolicy = new RestartPolicy { Name = restartKind },
+                },
+                Labels = spec.Labels,
+            };
         }
 
         public async Task StopAsync(CancellationToken cancellationToken)

--- a/src/KRINT.API/Nodes/NodeDtos.cs
+++ b/src/KRINT.API/Nodes/NodeDtos.cs
@@ -1,19 +1,20 @@
 namespace KRINT.API.Nodes
 {
-    /// <summary>What a node reports about itself when it dials in and registers. Phase 1 is purely
-    /// informational - routing provisioning to a node comes later.</summary>
-    public record NodeRegistrationDto(string Name, string MachineName, string Os, string DockerVersion);
+    /// <summary>What a node reports about itself when it dials in and registers. Id is the node's
+    /// stable Node:Id (a GUID, as string over the wire) so the control plane can persist it and let
+    /// instances reference the node across reconnects.</summary>
+    public record NodeRegistrationDto(string Id, string Name, string MachineName, string Os, string DockerVersion);
 
-    /// <summary>A node as the control-plane UI sees it. Id is the live SignalR connection id (phase 1
-    /// has no persisted node identity), so it changes across reconnects.</summary>
+    /// <summary>A node as the control-plane UI sees it. Id is the stable node id; Online is derived
+    /// from the live SignalR registry, the rest from the persisted Node row.</summary>
     public record NodeDto(
-        string ConnectionId,
+        Guid Id,
         string Name,
         string MachineName,
         string Os,
         string DockerVersion,
         bool Online,
-        DateTimeOffset ConnectedAt,
+        DateTimeOffset FirstSeenAt,
         DateTimeOffset LastSeenAt);
 
     /// <summary>Result of a control-plane -> node round-trip ping.</summary>

--- a/src/KRINT.API/Nodes/NodeOfflineException.cs
+++ b/src/KRINT.API/Nodes/NodeOfflineException.cs
@@ -1,0 +1,10 @@
+namespace KRINT.API.Nodes
+{
+    /// <summary>Thrown when an operation needs a node that is not currently connected. Controllers
+    /// surface it as a clean 409/400 rather than an opaque 500.</summary>
+    public class NodeOfflineException(Guid nodeId)
+        : Exception($"Node {nodeId} is not connected. Bring the node online and try again.")
+    {
+        public Guid NodeId { get; } = nodeId;
+    }
+}

--- a/src/KRINT.API/Nodes/NodeRegistry.cs
+++ b/src/KRINT.API/Nodes/NodeRegistry.cs
@@ -4,43 +4,50 @@ namespace KRINT.API.Nodes
 {
     public class NodeRegistry : INodeRegistry
     {
-        private sealed record Entry(NodeRegistrationDto Registration, DateTimeOffset ConnectedAt, DateTimeOffset LastSeenAt);
+        private sealed record Entry(Guid NodeId, string ConnectionId, DateTimeOffset LastSeenAt);
 
-        private readonly ConcurrentDictionary<string, Entry> _nodes = new();
+        // Keyed both ways: by node id (to route an RPC) and by connection id (to clean up on disconnect).
+        private readonly ConcurrentDictionary<Guid, Entry> _byNode = new();
+        private readonly ConcurrentDictionary<string, Guid> _byConnection = new();
 
-        public void Register(string connectionId, NodeRegistrationDto registration)
+        public void Register(Guid nodeId, string connectionId)
         {
-            var now = DateTimeOffset.UtcNow;
-            _nodes.AddOrUpdate(
-                connectionId,
-                _ => new Entry(registration, now, now),
-                // Re-registration on the same connection (e.g. after a reconnect handshake) keeps the
-                // original connect time but refreshes the reported details and last-seen.
-                (_, existing) => existing with { Registration = registration, LastSeenAt = now });
+            // A node id can only have one live connection; if it reconnected, drop the stale mapping.
+            if (_byNode.TryGetValue(nodeId, out var existing) && existing.ConnectionId != connectionId)
+                _byConnection.TryRemove(existing.ConnectionId, out _);
+
+            var entry = new Entry(nodeId, connectionId, DateTimeOffset.UtcNow);
+            _byNode[nodeId] = entry;
+            _byConnection[connectionId] = nodeId;
         }
 
         public void Touch(string connectionId)
         {
-            if (_nodes.TryGetValue(connectionId, out var existing))
-                _nodes.TryUpdate(connectionId, existing with { LastSeenAt = DateTimeOffset.UtcNow }, existing);
+            if (_byConnection.TryGetValue(connectionId, out var nodeId) && _byNode.TryGetValue(nodeId, out var existing))
+                _byNode[nodeId] = existing with { LastSeenAt = DateTimeOffset.UtcNow };
         }
 
-        public void Remove(string connectionId) => _nodes.TryRemove(connectionId, out _);
+        public void Remove(string connectionId)
+        {
+            if (!_byConnection.TryRemove(connectionId, out var nodeId)) return;
+            // Only remove the node entry if it still points at this connection (guards against a
+            // race where the node reconnected on a new connection before the old disconnect fired).
+            if (_byNode.TryGetValue(nodeId, out var existing) && existing.ConnectionId == connectionId)
+                _byNode.TryRemove(nodeId, out _);
+        }
 
-        public bool Contains(string connectionId) => _nodes.ContainsKey(connectionId);
+        public bool TryGetConnectionId(Guid nodeId, out string connectionId)
+        {
+            if (_byNode.TryGetValue(nodeId, out var entry))
+            {
+                connectionId = entry.ConnectionId;
+                return true;
+            }
+            connectionId = string.Empty;
+            return false;
+        }
 
-        public IReadOnlyList<NodeDto> Snapshot() =>
-            _nodes
-                .Select(kv => new NodeDto(
-                    kv.Key,
-                    kv.Value.Registration.Name,
-                    kv.Value.Registration.MachineName,
-                    kv.Value.Registration.Os,
-                    kv.Value.Registration.DockerVersion,
-                    Online: true,
-                    kv.Value.ConnectedAt,
-                    kv.Value.LastSeenAt))
-                .OrderBy(n => n.Name, StringComparer.OrdinalIgnoreCase)
-                .ToList();
+        public IReadOnlyDictionary<Guid, DateTimeOffset> OnlineLastSeen() =>
+            _byNode.ToDictionary(kv => kv.Key, kv => kv.Value.LastSeenAt);
     }
 }

--- a/src/KRINT.API/Nodes/NodeRpc.cs
+++ b/src/KRINT.API/Nodes/NodeRpc.cs
@@ -1,0 +1,26 @@
+using KRINT.API.Hubs;
+using KRINT.Infrastructure.Interfaces;
+using Microsoft.AspNetCore.SignalR;
+
+namespace KRINT.API.Nodes
+{
+    /// <summary>Control-plane implementation of <see cref="INodeRpc"/>: routes a call to the target
+    /// node's live connection and awaits its result.</summary>
+    public class NodeRpc(IHubContext<NodeHub> hub, INodeRegistry registry) : INodeRpc
+    {
+        public Task<T> InvokeAsync<T>(Guid nodeId, string method, object?[] args, CancellationToken cancellationToken)
+        {
+            if (!registry.TryGetConnectionId(nodeId, out var connectionId))
+                throw new NodeOfflineException(nodeId);
+            return hub.Clients.Client(connectionId).InvokeCoreAsync<T>(method, args, cancellationToken);
+        }
+    }
+
+    /// <summary>Registered in the node role, where dispatching to a node makes no sense. It never runs
+    /// in practice (node-side targets carry no NodeId) but keeps the inner-service resolvers satisfiable.</summary>
+    public class OfflineNodeRpc : INodeRpc
+    {
+        public Task<T> InvokeAsync<T>(Guid nodeId, string method, object?[] args, CancellationToken cancellationToken)
+            => throw new NotSupportedException("Node RPC is only available on the control plane.");
+    }
+}

--- a/src/KRINT.API/Nodes/NodeRpcContracts.cs
+++ b/src/KRINT.API/Nodes/NodeRpcContracts.cs
@@ -1,0 +1,21 @@
+namespace KRINT.API.Nodes
+{
+    // KRINT-owned wire contracts for node RPC. Deliberately NOT the Docker.DotNet model types:
+    // those carry Newtonsoft.Json attributes that SignalR's System.Text.Json ignores, so a raw
+    // CreateContainerParameters would lose its PortBindings/ExposedPorts in transit. These plain
+    // records round-trip cleanly; the node rebuilds the Docker parameters from them locally.
+
+    public record PortBindingSpec(string ContainerPort, string HostPort, string HostIp);
+
+    /// <summary>Everything KRINT sets when creating a container, in a transport-safe shape.</summary>
+    public record CreateContainerSpec(
+        string Image,
+        string Name,
+        List<string> Env,
+        List<string>? Cmd,
+        List<string> ExposedPorts,
+        List<PortBindingSpec> PortBindings,
+        List<string> Binds,
+        Dictionary<string, string> Labels,
+        string RestartPolicy);
+}

--- a/src/KRINT.API/Nodes/RemoteDockerService.cs
+++ b/src/KRINT.API/Nodes/RemoteDockerService.cs
@@ -1,0 +1,83 @@
+using Docker.DotNet.Models;
+using KRINT.API.Hubs;
+using KRINT.Infrastructure.Interfaces;
+using Microsoft.AspNetCore.SignalR;
+
+namespace KRINT.API.Nodes
+{
+    /// <summary>An <see cref="IDockerService"/> whose calls run on a remote node. Each method invokes
+    /// the matching handler on the node's live SignalR connection; the node executes it against its
+    /// own Docker daemon and returns the result. Streaming operations (stats, exec-with-stdin) are
+    /// not proxied yet.</summary>
+    public class RemoteDockerService(Guid nodeId, IHubContext<NodeHub> hub, INodeRegistry registry) : IDockerService
+    {
+        private ISingleClientProxy Node()
+        {
+            if (!registry.TryGetConnectionId(nodeId, out var connectionId))
+                throw new NodeOfflineException(nodeId);
+            return hub.Clients.Client(connectionId);
+        }
+
+        public async Task<bool> PingAsync(CancellationToken cancellationToken = default)
+        {
+            try { await Node().InvokeAsync<string>("Ping", cancellationToken); return true; }
+            catch { return false; }
+        }
+
+        public Task<string> GetVersionAsync(CancellationToken cancellationToken = default)
+            => Node().InvokeAsync<string>("GetVersion", cancellationToken);
+
+        public Task<IList<ContainerListResponse>> ListContainersAsync(bool all = true, CancellationToken cancellationToken = default)
+            => Node().InvokeAsync<IList<ContainerListResponse>>("ListContainers", all, cancellationToken);
+
+        public Task<ContainerInspectResponse> InspectContainerAsync(string id, CancellationToken cancellationToken = default)
+            => Node().InvokeAsync<ContainerInspectResponse>("InspectContainer", id, cancellationToken);
+
+        // Per-container stats aren't proxied; node-hosted instances just report no live CPU/mem.
+        public Task<ContainerStatsResponse?> GetContainerStatsOnceAsync(string id, CancellationToken cancellationToken = default)
+            => Task.FromResult<ContainerStatsResponse?>(null);
+
+        public Task PullImageAsync(string image, string tag = "latest", CancellationToken cancellationToken = default)
+            => Node().InvokeAsync<bool>("PullImage", image, tag, cancellationToken);
+
+        public Task<CreateContainerResponse> CreateContainerAsync(CreateContainerParameters parameters, CancellationToken cancellationToken = default)
+            => Node().InvokeAsync<CreateContainerResponse>("CreateContainer", ToSpec(parameters), cancellationToken);
+
+        public Task<bool> StartContainerAsync(string id, CancellationToken cancellationToken = default)
+            => Node().InvokeAsync<bool>("StartContainer", id, cancellationToken);
+
+        public Task StopContainerAsync(string id, CancellationToken cancellationToken = default)
+            => Node().InvokeAsync<bool>("StopContainer", id, cancellationToken);
+
+        public Task RemoveContainerAsync(string id, bool force = false, CancellationToken cancellationToken = default)
+            => Node().InvokeAsync<bool>("RemoveContainer", id, force, cancellationToken);
+
+        public Task RemoveVolumeAsync(string name, bool force = false, CancellationToken cancellationToken = default)
+            => Node().InvokeAsync<bool>("RemoveVolume", name, force, cancellationToken);
+
+        public Task<byte[]> ExecCaptureAsync(string containerId, IList<string> command, CancellationToken cancellationToken = default)
+            => Node().InvokeAsync<byte[]>("ExecCapture", containerId, command, cancellationToken);
+
+        public Task ExecWithStdinAsync(string containerId, IList<string> command, Stream stdin, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Streaming exec (backup/restore) is not supported on remote nodes yet.");
+
+        // Flatten the Docker.DotNet parameters KRINT sets into a transport-safe spec.
+        private static CreateContainerSpec ToSpec(CreateContainerParameters p)
+        {
+            var bindings = (p.HostConfig?.PortBindings ?? new Dictionary<string, IList<PortBinding>>())
+                .SelectMany(kv => kv.Value.Select(b => new PortBindingSpec(kv.Key, b.HostPort, b.HostIP ?? "")))
+                .ToList();
+
+            return new CreateContainerSpec(
+                Image: p.Image,
+                Name: p.Name,
+                Env: p.Env?.ToList() ?? [],
+                Cmd: p.Cmd?.ToList(),
+                ExposedPorts: p.ExposedPorts?.Keys.ToList() ?? [],
+                PortBindings: bindings,
+                Binds: p.HostConfig?.Binds?.ToList() ?? [],
+                Labels: p.Labels is null ? [] : new Dictionary<string, string>(p.Labels),
+                RestartPolicy: p.HostConfig?.RestartPolicy?.Name.ToString() ?? "UnlessStopped");
+        }
+    }
+}

--- a/src/KRINT.API/Program.cs
+++ b/src/KRINT.API/Program.cs
@@ -21,6 +21,10 @@ builder.WebHost.ConfigureKestrel(options => options.AddServerHeader = false);
 if (string.Equals(builder.Configuration["Krint:Role"], "node", StringComparison.OrdinalIgnoreCase))
 {
     builder.Services.AddDocker(builder.Configuration);
+    // The node executes Docker AND database operations locally; it needs the engine services. The
+    // inner-service resolvers depend on INodeRpc, which is a no-op stub here (a node never re-routes).
+    builder.Services.AddSingleton<KRINT.Infrastructure.Interfaces.INodeRpc, OfflineNodeRpc>();
+    builder.Services.AddInnerDatabases();
     builder.Services.AddHostedService<NodeAgentHostedService>();
 
     var nodeApp = builder.Build();
@@ -63,8 +67,12 @@ builder.Services.AddInnerDatabases();
 
 builder.Services.AddCatalog();
 
-// Live registry of nodes connected over /hubs/node (in-memory; phase 1 has no persisted node identity).
+// Live registry of nodes connected over /hubs/node (in-memory; node details are persisted in the DB).
 builder.Services.AddSingleton<INodeRegistry, NodeRegistry>();
+// Routes Docker operations to the local daemon or a node over SignalR, based on the instance's NodeId.
+builder.Services.AddScoped<KRINT.Infrastructure.Interfaces.IDockerServiceResolver, DockerServiceResolver>();
+// Dispatches inner-DB operations to a node when the target carries a NodeId (used by the routing resolvers).
+builder.Services.AddSingleton<KRINT.Infrastructure.Interfaces.INodeRpc, NodeRpc>();
 
 builder.Services.AddHostedService<KRINT.API.BackupSchedulerHostedService>();
 builder.Services.AddHostedService<KRINT.API.InstanceReconciliationHostedService>();
@@ -141,6 +149,24 @@ app.UseRouting();
 app.UseCors();
 app.UseAuthentication();
 app.UseAuthorization();
+
+// Surface node-routing failures as clean 4xx instead of opaque 500s: an offline node is a transient
+// conflict; an unsupported-on-node operation is a bad request. Hubs handle their own errors, so this
+// only ever fires for controller calls (response not yet started).
+app.Use(async (context, next) =>
+{
+    try { await next(); }
+    catch (NodeOfflineException ex) when (!context.Response.HasStarted)
+    {
+        context.Response.StatusCode = StatusCodes.Status409Conflict;
+        await context.Response.WriteAsJsonAsync(new { error = ex.Message });
+    }
+    catch (NotSupportedException ex) when (!context.Response.HasStarted)
+    {
+        context.Response.StatusCode = StatusCodes.Status400BadRequest;
+        await context.Response.WriteAsJsonAsync(new { error = ex.Message });
+    }
+});
 
 app.MapControllers();
 app.MapHub<ContainerHub>("/hubs/container").RequireAuthorization();

--- a/src/KRINT.API/appsettings.json
+++ b/src/KRINT.API/appsettings.json
@@ -14,6 +14,7 @@
     "Tokens": [],
     "ControlPlaneUrl": "",
     "Token": "",
+    "Id": "",
     "Name": ""
   }
 }

--- a/src/KRINT.Application/Command/Backup/CreateBackupCommand.cs
+++ b/src/KRINT.Application/Command/Backup/CreateBackupCommand.cs
@@ -17,6 +17,7 @@ namespace KRINT.Application.Command.Backup
         {
             var instance = await db.DatabaseInstances.FirstOrDefaultAsync(d => d.Id == command.InstanceId, cancellationToken)
                 ?? throw new InstanceNotFoundException(command.InstanceId);
+            NodeFeatureGuard.EnsureLocal(instance, "Backups");
 
             // Backups exec inside the container (pg_dump, mysqldump, mongodump). Available
             // whenever there's a reachable container, including adopted externals.

--- a/src/KRINT.Application/Command/Backup/RestoreBackupCommand.cs
+++ b/src/KRINT.Application/Command/Backup/RestoreBackupCommand.cs
@@ -17,6 +17,7 @@ namespace KRINT.Application.Command.Backup
 
             var instance = await db.DatabaseInstances.FirstOrDefaultAsync(d => d.Id == entry.InstanceId, cancellationToken)
                 ?? throw new InstanceNotFoundException(entry.InstanceId);
+            NodeFeatureGuard.EnsureLocal(instance, "Restore");
 
             if (instance.ContainerName is null || instance.ContainerId is null)
                 throw new InvalidOperationException("Restore requires a Docker container - this database isn't reachable that way.");

--- a/src/KRINT.Application/Command/Database/CreateDatabaseCommand.cs
+++ b/src/KRINT.Application/Command/Database/CreateDatabaseCommand.cs
@@ -14,9 +14,9 @@ using KRINT.Infrastructure.Interfaces;
 
 namespace KRINT.Application.Command.Database
 {
-    public record CreateDatabaseCommand(string Engine, string Version, string DisplayName, string? DatabaseName = null, IReadOnlyList<string>? Plugins = null, bool IsPublic = false, string? Password = null) : ICommand<ProvisionedDatabaseDto>;
+    public record CreateDatabaseCommand(string Engine, string Version, string DisplayName, string? DatabaseName = null, IReadOnlyList<string>? Plugins = null, bool IsPublic = false, string? Password = null, Guid? NodeId = null) : ICommand<ProvisionedDatabaseDto>;
 
-    public class CreateDatabaseCommandHandler(IDockerService docker, ISecretGeneratorService secretGenerator, ISecretsVaultService vault, KrintDbContext db, IOptions<KrintOptions> options, IActivityLogger activity, IInnerDatabaseServiceResolver innerDbs) : ICommandHandler<CreateDatabaseCommand, ProvisionedDatabaseDto>
+    public class CreateDatabaseCommandHandler(IDockerServiceResolver dockerResolver, ISecretGeneratorService secretGenerator, ISecretsVaultService vault, KrintDbContext db, IOptions<KrintOptions> options, IActivityLogger activity, IInnerDatabaseServiceResolver innerDbs) : ICommandHandler<CreateDatabaseCommand, ProvisionedDatabaseDto>
     {
         private const string Host = "localhost";
         // krint runs in its own container; localhost there is krint's loopback, not the Docker
@@ -35,10 +35,22 @@ namespace KRINT.Application.Command.Database
         /// </summary>
         public static string ResolveProbeHost(bool isPublic) => isPublic ? ProbeHost : "127.0.0.1";
 
+        /// <summary>Builds the readiness/operation target for an existing instance. Node-hosted
+        /// instances carry their NodeId and a loopback host so the inner-service resolver dispatches
+        /// the call to the node; local instances use the deployment-aware probe host.</summary>
+        public static InnerDatabaseTarget BuildProbeTarget(KRINT.Domain.DatabaseInstance instance, string password)
+        {
+            if (instance.NodeId is { } nodeId)
+                return new InnerDatabaseTarget(instance.Engine, "127.0.0.1", instance.Port, instance.Username, password, instance.DatabaseName, nodeId);
+            var probeHost = instance.IsManaged && instance.Host == "localhost" ? ResolveProbeHost(instance.IsPublic) : instance.Host;
+            return new InnerDatabaseTarget(instance.Engine, probeHost, instance.Port, instance.Username, password, instance.DatabaseName);
+        }
+
         private readonly KrintOptions _options = options.Value;
 
         public async ValueTask<ProvisionedDatabaseDto> Handle(CreateDatabaseCommand command, CancellationToken cancellationToken)
         {
+            var docker = dockerResolver.Resolve(command.NodeId);
             var spec = ResolveEngineSpec(command.Engine, command.Version);
 
             var databaseName = ResolveDatabaseName(spec, command.DatabaseName);
@@ -46,6 +58,17 @@ namespace KRINT.Application.Command.Database
             // Resolve selected plugins. DockerImageSwap replaces the image; EnvFlag appends env;
             // PgExtension / ContainerExec are applied later after readiness.
             var selectedPlugins = ResolvePlugins(command.Plugins);
+
+            // Plugins/engines that need a direct SQL connection from the control plane to install
+            // (pgvector's CREATE EXTENSION, PgExtension plugins) can't run against a node-hosted DB
+            // yet - the control plane has no socket to it. Block them clearly rather than half-provision.
+            if (command.NodeId is not null &&
+                (string.Equals(command.Engine, "pgvector", StringComparison.OrdinalIgnoreCase) ||
+                 selectedPlugins.Any(p => p.InstallMode == PluginInstallMode.PgExtension)))
+            {
+                throw new NotSupportedException("pgvector and Postgres-extension plugins are not supported on remote nodes yet.");
+            }
+
             var imageOverride = selectedPlugins.FirstOrDefault(p => p.InstallMode == PluginInstallMode.DockerImageSwap)?.Payload;
             var extraEnv = selectedPlugins
                 .Where(p => p.InstallMode == PluginInstallMode.EnvFlag)
@@ -78,7 +101,7 @@ namespace KRINT.Application.Command.Database
                 : command.Version;
             await docker.PullImageAsync(imageName, imageTag, cancellationToken);
 
-            var hostPort = await AllocateHostPortAsync(command.Engine, cancellationToken);
+            var hostPort = await AllocateHostPortAsync(command.Engine, command.NodeId, docker, cancellationToken);
 
             var env = BuildEnv(command.Engine, password, databaseName, spec.DefaultDatabase);
             env.AddRange(extraEnv);
@@ -98,8 +121,9 @@ namespace KRINT.Application.Command.Database
                     PortBindings = new Dictionary<string, IList<PortBinding>>
                     {
                         // Leaving HostIP unset is Docker's default and binds to 0.0.0.0
-                        // (visible on the LAN). "127.0.0.1" restricts to loopback.
-                        [$"{spec.InternalPort}/tcp"] = new List<PortBinding> { new() { HostPort = hostPort.ToString(), HostIP = command.IsPublic ? "" : "127.0.0.1" } },
+                        // (visible on the LAN). "127.0.0.1" restricts to loopback. Node-hosted
+                        // containers are always loopback-only - nothing connects to a node directly.
+                        [$"{spec.InternalPort}/tcp"] = new List<PortBinding> { new() { HostPort = hostPort.ToString(), HostIP = command.NodeId is not null || !command.IsPublic ? "127.0.0.1" : "" } },
                     },
                     Binds = new List<string> { bindSpec },
                     RestartPolicy = new RestartPolicy { Name = RestartPolicyKind.UnlessStopped },
@@ -143,9 +167,12 @@ namespace KRINT.Application.Command.Database
                 // Wait for the engine inside the container to accept connections. The returned
                 // target carries whichever probe host actually responded - init steps below
                 // must use it so they reach the same address.
+                // Node-hosted: probe runs on the node against its loopback (carry NodeId so the inner
+                // resolver dispatches there); local: the deployment-aware probe host.
+                var probeHostInitial = command.NodeId is not null ? "127.0.0.1" : ResolveProbeHost(command.IsPublic);
                 var readinessTarget = await ReadinessProbe.WaitForReadyAsync(
                     innerDbs.Resolve(command.Engine),
-                    new InnerDatabaseTarget(command.Engine, ResolveProbeHost(command.IsPublic), hostPort, spec.DefaultUsername, password, probeDatabase),
+                    new InnerDatabaseTarget(command.Engine, probeHostInitial, hostPort, spec.DefaultUsername, password, probeDatabase, command.NodeId),
                     command.IsPublic,
                     cancellationToken);
 
@@ -188,6 +215,7 @@ namespace KRINT.Application.Command.Database
                     Username = spec.DefaultUsername,
                     DatabaseName = databaseName,
                     IsPublic = command.IsPublic,
+                    NodeId = command.NodeId,
                 };
                 db.DatabaseInstances.Add(instance);
                 await db.SaveChangesAsync(cancellationToken);
@@ -465,22 +493,22 @@ namespace KRINT.Application.Command.Database
             await cmd.ExecuteNonQueryAsync(cancellationToken);
         }
 
-        private async Task<int> AllocateHostPortAsync(string engine, CancellationToken cancellationToken)
+        private async Task<int> AllocateHostPortAsync(string engine, Guid? nodeId, IDockerService docker, CancellationToken cancellationToken)
         {
             var range = _options.GetPortRange(engine);
 
-            // 1) Ports KRINT already recorded as in-use for this engine.
+            // 1) Ports KRINT already recorded as in-use for this engine on the same target (port
+            //    ranges are per-host, so two different nodes can reuse the same range independently).
             var usedInDb = await db.DatabaseInstances
-                .Where(d => d.Engine == engine && d.Port >= range.Start && d.Port <= range.End)
+                .Where(d => d.Engine == engine && d.NodeId == nodeId && d.Port >= range.Start && d.Port <= range.End)
                 .Select(d => d.Port)
                 .ToHashSetAsync(cancellationToken);
 
-            // 2) Ports actually published by any container on the Docker host - covers orphans
+            // 2) Ports actually published by any container on the target Docker host - covers orphans
             //    left over from a wiped krint DB, prior deploys, or anything else binding a port
-            //    in the configured range. Binding TcpListener on 127.0.0.1 from inside the krint
-            //    container would only check the container's own loopback, not the host, so this
-            //    Docker-level inspection is the only reliable signal.
-            var dockerPorts = await GetPublishedHostPortsAsync(cancellationToken);
+            //    in the configured range. The resolved docker service queries the local daemon or the
+            //    node's, matching where this instance will be created.
+            var dockerPorts = await GetPublishedHostPortsAsync(docker, cancellationToken);
 
             for (var port = range.Start; port <= range.End; port++)
             {
@@ -492,7 +520,7 @@ namespace KRINT.Application.Command.Database
             throw new InvalidOperationException($"No free host port in range {range.Start}-{range.End} for engine '{engine}'.");
         }
 
-        private async Task<HashSet<int>> GetPublishedHostPortsAsync(CancellationToken cancellationToken)
+        private static async Task<HashSet<int>> GetPublishedHostPortsAsync(IDockerService docker, CancellationToken cancellationToken)
         {
             var taken = new HashSet<int>();
             var containers = await docker.ListContainersAsync(all: true, cancellationToken);

--- a/src/KRINT.Application/Command/Database/UpgradeDatabaseCommand.cs
+++ b/src/KRINT.Application/Command/Database/UpgradeDatabaseCommand.cs
@@ -38,6 +38,7 @@ namespace KRINT.Application.Command.Database
             var instance = await db.DatabaseInstances.FirstOrDefaultAsync(d => d.Id == command.InstanceId, cancellationToken)
                 ?? throw new InstanceNotFoundException(command.InstanceId);
             guard.EnsureMutable(instance);
+            NodeFeatureGuard.EnsureLocal(instance, "Version upgrade");
 
             // Upgrade is dump-restore-swap: it destroys the old container and provisions a fresh
             // one with a new name + image. For externals (typically pinned in the user's

--- a/src/KRINT.Application/Command/DatabaseInstance/DeleteDatabaseCommand.cs
+++ b/src/KRINT.Application/Command/DatabaseInstance/DeleteDatabaseCommand.cs
@@ -9,7 +9,7 @@ namespace KRINT.Application.Command.DatabaseInstance
 {
     public record DeleteDatabaseCommand(Guid Id) : ICommand;
 
-    public class DeleteDatabaseCommandHandler(KrintDbContext db, IDockerService docker, ISecretsVaultService vault, IActivityLogger activity, IOptions<KrintOptions> options, ConfigManagedGuard guard) : ICommandHandler<DeleteDatabaseCommand>
+    public class DeleteDatabaseCommandHandler(KrintDbContext db, IDockerServiceResolver dockerResolver, ISecretsVaultService vault, IActivityLogger activity, IOptions<KrintOptions> options, ConfigManagedGuard guard) : ICommandHandler<DeleteDatabaseCommand>
     {
         public async ValueTask<Unit> Handle(DeleteDatabaseCommand command, CancellationToken cancellationToken)
         {
@@ -21,6 +21,7 @@ namespace KRINT.Application.Command.DatabaseInstance
             // destroy it. We drop the row + vault entry only and leave the remote engine untouched.
             if (instance.IsManaged && instance.ContainerName is not null && instance.ContainerId is not null)
             {
+                var docker = dockerResolver.Resolve(instance.NodeId);
                 var volumeName = $"{instance.ContainerName}-data";
 
                 try { await docker.RemoveContainerAsync(instance.ContainerId, force: true, cancellationToken); }
@@ -32,11 +33,16 @@ namespace KRINT.Application.Command.DatabaseInstance
                 try { await docker.RemoveVolumeAsync(volumeName, force: true, cancellationToken); }
                 catch { /* volume may already be gone */ }
 
-                var hostFolder = options.Value.Storage.TryResolveHostFolderForContainer(instance.ContainerName);
-                if (hostFolder is not null && Directory.Exists(hostFolder))
+                // Host-folder cleanup only makes sense for local instances - the folder lives on the
+                // node's filesystem otherwise, which this process can't see.
+                if (instance.NodeId is null)
                 {
-                    try { Directory.Delete(hostFolder, recursive: true); }
-                    catch { /* not accessible from this process; user can clean up manually */ }
+                    var hostFolder = options.Value.Storage.TryResolveHostFolderForContainer(instance.ContainerName);
+                    if (hostFolder is not null && Directory.Exists(hostFolder))
+                    {
+                        try { Directory.Delete(hostFolder, recursive: true); }
+                        catch { /* not accessible from this process; user can clean up manually */ }
+                    }
                 }
             }
 

--- a/src/KRINT.Application/Command/DatabaseInstance/SetInstanceRootPasswordCommand.cs
+++ b/src/KRINT.Application/Command/DatabaseInstance/SetInstanceRootPasswordCommand.cs
@@ -28,7 +28,7 @@ namespace KRINT.Application.Command.DatabaseInstance
     /// </summary>
     public class SetInstanceRootPasswordCommandHandler(
         KrintDbContext db,
-        IDockerService docker,
+        IDockerServiceResolver dockerResolver,
         ISecretsVaultService vault,
         IInnerDatabaseServiceResolver innerDbs,
         IInnerUserServiceResolver innerUsers,
@@ -45,6 +45,8 @@ namespace KRINT.Application.Command.DatabaseInstance
 
             if (!instance.IsManaged || instance.ContainerId is null)
                 throw new InvalidOperationException("Root password can only be changed on KRINT-managed databases.");
+
+            var docker = dockerResolver.Resolve(instance.NodeId);
 
             // Require the user to have stopped the DB first. This is the explicit safety gate
             // the user asked for - prevents accidental rotation while applications are connected.
@@ -71,8 +73,7 @@ namespace KRINT.Application.Command.DatabaseInstance
             await docker.StartContainerAsync(instance.ContainerId, cancellationToken);
             try
             {
-                var probeHost = instance.Host == "localhost" ? CreateDatabaseCommandHandler.ResolveProbeHost(instance.IsPublic) : instance.Host;
-                var target = new InnerDatabaseTarget(instance.Engine, probeHost, instance.Port, instance.Username, oldPassword, instance.DatabaseName);
+                var target = CreateDatabaseCommandHandler.BuildProbeTarget(instance, oldPassword);
                 await WaitForReadyAsync(target, cancellationToken);
 
                 await innerUsers.Resolve(instance.Engine).ResetPasswordAsync(target, instance.Username, newPassword, cancellationToken);

--- a/src/KRINT.Application/Command/DatabaseInstance/SetInstanceVisibilityCommand.cs
+++ b/src/KRINT.Application/Command/DatabaseInstance/SetInstanceVisibilityCommand.cs
@@ -41,6 +41,11 @@ namespace KRINT.Application.Command.DatabaseInstance
             if (!instance.IsManaged || instance.ContainerName is null || instance.ContainerId is null)
                 throw new InvalidOperationException("Visibility can only be changed on KRINT-managed databases. External containers are owned by the orchestrator that created them.");
 
+            // Node-hosted databases are always loopback-only on the node - nothing connects to a node
+            // directly, so LAN visibility doesn't apply.
+            if (instance.NodeId is not null)
+                throw new NotSupportedException("Visibility can't be changed for node-hosted databases - they are reachable only through the control plane.");
+
             if (instance.IsPublic == command.IsPublic)
                 return instance.ToDto(); // no-op, already in desired state
 

--- a/src/KRINT.Application/Command/DatabaseInstance/StartInstanceCommand.cs
+++ b/src/KRINT.Application/Command/DatabaseInstance/StartInstanceCommand.cs
@@ -16,7 +16,7 @@ namespace KRINT.Application.Command.DatabaseInstance
     /// </summary>
     public class StartInstanceCommandHandler(
         KrintDbContext db,
-        IDockerService docker,
+        IDockerServiceResolver dockerResolver,
         ISecretsVaultService vault,
         IInnerDatabaseServiceResolver innerDbs,
         IActivityLogger activity,
@@ -32,15 +32,14 @@ namespace KRINT.Application.Command.DatabaseInstance
             if (instance.ContainerId is null)
                 throw new InvalidOperationException("This instance has no Docker container - nothing to start.");
 
-            await docker.StartContainerAsync(instance.ContainerId, cancellationToken);
+            await dockerResolver.Resolve(instance.NodeId).StartContainerAsync(instance.ContainerId, cancellationToken);
 
             // Block until the engine accepts a query. Same envelope as create/visibility:
             // JVM-heavy engines get 180s, the rest 60s. If the container starts but the
             // engine never comes ready, surface that as a failure - the user wants to know.
             var password = await vault.RetrieveAsync(ConnectionStringBuilder.VaultKeyFor(instance), cancellationToken)
                 ?? throw new InvalidOperationException($"Vault has no password for instance {instance.Id}.");
-            var probeHost = instance.IsManaged && instance.Host == "localhost" ? CreateDatabaseCommandHandler.ResolveProbeHost(instance.IsPublic) : instance.Host;
-            var target = new InnerDatabaseTarget(instance.Engine, probeHost, instance.Port, instance.Username, password, instance.DatabaseName);
+            var target = CreateDatabaseCommandHandler.BuildProbeTarget(instance, password);
             await WaitForReadyAsync(target, cancellationToken);
 
             await activity.LogAsync("instance.start", instance.ContainerName ?? instance.DisplayName, instance.Id, instance.Engine, null, cancellationToken);

--- a/src/KRINT.Application/Command/DatabaseInstance/StopInstanceCommand.cs
+++ b/src/KRINT.Application/Command/DatabaseInstance/StopInstanceCommand.cs
@@ -13,7 +13,7 @@ namespace KRINT.Application.Command.DatabaseInstance
     /// preserved; the row stays. Externals without a containerId are rejected because there's
     /// nothing for KRINT to stop.
     /// </summary>
-    public class StopInstanceCommandHandler(KrintDbContext db, IDockerService docker, IActivityLogger activity, ConfigManagedGuard guard)
+    public class StopInstanceCommandHandler(KrintDbContext db, IDockerServiceResolver dockerResolver, IActivityLogger activity, ConfigManagedGuard guard)
         : ICommandHandler<StopInstanceCommand>
     {
         public async ValueTask<Unit> Handle(StopInstanceCommand command, CancellationToken cancellationToken)
@@ -25,7 +25,7 @@ namespace KRINT.Application.Command.DatabaseInstance
             if (instance.ContainerId is null)
                 throw new InvalidOperationException("This instance has no Docker container - nothing to stop.");
 
-            await docker.StopContainerAsync(instance.ContainerId, cancellationToken);
+            await dockerResolver.Resolve(instance.NodeId).StopContainerAsync(instance.ContainerId, cancellationToken);
 
             await activity.LogAsync("instance.stop", instance.ContainerName ?? instance.DisplayName, instance.Id, instance.Engine, null, cancellationToken);
             return Unit.Value;

--- a/src/KRINT.Application/Command/Provision/ProvisionDatabaseCommand.cs
+++ b/src/KRINT.Application/Command/Provision/ProvisionDatabaseCommand.cs
@@ -20,7 +20,7 @@ namespace KRINT.Application.Command.Provision
             // 1. Create the instance (provisions the container, opens host port, stores root password).
             // Plugins propagate down so CreateDatabaseCommand can swap the image, set env vars,
             // and/or run post-readiness install steps.
-            var instance = await mediator.Send(new CreateDatabaseCommand(req.Engine, req.Version, req.DisplayName, req.DefaultDatabaseName, req.Plugins, req.IsPublic, req.Password), cancellationToken);
+            var instance = await mediator.Send(new CreateDatabaseCommand(req.Engine, req.Version, req.DisplayName, req.DefaultDatabaseName, req.Plugins, req.IsPublic, req.Password, req.NodeId), cancellationToken);
 
             var createdDatabases = new List<string>();
             var createdUsers = new List<InnerUserPasswordDto>();

--- a/src/KRINT.Application/Dtos/DatabaseInstance/DatabaseInstanceDto.cs
+++ b/src/KRINT.Application/Dtos/DatabaseInstance/DatabaseInstanceDto.cs
@@ -27,5 +27,9 @@ namespace KRINT.Application.Dtos.DatabaseInstance
         public string? State { get; init; }
         /// <summary>True if owned by instances.yaml. The UI hides/disables mutation controls.</summary>
         public required bool IsConfigManaged { get; init; }
+        /// <summary>The node this instance runs on, or null for the control plane's local Docker.
+        /// The UI shows a node badge and hides the not-yet-supported controls (logs, console,
+        /// backups, upgrade, visibility) for node-hosted instances.</summary>
+        public Guid? NodeId { get; init; }
     }
 }

--- a/src/KRINT.Application/Dtos/Provision/ProvisionRequestDto.cs
+++ b/src/KRINT.Application/Dtos/Provision/ProvisionRequestDto.cs
@@ -21,5 +21,8 @@ namespace KRINT.Application.Dtos.Provision
         /// the SafePasswordGuard alphabet ([A-Za-z0-9-_.~]) - those are the chars KRINT can
         /// safely inline into engine DDL across every supported backend.</summary>
         public string? Password { get; init; }
+        /// <summary>Target node to provision on. Null (default) provisions on the control plane's
+        /// local Docker daemon; otherwise the container runs on the chosen node.</summary>
+        public Guid? NodeId { get; init; }
     }
 }

--- a/src/KRINT.Application/InnerDatabaseTargetLoader.cs
+++ b/src/KRINT.Application/InnerDatabaseTargetLoader.cs
@@ -21,6 +21,12 @@ namespace KRINT.Application
             var password = await vault.RetrieveAsync(ConnectionStringBuilder.VaultKeyFor(instance), cancellationToken)
                 ?? throw new InvalidOperationException($"Vault has no password for instance {instanceId}.");
 
+            // Node-hosted: the operation is dispatched to the node and runs against the container on
+            // the node's own loopback, so there's no host to probe from here - carry the NodeId so the
+            // inner-service resolver routes it.
+            if (instance.NodeId is { } nodeId)
+                return new InnerDatabaseTarget(instance.Engine, "127.0.0.1", instance.Port, instance.Username, password, instance.DatabaseName, nodeId);
+
             var preferred = ResolveTargetHost(instance.Host, instance.IsManaged, instance.IsPublic);
             var host = await PickReachableHostAsync(preferred, instance.Port, cancellationToken);
 

--- a/src/KRINT.Application/Mappings/DatabaseInstance/DatabaseInstanceMappings.cs
+++ b/src/KRINT.Application/Mappings/DatabaseInstance/DatabaseInstanceMappings.cs
@@ -20,6 +20,7 @@ namespace KRINT.Application.Mappings.DatabaseInstance
             IsManaged = d.IsManaged,
             IsPublic = d.IsPublic,
             IsConfigManaged = d.IsConfigManaged,
+            NodeId = d.NodeId,
         };
     }
 }

--- a/src/KRINT.Application/NodeFeatureGuard.cs
+++ b/src/KRINT.Application/NodeFeatureGuard.cs
@@ -1,0 +1,17 @@
+using KRINT.Domain;
+
+namespace KRINT.Application
+{
+    /// <summary>Phase 2a routes provisioning, lifecycle and browse/query/users to nodes. The
+    /// streaming-shaped features (logs, interactive console, backups/restore, version upgrade) need
+    /// the node to proxy a stream and aren't wired up yet, so they're blocked for node-hosted
+    /// instances with a clear message rather than failing obscurely.</summary>
+    public static class NodeFeatureGuard
+    {
+        public static void EnsureLocal(DatabaseInstance instance, string feature)
+        {
+            if (instance.NodeId is not null)
+                throw new NotSupportedException($"{feature} is not supported on remote nodes yet.");
+        }
+    }
+}

--- a/src/KRINT.Application/Queries/Container/ResolveContainerIdQuery.cs
+++ b/src/KRINT.Application/Queries/Container/ResolveContainerIdQuery.cs
@@ -15,6 +15,7 @@ namespace KRINT.Application.Queries.Container
                 .AsNoTracking()
                 .FirstOrDefaultAsync(d => d.Id == query.InstanceId, cancellationToken)
                 ?? throw new InstanceNotFoundException(query.InstanceId);
+            NodeFeatureGuard.EnsureLocal(instance, "The interactive console");
             return instance.ContainerId
                 ?? throw new InvalidOperationException("Container operations are not available for externally-registered databases.");
         }

--- a/src/KRINT.Application/Queries/Container/StreamContainerLogsQuery.cs
+++ b/src/KRINT.Application/Queries/Container/StreamContainerLogsQuery.cs
@@ -20,6 +20,7 @@ namespace KRINT.Application.Queries.Container
                 .AsNoTracking()
                 .FirstOrDefaultAsync(d => d.Id == query.InstanceId, cancellationToken)
                 ?? throw new InstanceNotFoundException(query.InstanceId);
+            NodeFeatureGuard.EnsureLocal(instance, "Container log streaming");
 
             var containerId = instance.ContainerId
                 ?? throw new InvalidOperationException("Container logs are not available for externally-registered databases.");

--- a/src/KRINT.Application/Queries/Database/GetDatabaseDetailsQuery.cs
+++ b/src/KRINT.Application/Queries/Database/GetDatabaseDetailsQuery.cs
@@ -9,7 +9,7 @@ namespace KRINT.Application.Queries.Database
 {
     public record GetDatabaseDetailsQuery(Guid Id) : IQuery<ProvisionedDatabaseDto?>;
 
-    public class GetDatabaseDetailsQueryHandler(KrintDbContext db, ISecretsVaultService vault, IDockerService docker)
+    public class GetDatabaseDetailsQueryHandler(KrintDbContext db, ISecretsVaultService vault, IDockerServiceResolver dockerResolver)
         : IQueryHandler<GetDatabaseDetailsQuery, ProvisionedDatabaseDto?>
     {
         public async ValueTask<ProvisionedDatabaseDto?> Handle(GetDatabaseDetailsQuery query, CancellationToken cancellationToken)
@@ -29,7 +29,7 @@ namespace KRINT.Application.Queries.Database
             {
                 try
                 {
-                    var inspect = await docker.InspectContainerAsync(instance.ContainerId, cancellationToken);
+                    var inspect = await dockerResolver.Resolve(instance.NodeId).InspectContainerAsync(instance.ContainerId, cancellationToken);
                     state = inspect.State?.Status;
                 }
                 catch

--- a/src/KRINT.Application/Queries/Database/ListDatabasesQuery.cs
+++ b/src/KRINT.Application/Queries/Database/ListDatabasesQuery.cs
@@ -9,7 +9,7 @@ namespace KRINT.Application.Queries.Database
 {
     public record ListDatabasesQuery : IQuery<IReadOnlyList<DatabaseInstanceDto>>;
 
-    public class ListDatabasesQueryHandler(KrintDbContext db, IDockerService docker)
+    public class ListDatabasesQueryHandler(KrintDbContext db, IDockerServiceResolver dockerResolver)
         : IQueryHandler<ListDatabasesQuery, IReadOnlyList<DatabaseInstanceDto>>
     {
         public async ValueTask<IReadOnlyList<DatabaseInstanceDto>> Handle(ListDatabasesQuery query, CancellationToken cancellationToken)
@@ -18,27 +18,26 @@ namespace KRINT.Application.Queries.Database
                 .OrderByDescending(d => d.CreatedAt)
                 .ToListAsync(cancellationToken);
 
-            // One Docker call covers every container, indexed by name. Matching by name (Docker
-            // prefixes with '/') is cheaper than N inspects and tolerates missing containers
-            // gracefully - if a row has no entry it just gets a null state.
+            // Container state lives on whichever daemon owns it: the local one for control-plane
+            // instances, the node's for node-hosted ones. Query each distinct target once (a name ->
+            // state map) so a row without a container - or an offline node - just gets a null state.
             var stateByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            try
+            foreach (var nodeId in rows.Select(d => d.NodeId).Distinct())
             {
-                var containers = await docker.ListContainersAsync(all: true, cancellationToken);
-                foreach (var c in containers)
+                try
                 {
-                    if (c.Names is null) continue;
-                    foreach (var raw in c.Names)
+                    var containers = await dockerResolver.Resolve(nodeId).ListContainersAsync(all: true, cancellationToken);
+                    foreach (var c in containers)
                     {
-                        var name = raw.TrimStart('/');
-                        stateByName[name] = c.State ?? "unknown";
+                        if (c.Names is null) continue;
+                        foreach (var raw in c.Names)
+                            stateByName[raw.TrimStart('/')] = c.State ?? "unknown";
                     }
                 }
-            }
-            catch
-            {
-                // Docker daemon unreachable - all rows return State=null and the UI falls back
-                // to its "unknown" pill rather than failing the whole list.
+                catch
+                {
+                    // Daemon/node unreachable - those rows return State=null and the UI shows "unknown".
+                }
             }
 
             return rows.Select(d =>

--- a/src/KRINT.Application/ReadinessProbe.cs
+++ b/src/KRINT.Application/ReadinessProbe.cs
@@ -22,9 +22,15 @@ namespace KRINT.Application
 
         public static async Task<InnerDatabaseTarget> WaitForReadyAsync(IInnerDatabaseService inner, InnerDatabaseTarget target, bool isPublic, CancellationToken cancellationToken)
         {
-            var preferred = Command.Database.CreateDatabaseCommandHandler.ResolveProbeHost(isPublic);
-            var fallback = preferred == "127.0.0.1" ? Command.Database.CreateDatabaseCommandHandler.ProbeHost : "127.0.0.1";
-            var candidates = new[] { target with { Host = preferred }, target with { Host = fallback } };
+            // Node-hosted: the probe runs ON the node against its own loopback (the inner service
+            // dispatches there), so there are no host candidates to try - use the target verbatim.
+            var candidates = target.NodeId is not null
+                ? [target]
+                : new[]
+                {
+                    target with { Host = Command.Database.CreateDatabaseCommandHandler.ResolveProbeHost(isPublic) },
+                    target with { Host = Command.Database.CreateDatabaseCommandHandler.ResolveProbeHost(isPublic) == "127.0.0.1" ? Command.Database.CreateDatabaseCommandHandler.ProbeHost : "127.0.0.1" },
+                };
 
             var ceilingSeconds = CeilingSecondsFor(target.Engine);
             var deadline = DateTime.UtcNow.AddSeconds(ceilingSeconds);

--- a/src/KRINT.Domain/DatabaseInstance.cs
+++ b/src/KRINT.Domain/DatabaseInstance.cs
@@ -33,5 +33,9 @@ namespace KRINT.Domain
         /// new KRINT-managed instance that holds the migrated data. The UI uses this to badge
         /// the source row as "Migrated -&gt;" and to suppress re-offering it in discovery.</summary>
         public Guid? MigratedToInstanceId { get; set; }
+        /// <summary>The node this instance's container runs on, or null when it runs on the control
+        /// plane's local Docker daemon. When set, all container and DB operations are dispatched to
+        /// that node over SignalR (the node executes them locally and returns the result).</summary>
+        public Guid? NodeId { get; set; }
     }
 }

--- a/src/KRINT.Domain/Node.cs
+++ b/src/KRINT.Domain/Node.cs
@@ -1,0 +1,15 @@
+namespace KRINT.Domain
+{
+    /// <summary>A worker node registered with this control plane. The Id is supplied by the node
+    /// itself (its stable Node:Id) so it survives reconnects and lets a DatabaseInstance reference
+    /// the node it runs on. Online state is NOT stored - it's derived from the live SignalR registry.
+    /// Rows are upserted on registration and never auto-deleted; CreatedAt is the first-seen time.</summary>
+    public class Node : BaseEntity
+    {
+        public required string Name { get; set; }
+        public required string MachineName { get; set; }
+        public required string Os { get; set; }
+        public required string DockerVersion { get; set; }
+        public DateTime LastSeenAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/src/KRINT.Frontend/src/app/api/api/nodes.service.ts
+++ b/src/KRINT.Frontend/src/app/api/api/nodes.service.ts
@@ -40,66 +40,6 @@ export class NodesService extends BaseService {
     }
 
     /**
-     * @endpoint post /api/Nodes/{connectionId}/ping
-     * @param connectionId 
-     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
-     * @param reportProgress flag to report request and response progress.
-     * @param options additional options
-     */
-    public apiNodesConnectionIdPingPost(connectionId: string, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<NodePingResultDto>;
-    public apiNodesConnectionIdPingPost(connectionId: string, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<NodePingResultDto>>;
-    public apiNodesConnectionIdPingPost(connectionId: string, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<NodePingResultDto>>;
-    public apiNodesConnectionIdPingPost(connectionId: string, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
-        if (connectionId === null || connectionId === undefined) {
-            throw new Error('Required parameter connectionId was null or undefined when calling apiNodesConnectionIdPingPost.');
-        }
-
-        let localVarHeaders = this.defaultHeaders;
-
-        // authentication (OAuth2) required
-        localVarHeaders = this.configuration.addCredentialToHeaders('OAuth2', 'Authorization', localVarHeaders, 'Bearer ');
-
-        const localVarHttpHeaderAcceptSelected: string | undefined = options?.httpHeaderAccept ?? this.configuration.selectHeaderAccept([
-            'text/plain',
-            'application/json',
-            'text/json'
-        ]);
-        if (localVarHttpHeaderAcceptSelected !== undefined) {
-            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
-        }
-
-        const localVarHttpContext: HttpContext = options?.context ?? new HttpContext();
-
-        const localVarTransferCache: boolean = options?.transferCache ?? true;
-
-
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
-        if (localVarHttpHeaderAcceptSelected) {
-            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
-                responseType_ = 'text';
-            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
-                responseType_ = 'json';
-            } else {
-                responseType_ = 'blob';
-            }
-        }
-
-        let localVarPath = `/api/Nodes/${this.configuration.encodeParam({name: "connectionId", value: connectionId, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: undefined})}/ping`;
-        const { basePath, withCredentials } = this.configuration;
-        return this.httpClient.request<NodePingResultDto>('post', `${basePath}${localVarPath}`,
-            {
-                context: localVarHttpContext,
-                responseType: <any>responseType_,
-                ...(withCredentials ? { withCredentials } : {}),
-                headers: localVarHeaders,
-                observe: observe,
-                ...(localVarTransferCache !== undefined ? { transferCache: localVarTransferCache } : {}),
-                reportProgress: reportProgress
-            }
-        );
-    }
-
-    /**
      * @endpoint get /api/Nodes
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
@@ -143,6 +83,66 @@ export class NodesService extends BaseService {
         let localVarPath = `/api/Nodes`;
         const { basePath, withCredentials } = this.configuration;
         return this.httpClient.request<Array<NodeDto>>('get', `${basePath}${localVarPath}`,
+            {
+                context: localVarHttpContext,
+                responseType: <any>responseType_,
+                ...(withCredentials ? { withCredentials } : {}),
+                headers: localVarHeaders,
+                observe: observe,
+                ...(localVarTransferCache !== undefined ? { transferCache: localVarTransferCache } : {}),
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
+     * @endpoint post /api/Nodes/{id}/ping
+     * @param id 
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     * @param options additional options
+     */
+    public apiNodesIdPingPost(id: string, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<NodePingResultDto>;
+    public apiNodesIdPingPost(id: string, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<NodePingResultDto>>;
+    public apiNodesIdPingPost(id: string, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<NodePingResultDto>>;
+    public apiNodesIdPingPost(id: string, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+        if (id === null || id === undefined) {
+            throw new Error('Required parameter id was null or undefined when calling apiNodesIdPingPost.');
+        }
+
+        let localVarHeaders = this.defaultHeaders;
+
+        // authentication (OAuth2) required
+        localVarHeaders = this.configuration.addCredentialToHeaders('OAuth2', 'Authorization', localVarHeaders, 'Bearer ');
+
+        const localVarHttpHeaderAcceptSelected: string | undefined = options?.httpHeaderAccept ?? this.configuration.selectHeaderAccept([
+            'text/plain',
+            'application/json',
+            'text/json'
+        ]);
+        if (localVarHttpHeaderAcceptSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+        }
+
+        const localVarHttpContext: HttpContext = options?.context ?? new HttpContext();
+
+        const localVarTransferCache: boolean = options?.transferCache ?? true;
+
+
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
+            }
+        }
+
+        let localVarPath = `/api/Nodes/${this.configuration.encodeParam({name: "id", value: id, in: "path", style: "simple", explode: false, dataType: "string", dataFormat: "uuid"})}/ping`;
+        const { basePath, withCredentials } = this.configuration;
+        return this.httpClient.request<NodePingResultDto>('post', `${basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,

--- a/src/KRINT.Frontend/src/app/api/model/databaseInstanceDto.ts
+++ b/src/KRINT.Frontend/src/app/api/model/databaseInstanceDto.ts
@@ -26,5 +26,6 @@ export interface DatabaseInstanceDto {
     isPublic: boolean;
     state?: string | null;
     isConfigManaged: boolean;
+    nodeId?: string | null;
 }
 

--- a/src/KRINT.Frontend/src/app/api/model/nodeDto.ts
+++ b/src/KRINT.Frontend/src/app/api/model/nodeDto.ts
@@ -10,13 +10,13 @@
 
 
 export interface NodeDto { 
-    connectionId: string;
+    id: string;
     name: string;
     machineName: string;
     os: string;
     dockerVersion: string;
     online: boolean;
-    connectedAt: string;
+    firstSeenAt: string;
     lastSeenAt: string;
 }
 

--- a/src/KRINT.Frontend/src/app/api/model/provisionRequestDto.ts
+++ b/src/KRINT.Frontend/src/app/api/model/provisionRequestDto.ts
@@ -20,5 +20,6 @@ export interface ProvisionRequestDto {
     plugins?: Array<string>;
     isPublic?: boolean;
     password?: string | null;
+    nodeId?: string | null;
 }
 

--- a/src/KRINT.Frontend/src/app/create/create.html
+++ b/src/KRINT.Frontend/src/app/create/create.html
@@ -11,7 +11,8 @@
         </h2>
         <p hlmCardDescription>
           <code class="font-mono">{{ res.instance.containerName }}</code> is up on
-          <code class="font-mono">{{ res.instance.host }}:{{ res.instance.port }}</code>.
+          <code class="font-mono">{{ res.instance.host }}:{{ res.instance.port }}</code
+          >.
         </p>
       </div>
 
@@ -19,7 +20,9 @@
         <div class="flex flex-col gap-2">
           <span class="text-muted-foreground text-sm">Connection string (root)</span>
           <div class="flex items-start gap-2">
-            <code class="bg-muted flex-1 break-all rounded-md p-3 font-mono text-xs">{{ res.instance.connectionString }}</code>
+            <code class="bg-muted flex-1 break-all rounded-md p-3 font-mono text-xs">{{
+              res.instance.connectionString
+            }}</code>
             <app-copy-button [value]="res.instance.connectionString" />
           </div>
         </div>
@@ -37,7 +40,9 @@
 
         @if (res.users.length > 0) {
           <div class="flex flex-col gap-2">
-            <span class="text-muted-foreground text-sm">Users - save these passwords, they won't be shown again</span>
+            <span class="text-muted-foreground text-sm"
+              >Users - save these passwords, they won't be shown again</span
+            >
             <ul class="divide-border divide-y rounded-md border">
               @for (u of res.users; track u.name) {
                 <li class="grid grid-cols-[auto_1fr_auto] items-center gap-3 px-3 py-2 text-sm">
@@ -73,7 +78,11 @@
               {{ s.n }}
             }
           </span>
-          <span [class.font-medium]="step() === s.n" [class.text-muted-foreground]="step() !== s.n">{{ s.label }}</span>
+          <span
+            [class.font-medium]="step() === s.n"
+            [class.text-muted-foreground]="step() !== s.n"
+            >{{ s.label }}</span
+          >
           @if (!last) {
             <span class="bg-border h-px w-6"></span>
           }
@@ -87,7 +96,9 @@
         @if (step() === 1) {
           <div class="flex flex-col gap-4">
             <h2 class="text-xl font-semibold">Pick an engine</h2>
-            <p class="text-muted-foreground text-sm">Choose the database engine you want to provision.</p>
+            <p class="text-muted-foreground text-sm">
+              Choose the database engine you want to provision.
+            </p>
             <div class="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
               @for (s of supported(); track s.key) {
                 <button
@@ -109,7 +120,9 @@
         @if (step() === 2) {
           <div class="flex flex-col gap-4">
             <h2 class="text-xl font-semibold">Version &amp; default database</h2>
-            <p class="text-muted-foreground text-sm">Pick the engine version. Optionally rename the default database.</p>
+            <p class="text-muted-foreground text-sm">
+              Pick the engine version. Optionally rename the default database.
+            </p>
 
             <div class="flex flex-col gap-2">
               <label hlmLabel>Version</label>
@@ -140,15 +153,41 @@
                 <span class="text-destructive text-sm">{{ err }}</span>
               } @else {
                 <span class="text-muted-foreground text-xs">
-                  Friendly label shown next to the engine logo. Doesn't affect the connection string.
+                  Friendly label shown next to the engine logo. Doesn't affect the connection
+                  string.
                 </span>
               }
             </div>
 
+            @if (onlineNodes().length > 0) {
+              <div class="flex flex-col gap-2">
+                <label hlmLabel>Target node</label>
+                <hlm-select
+                  [value]="selectedNodeId() ?? ''"
+                  (valueChange)="selectedNodeId.set($event || null)"
+                >
+                  <hlm-select-trigger class="w-full">
+                    <hlm-select-value placeholder="Local (control plane)" />
+                  </hlm-select-trigger>
+                  <hlm-select-content *hlmSelectPortal>
+                    <hlm-select-item value="">Local (control plane)</hlm-select-item>
+                    @for (n of onlineNodes(); track n.id) {
+                      <hlm-select-item [value]="n.id">{{ n.name }}</hlm-select-item>
+                    }
+                  </hlm-select-content>
+                </hlm-select>
+                <span class="text-muted-foreground text-xs">
+                  Where the container runs. Node-hosted databases are managed through the control
+                  plane.
+                </span>
+              </div>
+            }
+
             @if (supportsDatabaseNaming()) {
               <div class="flex flex-col gap-2">
                 <label hlmLabel for="default-db">
-                  Default {{ databaseTerm() }} name <span class="text-muted-foreground">(optional)</span>
+                  Default {{ databaseTerm() }} name
+                  <span class="text-muted-foreground">(optional)</span>
                 </label>
                 <input
                   hlmInput
@@ -172,7 +211,8 @@
             <!-- Custom root password. Empty = let KRINT generate one. -->
             <div class="flex flex-col gap-2">
               <label hlmLabel for="root-password">
-                Root password <span class="text-muted-foreground">(optional - leave blank to auto-generate)</span>
+                Root password
+                <span class="text-muted-foreground">(optional - leave blank to auto-generate)</span>
               </label>
               <input
                 hlmInput
@@ -203,17 +243,13 @@
               [class.bg-muted]="isPublic()"
               (click)="isPublic.set(!isPublic())"
             >
-              <hlm-checkbox
-                aria-label="Expose on the LAN"
-                [checked]="isPublic()"
-                class="mt-0.5"
-              />
+              <hlm-checkbox aria-label="Expose on the LAN" [checked]="isPublic()" class="mt-0.5" />
               <span class="flex flex-1 flex-col gap-1">
                 <span class="text-sm font-medium">Expose on the LAN</span>
                 <span class="text-muted-foreground text-xs">
-                  Publishes the host port on 0.0.0.0 so other machines on this network can reach
-                  the database. Off by default - port is bound to 127.0.0.1 (this host only).
-                  You can flip this later from the instance menu.
+                  Publishes the host port on 0.0.0.0 so other machines on this network can reach the
+                  database. Off by default - port is bound to 127.0.0.1 (this host only). You can
+                  flip this later from the instance menu.
                 </span>
               </span>
             </button>
@@ -224,12 +260,12 @@
         @if (step() === 3) {
           <div class="flex flex-col gap-4">
             <h2 class="text-xl font-semibold">Plugins &amp; extensions</h2>
-            <p class="text-muted-foreground text-sm">
-              Optional add-ons enabled on this instance.
-            </p>
+            <p class="text-muted-foreground text-sm">Optional add-ons enabled on this instance.</p>
 
             @if (availablePlugins().length === 0) {
-              <p class="text-muted-foreground rounded-md border border-dashed p-4 text-center text-sm">
+              <p
+                class="text-muted-foreground rounded-md border border-dashed p-4 text-center text-sm"
+              >
                 No plugins available for this engine.
               </p>
             } @else {
@@ -263,17 +299,22 @@
           <div class="flex flex-col gap-4">
             <h2 class="text-xl font-semibold">{{ databaseTermPlural() | titlecase }}</h2>
             @if (!supportsDatabaseNaming()) {
-              <p class="text-muted-foreground rounded-md border border-dashed p-6 text-center text-sm">
-                The <code class="font-mono">{{ engine() }}</code> engine has a single virtual {{ databaseTerm() }};
-                there's nothing to configure on this step.
+              <p
+                class="text-muted-foreground rounded-md border border-dashed p-6 text-center text-sm"
+              >
+                The <code class="font-mono">{{ engine() }}</code> engine has a single virtual
+                {{ databaseTerm() }}; there's nothing to configure on this step.
               </p>
             } @else {
               <p class="text-muted-foreground text-sm">
-                Add more {{ databaseTermPlural() }} on top of the default. Skip if you only need one.
+                Add more {{ databaseTermPlural() }} on top of the default. Skip if you only need
+                one.
               </p>
 
               @if (databases().length === 0) {
-                <p class="text-muted-foreground rounded-md border border-dashed p-4 text-center text-sm">
+                <p
+                  class="text-muted-foreground rounded-md border border-dashed p-4 text-center text-sm"
+                >
                   No extra {{ databaseTermPlural() }} yet.
                 </p>
               }
@@ -290,7 +331,15 @@
                       [attr.data-matches-spartan-invalid]="!!databaseErrors()[$index]"
                       [attr.aria-invalid]="!!databaseErrors()[$index] || null"
                     />
-                    <button hlmBtn variant="ghost" size="icon" type="button" (click)="removeDatabase($index)" aria-label="Remove" [hlmTooltip]="'Remove ' + databaseTerm()">
+                    <button
+                      hlmBtn
+                      variant="ghost"
+                      size="icon"
+                      type="button"
+                      (click)="removeDatabase($index)"
+                      aria-label="Remove"
+                      [hlmTooltip]="'Remove ' + databaseTerm()"
+                    >
                       <ng-icon name="lucideTrash2" size="16" />
                     </button>
                   </div>
@@ -300,7 +349,13 @@
                 </div>
               }
 
-              <button hlmBtn variant="outline" type="button" (click)="addDatabase()" class="self-start">
+              <button
+                hlmBtn
+                variant="outline"
+                type="button"
+                (click)="addDatabase()"
+                class="self-start"
+              >
                 <ng-icon name="lucidePlus" size="16" />
                 Add {{ databaseTerm() }}
               </button>
@@ -313,11 +368,14 @@
           <div class="flex flex-col gap-4">
             <h2 class="text-xl font-semibold">Users</h2>
             <p class="text-muted-foreground text-sm">
-              Define login users. Tick which databases each user can access - a fresh password is generated on launch.
+              Define login users. Tick which databases each user can access - a fresh password is
+              generated on launch.
             </p>
 
             @if (users().length === 0) {
-              <p class="text-muted-foreground rounded-md border border-dashed p-4 text-center text-sm">
+              <p
+                class="text-muted-foreground rounded-md border border-dashed p-4 text-center text-sm"
+              >
                 No users yet. The root account always exists.
               </p>
             }
@@ -335,7 +393,15 @@
                       [attr.data-matches-spartan-invalid]="!!userNameErrors()[userIdx]"
                       [attr.aria-invalid]="!!userNameErrors()[userIdx] || null"
                     />
-                    <button hlmBtn variant="ghost" size="icon" type="button" (click)="removeUser(userIdx)" aria-label="Remove user" hlmTooltip="Remove user">
+                    <button
+                      hlmBtn
+                      variant="ghost"
+                      size="icon"
+                      type="button"
+                      (click)="removeUser(userIdx)"
+                      aria-label="Remove user"
+                      hlmTooltip="Remove user"
+                    >
                       <ng-icon name="lucideTrash2" size="16" />
                     </button>
                   </div>
@@ -368,7 +434,10 @@
                     <label
                       class="flex cursor-pointer items-center gap-2 text-sm"
                       [attr.data-testid]="'grant-' + userIdx + '-' + db"
-                      (click)="toggleUserGrant(userIdx, db, !userHasGrant(userIdx, db)); $event.preventDefault()"
+                      (click)="
+                        toggleUserGrant(userIdx, db, !userHasGrant(userIdx, db));
+                        $event.preventDefault()
+                      "
                     >
                       <hlm-checkbox
                         [attr.aria-label]="'Grant ' + db"
@@ -423,7 +492,12 @@
                       <li class="font-mono">
                         {{ u.name }}
                         <span class="text-muted-foreground">
-                          → {{ u.grantDatabases.length === 0 ? 'no grants' : u.grantDatabases.join(', ') }}
+                          →
+                          {{
+                            u.grantDatabases.length === 0
+                              ? 'no grants'
+                              : u.grantDatabases.join(', ')
+                          }}
                         </span>
                       </li>
                     }
@@ -440,7 +514,13 @@
       </div>
 
       <div hlmCardFooter class="justify-between">
-        <button hlmBtn variant="outline" type="button" (click)="back()" [disabled]="step() === 1 || submitting()">
+        <button
+          hlmBtn
+          variant="outline"
+          type="button"
+          (click)="back()"
+          [disabled]="step() === 1 || submitting()"
+        >
           <ng-icon name="lucideArrowLeft" size="16" />
           Back
         </button>

--- a/src/KRINT.Frontend/src/app/create/create.ts
+++ b/src/KRINT.Frontend/src/app/create/create.ts
@@ -1,4 +1,11 @@
-import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal,
+} from '@angular/core';
 import { TitleCasePipe } from '@angular/common';
 import { Router } from '@angular/router';
 import { NgIcon, provideIcons } from '@ng-icons/core';
@@ -13,7 +20,19 @@ import {
   lucideRocket,
   lucideTrash2,
 } from '@ng-icons/lucide';
-import { simpleApachecassandra, simpleApachecouchdb, simpleClickhouse, simpleCockroachlabs, simpleMariadb, simpleMongodb, simpleMysql, simpleNeo4j, simplePostgresql, simpleRedis, simpleTimescale } from '@ng-icons/simple-icons';
+import {
+  simpleApachecassandra,
+  simpleApachecouchdb,
+  simpleClickhouse,
+  simpleCockroachlabs,
+  simpleMariadb,
+  simpleMongodb,
+  simpleMysql,
+  simpleNeo4j,
+  simplePostgresql,
+  simpleRedis,
+  simpleTimescale,
+} from '@ng-icons/simple-icons';
 import { HlmButtonImports } from '@spartan-ng/helm/button';
 import { HlmCardImports } from '@spartan-ng/helm/card';
 import { HlmCheckboxImports } from '@spartan-ng/helm/checkbox';
@@ -23,8 +42,16 @@ import { HlmSelectImports } from '@spartan-ng/helm/select';
 import { HlmTooltipImports } from '@spartan-ng/helm/tooltip';
 import { ContentHeader } from '../shared/components/content-header/content-header';
 import { CopyButton } from '../shared/components/copy-button/copy-button';
-import { customAzurite, customMssql, customQdrant, customSeaweedfs, customValkey } from '../shared/icons/custom-icons';
+import {
+  customAzurite,
+  customMssql,
+  customQdrant,
+  customSeaweedfs,
+  customValkey,
+} from '../shared/icons/custom-icons';
 import { DatabaseService } from '../api/api/database.service';
+import { NodesService } from '../api/api/nodes.service';
+import { NodeDto } from '../api/model/nodeDto';
 import { SupportedDatabaseDto } from '../api/model/supportedDatabaseDto';
 import { ProvisionResultDto } from '../api/model/provisionResultDto';
 
@@ -79,6 +106,7 @@ type WizardUser = { name: string; grantDatabases: string[] };
 })
 export class Create {
   private readonly api = inject(DatabaseService);
+  private readonly nodesApi = inject(NodesService);
   private readonly router = inject(Router);
 
   // ----- step state -----
@@ -93,6 +121,9 @@ export class Create {
   protected readonly users = signal<WizardUser[]>([]);
   protected readonly selectedPlugins = signal<ReadonlySet<string>>(new Set());
   protected readonly isPublic = signal(false);
+  // Target node for provisioning: null = the control plane's local Docker. Only online nodes are offered.
+  protected readonly onlineNodes = signal<ReadonlyArray<NodeDto>>([]);
+  protected readonly selectedNodeId = signal<string | null>(null);
   // Root password: empty string = auto-generate at provision time.
   protected readonly customRootPassword = signal('');
   // Per-user custom passwords - empty string at index n means auto-generate.
@@ -117,27 +148,31 @@ export class Create {
   // "collections" + "points"; Redis has "keys"; etc. The catalog already declares these
   // strings on EngineCapabilitiesDto - the wizard just plucks them.
   protected readonly databaseTerm = computed(() => this.capabilities()?.databaseTerm ?? 'database');
-  protected readonly tableTerm    = computed(() => this.capabilities()?.tableTerm ?? 'table');
+  protected readonly tableTerm = computed(() => this.capabilities()?.tableTerm ?? 'table');
   protected readonly databaseTermPlural = computed(() => pluralize(this.databaseTerm()));
-  protected readonly tableTermPlural    = computed(() => pluralize(this.tableTerm()));
+  protected readonly tableTermPlural = computed(() => pluralize(this.tableTerm()));
 
   // Whether the engine supports a user-named default database. Single-keyspace engines
   // (Qdrant, Redis) hide the Basics > Default DB input and the Databases
   // step entirely - there's nothing meaningful for the user to type.
-  protected readonly supportsDatabaseNaming = computed(() => this.capabilities()?.supportsCreateDatabase ?? true);
+  protected readonly supportsDatabaseNaming = computed(
+    () => this.capabilities()?.supportsCreateDatabase ?? true,
+  );
 
-  protected readonly steps = computed<ReadonlyArray<{ n: 1 | 2 | 3 | 4 | 5 | 6; label: string }>>(() => {
-    const term = capitalize(this.databaseTermPlural());
-    return [
-      { n: 1, label: 'Engine' },
-      { n: 2, label: 'Basics' },
-      { n: 3, label: 'Plugins' },
-      // Relabel to match the engine: "Databases" / "Collections" / "Indexes" / "Buckets".
-      { n: 4, label: term },
-      { n: 5, label: 'Users' },
-      { n: 6, label: 'Review' },
-    ];
-  });
+  protected readonly steps = computed<ReadonlyArray<{ n: 1 | 2 | 3 | 4 | 5 | 6; label: string }>>(
+    () => {
+      const term = capitalize(this.databaseTermPlural());
+      return [
+        { n: 1, label: 'Engine' },
+        { n: 2, label: 'Basics' },
+        { n: 3, label: 'Plugins' },
+        // Relabel to match the engine: "Databases" / "Collections" / "Indexes" / "Buckets".
+        { n: 4, label: term },
+        { n: 5, label: 'Users' },
+        { n: 6, label: 'Review' },
+      ];
+    },
+  );
 
   protected readonly availablePlugins = computed(
     () => this.supported().find((s) => s.key === this.engine())?.plugins ?? [],
@@ -149,10 +184,14 @@ export class Create {
 
   protected readonly defaultDbPlaceholder = computed(() => {
     switch (this.engine()) {
-      case 'postgres': return 'postgres';
-      case 'mysql':    return 'mysql';
-      case 'mongo':    return 'admin';
-      default:         return 'default';
+      case 'postgres':
+        return 'postgres';
+      case 'mysql':
+        return 'mysql';
+      case 'mongo':
+        return 'admin';
+      default:
+        return 'default';
     }
   });
 
@@ -202,19 +241,35 @@ export class Create {
   protected readonly userNameErrors = computed(() =>
     this.users().map((u) => this.nameError(u.name, { required: true })),
   );
-  protected readonly rootPasswordError = computed(() => this.passwordError(this.customRootPassword()));
+  protected readonly rootPasswordError = computed(() =>
+    this.passwordError(this.customRootPassword()),
+  );
   protected readonly userPasswordErrors = computed(() =>
     this.userPasswords().map((p) => this.passwordError(p)),
   );
 
   protected readonly canNext = computed(() => {
     switch (this.step()) {
-      case 1: return !!this.engine();
-      case 2: return !!this.version() && !this.displayNameError() && (!this.supportsDatabaseNaming() || !this.defaultDbError()) && !this.rootPasswordError();
-      case 3: return true;  // Plugins are always optional
-      case 4: return !this.supportsDatabaseNaming() || this.databaseErrors().every((e) => e === null);
-      case 5: return this.userNameErrors().every((e) => e === null) && this.userPasswordErrors().every((e) => e === null);
-      default: return true;
+      case 1:
+        return !!this.engine();
+      case 2:
+        return (
+          !!this.version() &&
+          !this.displayNameError() &&
+          (!this.supportsDatabaseNaming() || !this.defaultDbError()) &&
+          !this.rootPasswordError()
+        );
+      case 3:
+        return true; // Plugins are always optional
+      case 4:
+        return !this.supportsDatabaseNaming() || this.databaseErrors().every((e) => e === null);
+      case 5:
+        return (
+          this.userNameErrors().every((e) => e === null) &&
+          this.userPasswordErrors().every((e) => e === null)
+        );
+      default:
+        return true;
     }
   });
 
@@ -222,6 +277,12 @@ export class Create {
     this.api.apiDatabaseSupportedGet().subscribe({
       next: (s) => this.supported.set(s),
       error: (err) => this.error.set(messageOf(err)),
+    });
+
+    // Offer connected nodes as provisioning targets; the picker is hidden when none are online.
+    this.nodesApi.apiNodesGet().subscribe({
+      next: (nodes) => this.onlineNodes.set(nodes.filter((n) => n.online)),
+      error: () => this.onlineNodes.set([]),
     });
 
     effect(() => {
@@ -235,7 +296,8 @@ export class Create {
   protected togglePlugin(key: string): void {
     this.selectedPlugins.update((curr) => {
       const next = new Set(curr);
-      if (next.has(key)) next.delete(key); else next.add(key);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
       return next;
     });
   }
@@ -246,24 +308,42 @@ export class Create {
 
   protected engineIcon(key: string): string {
     switch (key) {
-      case 'postgres': return 'simplePostgresql';
-      case 'mysql':    return 'simpleMysql';
-      case 'mongo':    return 'simpleMongodb';
-      case 'mariadb':     return 'simpleMariadb';
-      case 'timescaledb': return 'simpleTimescale';
-      case 'redis':       return 'simpleRedis';
-      case 'cockroachdb': return 'simpleCockroachlabs';
-      case 'clickhouse':  return 'simpleClickhouse';
-      case 'cassandra':   return 'simpleApachecassandra';
-      case 'couchdb':     return 'simpleApachecouchdb';
-      case 'pgvector':    return 'simplePostgresql';
-      case 'neo4j':       return 'simpleNeo4j';
-      case 'qdrant':      return 'customQdrant';
-      case 'valkey':      return 'customValkey';
-      case 'mssql':       return 'customMssql';
-      case 'seaweedfs':       return 'customSeaweedfs';
-      case 'azurite':       return 'customAzurite';
-      default:         return 'lucideDatabase';
+      case 'postgres':
+        return 'simplePostgresql';
+      case 'mysql':
+        return 'simpleMysql';
+      case 'mongo':
+        return 'simpleMongodb';
+      case 'mariadb':
+        return 'simpleMariadb';
+      case 'timescaledb':
+        return 'simpleTimescale';
+      case 'redis':
+        return 'simpleRedis';
+      case 'cockroachdb':
+        return 'simpleCockroachlabs';
+      case 'clickhouse':
+        return 'simpleClickhouse';
+      case 'cassandra':
+        return 'simpleApachecassandra';
+      case 'couchdb':
+        return 'simpleApachecouchdb';
+      case 'pgvector':
+        return 'simplePostgresql';
+      case 'neo4j':
+        return 'simpleNeo4j';
+      case 'qdrant':
+        return 'customQdrant';
+      case 'valkey':
+        return 'customValkey';
+      case 'mssql':
+        return 'customMssql';
+      case 'seaweedfs':
+        return 'customSeaweedfs';
+      case 'azurite':
+        return 'customAzurite';
+      default:
+        return 'lucideDatabase';
     }
   }
 
@@ -355,7 +435,9 @@ export class Create {
       version: this.version()!,
       displayName: this.displayName().trim(),
       defaultDatabaseName: this.defaultDbName().trim() || null,
-      databases: this.databases().map((d) => d.trim()).filter((d) => d !== ''),
+      databases: this.databases()
+        .map((d) => d.trim())
+        .filter((d) => d !== ''),
       users: this.users().map((u, i) => ({
         name: u.name.trim(),
         grantDatabases: u.grantDatabases,
@@ -364,6 +446,7 @@ export class Create {
       plugins: Array.from(this.selectedPlugins()),
       isPublic: this.isPublic(),
       password: this.customRootPassword().trim() || null,
+      nodeId: this.selectedNodeId(),
     };
 
     this.api.apiDatabaseProvisionPost(payload).subscribe({
@@ -388,7 +471,8 @@ export class Create {
 // a real i18n library here.
 function pluralize(term: string): string {
   if (term.endsWith('y')) return term.slice(0, -1) + 'ies';
-  if (term.endsWith('x') || term.endsWith('s') || term.endsWith('ch') || term.endsWith('sh')) return term + 'es';
+  if (term.endsWith('x') || term.endsWith('s') || term.endsWith('ch') || term.endsWith('sh'))
+    return term + 'es';
   return term + 's';
 }
 

--- a/src/KRINT.Frontend/src/app/databases/databases.html
+++ b/src/KRINT.Frontend/src/app/databases/databases.html
@@ -14,7 +14,14 @@
         <ng-icon name="lucideLink" size="16" />
         Register external
       </button>
-      <button hlmBtn variant="outline" size="sm" type="button" (click)="reload()" [disabled]="store.loading()">
+      <button
+        hlmBtn
+        variant="outline"
+        size="sm"
+        type="button"
+        (click)="reload()"
+        [disabled]="store.loading()"
+      >
         {{ store.loading() ? 'Loading…' : 'Refresh' }}
       </button>
     </div>
@@ -27,7 +34,9 @@
       </div>
     }
     @if (store.isEmpty()) {
-      <p class="text-muted-foreground p-4 text-sm">No instances yet. Click <strong>Create</strong> to provision one.</p>
+      <p class="text-muted-foreground p-4 text-sm">
+        No instances yet. Click <strong>Create</strong> to provision one.
+      </p>
     } @else {
       <table hlmTable>
         <thead hlmTableHeader>
@@ -52,23 +61,57 @@
                     <span class="text-sm font-medium inline-flex items-center gap-2">
                       {{ db.displayName }}
                       @if (!db.isManaged) {
-                        <span hlmBadge variant="outline" class="text-[10px] uppercase tracking-wide">External</span>
+                        <span hlmBadge variant="outline" class="text-[10px] uppercase tracking-wide"
+                          >External</span
+                        >
                       }
                       @if (db.isConfigManaged) {
-                        <span hlmBadge variant="outline" class="text-[10px] uppercase tracking-wide" hlmTooltip="Owned by instances.yaml. Edit the file and restart KRINT to change.">Config</span>
+                        <span
+                          hlmBadge
+                          variant="outline"
+                          class="text-[10px] uppercase tracking-wide"
+                          hlmTooltip="Owned by instances.yaml. Edit the file and restart KRINT to change."
+                          >Config</span
+                        >
+                      }
+                      @if (db.nodeId) {
+                        <span
+                          hlmBadge
+                          variant="secondary"
+                          class="text-[10px] normal-case"
+                          [hlmTooltip]="'Runs on node ' + nodeName(db.nodeId)"
+                        >
+                          <ng-icon name="lucideNetwork" size="11" class="mr-1" />{{
+                            nodeName(db.nodeId)
+                          }}
+                        </span>
                       }
                       @if (db.isManaged && db.containerName) {
                         @if (db.isPublic) {
-                          <ng-icon name="lucideGlobe" size="14" class="text-amber-500" [hlmTooltip]="'Published on 0.0.0.0 - visible on the LAN'" />
+                          <ng-icon
+                            name="lucideGlobe"
+                            size="14"
+                            class="text-amber-500"
+                            [hlmTooltip]="'Published on 0.0.0.0 - visible on the LAN'"
+                          />
                         } @else {
-                          <ng-icon name="lucideLock" size="14" class="text-muted-foreground" [hlmTooltip]="'Bound to 127.0.0.1 - localhost only'" />
+                          <ng-icon
+                            name="lucideLock"
+                            size="14"
+                            class="text-muted-foreground"
+                            [hlmTooltip]="'Bound to 127.0.0.1 - localhost only'"
+                          />
                         }
                       }
                       @if (db.containerName && db.state && db.state !== 'running') {
-                        <span hlmBadge variant="secondary" class="text-[10px] uppercase">{{ db.state }}</span>
+                        <span hlmBadge variant="secondary" class="text-[10px] uppercase">{{
+                          db.state
+                        }}</span>
                       }
                       @if (store.lifecycleBusy() === db.id) {
-                        <span hlmBadge variant="outline" class="text-[10px] normal-case">working...</span>
+                        <span hlmBadge variant="outline" class="text-[10px] normal-case"
+                          >working...</span
+                        >
                       }
                     </span>
                     <span class="text-muted-foreground text-[10px] uppercase">{{ db.engine }}</span>
@@ -119,11 +162,19 @@
                         <ng-icon name="lucideClipboardCopy" />
                         Copy as YAML
                       </button>
-                      <button hlmDropdownMenuItem (click)="upgradeInstance(db)" [disabled]="!db.isManaged || db.isConfigManaged">
+                      <button
+                        hlmDropdownMenuItem
+                        (click)="upgradeInstance(db)"
+                        [disabled]="!db.isManaged || db.isConfigManaged"
+                      >
                         <ng-icon name="lucideArrowUpCircle" />
                         Upgrade version
                       </button>
-                      <button hlmDropdownMenuItem (click)="toggleVisibility(db)" [disabled]="!db.isManaged || db.isConfigManaged">
+                      <button
+                        hlmDropdownMenuItem
+                        (click)="toggleVisibility(db)"
+                        [disabled]="!db.isManaged || db.isConfigManaged"
+                      >
                         @if (db.isPublic) {
                           <ng-icon name="lucideLock" />
                           Lock to localhost
@@ -133,18 +184,38 @@
                         }
                       </button>
                       @if (db.state === 'running') {
-                        <button hlmDropdownMenuItem (click)="stopInstance(db)" [disabled]="!db.containerName || db.isConfigManaged || store.lifecycleBusy() === db.id">
+                        <button
+                          hlmDropdownMenuItem
+                          (click)="stopInstance(db)"
+                          [disabled]="
+                            !db.containerName ||
+                            db.isConfigManaged ||
+                            store.lifecycleBusy() === db.id
+                          "
+                        >
                           <ng-icon name="lucideSquare" />
                           Stop
                         </button>
                       } @else {
-                        <button hlmDropdownMenuItem (click)="startInstance(db)" [disabled]="!db.containerName || db.isConfigManaged || store.lifecycleBusy() === db.id">
+                        <button
+                          hlmDropdownMenuItem
+                          (click)="startInstance(db)"
+                          [disabled]="
+                            !db.containerName ||
+                            db.isConfigManaged ||
+                            store.lifecycleBusy() === db.id
+                          "
+                        >
                           <ng-icon name="lucidePlay" />
                           Start
                         </button>
                       }
                       <hlm-dropdown-menu-separator />
-                      <button hlmDropdownMenuItem (click)="deleteInstance(db)" [disabled]="db.isConfigManaged">
+                      <button
+                        hlmDropdownMenuItem
+                        (click)="deleteInstance(db)"
+                        [disabled]="db.isConfigManaged"
+                      >
                         <ng-icon name="lucideTrash2" />
                         Delete
                       </button>

--- a/src/KRINT.Frontend/src/app/databases/databases.ts
+++ b/src/KRINT.Frontend/src/app/databases/databases.ts
@@ -1,8 +1,36 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { lucideArrowUpCircle, lucideBrain, lucideClipboardCopy, lucideDatabase, lucideEllipsisVertical, lucideEye, lucideGlobe, lucideLink, lucideLock, lucidePencil, lucidePlay, lucidePlus, lucideSquare, lucideTrash2 } from '@ng-icons/lucide';
-import { simpleApachecassandra, simpleApachecouchdb, simpleClickhouse, simpleCockroachlabs, simpleMariadb, simpleMongodb, simpleMysql, simpleNeo4j, simplePostgresql, simpleRedis, simpleTimescale } from '@ng-icons/simple-icons';
+import {
+  lucideArrowUpCircle,
+  lucideBrain,
+  lucideClipboardCopy,
+  lucideDatabase,
+  lucideEllipsisVertical,
+  lucideEye,
+  lucideGlobe,
+  lucideLink,
+  lucideLock,
+  lucideNetwork,
+  lucidePencil,
+  lucidePlay,
+  lucidePlus,
+  lucideSquare,
+  lucideTrash2,
+} from '@ng-icons/lucide';
+import {
+  simpleApachecassandra,
+  simpleApachecouchdb,
+  simpleClickhouse,
+  simpleCockroachlabs,
+  simpleMariadb,
+  simpleMongodb,
+  simpleMysql,
+  simpleNeo4j,
+  simplePostgresql,
+  simpleRedis,
+  simpleTimescale,
+} from '@ng-icons/simple-icons';
 import { HlmBadgeImports } from '@spartan-ng/helm/badge';
 import { HlmButtonImports } from '@spartan-ng/helm/button';
 import { HlmCardImports } from '@spartan-ng/helm/card';
@@ -12,10 +40,17 @@ import { HlmTableImports } from '@spartan-ng/helm/table';
 import { HlmTooltipImports } from '@spartan-ng/helm/tooltip';
 import { ContentHeader } from '../shared/components/content-header/content-header';
 import { ConfirmService } from '../shared/components/confirm-dialog/confirm-dialog';
-import { customAzurite, customMssql, customQdrant, customSeaweedfs, customValkey } from '../shared/icons/custom-icons';
+import {
+  customAzurite,
+  customMssql,
+  customQdrant,
+  customSeaweedfs,
+  customValkey,
+} from '../shared/icons/custom-icons';
 import { DatabaseInstanceDto } from '../api/model/databaseInstanceDto';
 import { DatabasesStore } from '../shared/stores/databases.store';
 import { DatabaseService } from '../api/api/database.service';
+import { NodesService } from '../api/api/nodes.service';
 import { DatabaseDetailsDialog } from './database-details-dialog';
 import { DatabaseEditDialog } from './database-edit-dialog';
 import { DatabaseExportYamlDialog } from './database-export-yaml-dialog';
@@ -46,6 +81,7 @@ import { DatabaseUpgradeDialog } from './database-upgrade-dialog';
       lucideGlobe,
       lucideLink,
       lucideLock,
+      lucideNetwork,
       lucidePencil,
       lucidePlay,
       lucidePlus,
@@ -77,6 +113,21 @@ export class Databases {
   private readonly dialog = inject(HlmDialogService);
   private readonly confirmService = inject(ConfirmService);
   private readonly api = inject(DatabaseService);
+  private readonly nodesApi = inject(NodesService);
+
+  // Map of node id -> display name so node-hosted instances can show the node's name in a badge.
+  private readonly nodeNames = signal<Record<string, string>>({});
+
+  constructor() {
+    this.nodesApi.apiNodesGet().subscribe({
+      next: (nodes) => this.nodeNames.set(Object.fromEntries(nodes.map((n) => [n.id, n.name]))),
+      error: () => this.nodeNames.set({}),
+    });
+  }
+
+  protected nodeName(id: string): string {
+    return this.nodeNames()[id] ?? 'node';
+  }
 
   protected viewDetails(id: string): void {
     this.dialog.open(DatabaseDetailsDialog, {
@@ -87,7 +138,12 @@ export class Databases {
 
   protected editInstance(db: DatabaseInstanceDto): void {
     this.dialog.open(DatabaseEditDialog, {
-      context: { id: db.id, engine: db.engine, containerName: db.containerName ?? db.displayName, displayName: db.displayName },
+      context: {
+        id: db.id,
+        engine: db.engine,
+        containerName: db.containerName ?? db.displayName,
+        displayName: db.displayName,
+      },
       contentClass: 'sm:max-w-[640px]',
     });
   }
@@ -115,7 +171,12 @@ export class Databases {
     // declared state - so we gate it on IsManaged, not on container presence.
     if (!db.isManaged || !db.containerName) return;
     this.dialog.open(DatabaseUpgradeDialog, {
-      context: { id: db.id, engine: db.engine, containerName: db.containerName, currentVersion: db.version },
+      context: {
+        id: db.id,
+        engine: db.engine,
+        containerName: db.containerName,
+        currentVersion: db.version,
+      },
       contentClass: 'sm:max-w-[480px]',
     });
   }
@@ -170,24 +231,42 @@ export class Databases {
 
   protected engineIcon(engine: string): string {
     switch (engine) {
-      case 'postgres': return 'simplePostgresql';
-      case 'mysql':    return 'simpleMysql';
-      case 'mongo':    return 'simpleMongodb';
-      case 'mariadb':     return 'simpleMariadb';
-      case 'timescaledb': return 'simpleTimescale';
-      case 'redis':       return 'simpleRedis';
-      case 'cockroachdb': return 'simpleCockroachlabs';
-      case 'clickhouse':  return 'simpleClickhouse';
-      case 'cassandra':   return 'simpleApachecassandra';
-      case 'couchdb':     return 'simpleApachecouchdb';
-      case 'pgvector':    return 'simplePostgresql';
-      case 'neo4j':       return 'simpleNeo4j';
-      case 'qdrant':      return 'customQdrant';
-      case 'valkey':      return 'customValkey';
-      case 'mssql':       return 'customMssql';
-      case 'seaweedfs':       return 'customSeaweedfs';
-      case 'azurite':       return 'customAzurite';
-      default:         return 'lucideDatabase';
+      case 'postgres':
+        return 'simplePostgresql';
+      case 'mysql':
+        return 'simpleMysql';
+      case 'mongo':
+        return 'simpleMongodb';
+      case 'mariadb':
+        return 'simpleMariadb';
+      case 'timescaledb':
+        return 'simpleTimescale';
+      case 'redis':
+        return 'simpleRedis';
+      case 'cockroachdb':
+        return 'simpleCockroachlabs';
+      case 'clickhouse':
+        return 'simpleClickhouse';
+      case 'cassandra':
+        return 'simpleApachecassandra';
+      case 'couchdb':
+        return 'simpleApachecouchdb';
+      case 'pgvector':
+        return 'simplePostgresql';
+      case 'neo4j':
+        return 'simpleNeo4j';
+      case 'qdrant':
+        return 'customQdrant';
+      case 'valkey':
+        return 'customValkey';
+      case 'mssql':
+        return 'customMssql';
+      case 'seaweedfs':
+        return 'customSeaweedfs';
+      case 'azurite':
+        return 'customAzurite';
+      default:
+        return 'lucideDatabase';
     }
   }
 

--- a/src/KRINT.Frontend/src/app/nodes/nodes.ts
+++ b/src/KRINT.Frontend/src/app/nodes/nodes.ts
@@ -64,7 +64,7 @@ import { NodeDto } from '../api/model/nodeDto';
               </tr>
             </thead>
             <tbody hlmTableBody>
-              @for (n of nodes(); track n.connectionId) {
+              @for (n of nodes(); track n.id) {
                 <tr hlmTableRow>
                   <td hlmTableCell class="font-medium">{{ n.name }}</td>
                   <td hlmTableCell>
@@ -78,14 +78,14 @@ import { NodeDto } from '../api/model/nodeDto';
                   <td hlmTableCell class="max-w-xs truncate text-xs" [title]="n.os">{{ n.os }}</td>
                   <td hlmTableCell class="font-mono text-xs">{{ n.dockerVersion }}</td>
                   <td hlmTableCell class="font-mono text-xs">
-                    {{ n.connectedAt | date: 'HH:mm:ss' }}
+                    {{ n.firstSeenAt | date: 'HH:mm:ss' }}
                   </td>
                   <td hlmTableCell class="font-mono text-xs">
                     {{ n.lastSeenAt | date: 'HH:mm:ss' }}
                   </td>
                   <td hlmTableCell class="text-right">
                     <div class="flex items-center justify-end gap-2">
-                      @if (pingResults()[n.connectionId]; as result) {
+                      @if (pingResults()[n.id]; as result) {
                         <span class="text-muted-foreground text-xs">{{ result }}</span>
                       }
                       <button
@@ -93,10 +93,10 @@ import { NodeDto } from '../api/model/nodeDto';
                         variant="outline"
                         size="sm"
                         type="button"
-                        [disabled]="pinging()[n.connectionId]"
-                        (click)="ping(n.connectionId)"
+                        [disabled]="pinging()[n.id]"
+                        (click)="ping(n.id)"
                       >
-                        {{ pinging()[n.connectionId] ? '…' : 'Ping' }}
+                        {{ pinging()[n.id] ? '…' : 'Ping' }}
                       </button>
                     </div>
                   </td>
@@ -146,19 +146,19 @@ export class Nodes {
     });
   }
 
-  protected ping(connectionId: string): void {
-    this.pinging.update((p) => ({ ...p, [connectionId]: true }));
-    this.api.apiNodesConnectionIdPingPost(connectionId).subscribe({
+  protected ping(id: string): void {
+    this.pinging.update((p) => ({ ...p, [id]: true }));
+    this.api.apiNodesIdPingPost(id).subscribe({
       next: (result) => {
         // roundTripMs is an integer the generator types as an opaque interface (.NET emits every
         // numeric as integer|string); coerce it for display.
         const ms = Number(result.roundTripMs as unknown);
-        this.pingResults.update((r) => ({ ...r, [connectionId]: `${result.reply} · ${ms}ms` }));
-        this.pinging.update((p) => ({ ...p, [connectionId]: false }));
+        this.pingResults.update((r) => ({ ...r, [id]: `${result.reply} · ${ms}ms` }));
+        this.pinging.update((p) => ({ ...p, [id]: false }));
       },
       error: () => {
-        this.pingResults.update((r) => ({ ...r, [connectionId]: 'unreachable' }));
-        this.pinging.update((p) => ({ ...p, [connectionId]: false }));
+        this.pingResults.update((r) => ({ ...r, [id]: 'unreachable' }));
+        this.pinging.update((p) => ({ ...p, [id]: false }));
       },
     });
   }

--- a/src/KRINT.Infrastructure.Migrations.Sqlite/Migrations/20260625173434_AddNodesAndDatabaseInstanceNodeId.Designer.cs
+++ b/src/KRINT.Infrastructure.Migrations.Sqlite/Migrations/20260625173434_AddNodesAndDatabaseInstanceNodeId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using KRINT.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace KRINT.Infrastructure.Migrations.Sqlite.Migrations
 {
     [DbContext(typeof(KrintDbContext))]
-    partial class KrintDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260625173434_AddNodesAndDatabaseInstanceNodeId")]
+    partial class AddNodesAndDatabaseInstanceNodeId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.8");

--- a/src/KRINT.Infrastructure.Migrations.Sqlite/Migrations/20260625173434_AddNodesAndDatabaseInstanceNodeId.cs
+++ b/src/KRINT.Infrastructure.Migrations.Sqlite/Migrations/20260625173434_AddNodesAndDatabaseInstanceNodeId.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace KRINT.Infrastructure.Migrations.Sqlite.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNodesAndDatabaseInstanceNodeId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "NodeId",
+                table: "DatabaseInstances",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "Nodes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", nullable: false),
+                    MachineName = table.Column<string>(type: "TEXT", nullable: false),
+                    Os = table.Column<string>(type: "TEXT", nullable: false),
+                    DockerVersion = table.Column<string>(type: "TEXT", nullable: false),
+                    LastSeenAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Nodes", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Nodes");
+
+            migrationBuilder.DropColumn(
+                name: "NodeId",
+                table: "DatabaseInstances");
+        }
+    }
+}

--- a/src/KRINT.Infrastructure/Extensions/InnerDatabasesExtensions.cs
+++ b/src/KRINT.Infrastructure/Extensions/InnerDatabasesExtensions.cs
@@ -115,10 +115,12 @@ namespace KRINT.Infrastructure.Extensions
         IInnerSchemaService Resolve(string engine);
     }
 
-    internal sealed class InnerSchemaServiceResolver(IEnumerable<IInnerSchemaService> services) : IInnerSchemaServiceResolver
+    internal sealed class InnerSchemaServiceResolver(IEnumerable<IInnerSchemaService> services, INodeRpc rpc) : IInnerSchemaServiceResolver
     {
+        // Each engine service is wrapped so node-hosted targets dispatch over SignalR; local targets
+        // run in-process unchanged.
         private readonly Dictionary<string, IInnerSchemaService> _byEngine =
-            services.ToDictionary(s => s.Engine, StringComparer.OrdinalIgnoreCase);
+            services.ToDictionary(s => s.Engine, s => (IInnerSchemaService)new RoutingInnerSchemaService(s, rpc), StringComparer.OrdinalIgnoreCase);
 
         public IInnerSchemaService Resolve(string engine) =>
             _byEngine.TryGetValue(engine, out var svc)
@@ -131,10 +133,10 @@ namespace KRINT.Infrastructure.Extensions
         IInnerDatabaseService Resolve(string engine);
     }
 
-    internal sealed class InnerDatabaseServiceResolver(IEnumerable<IInnerDatabaseService> services) : IInnerDatabaseServiceResolver
+    internal sealed class InnerDatabaseServiceResolver(IEnumerable<IInnerDatabaseService> services, INodeRpc rpc) : IInnerDatabaseServiceResolver
     {
         private readonly Dictionary<string, IInnerDatabaseService> _byEngine =
-            services.ToDictionary(s => s.Engine, StringComparer.OrdinalIgnoreCase);
+            services.ToDictionary(s => s.Engine, s => (IInnerDatabaseService)new RoutingInnerDatabaseService(s, rpc), StringComparer.OrdinalIgnoreCase);
 
         public IInnerDatabaseService Resolve(string engine) =>
             _byEngine.TryGetValue(engine, out var svc)
@@ -148,10 +150,10 @@ namespace KRINT.Infrastructure.Extensions
         bool IsSupported(string engine);
     }
 
-    internal sealed class InnerQueryServiceResolver(IEnumerable<IInnerQueryService> services) : IInnerQueryServiceResolver
+    internal sealed class InnerQueryServiceResolver(IEnumerable<IInnerQueryService> services, INodeRpc rpc) : IInnerQueryServiceResolver
     {
         private readonly Dictionary<string, IInnerQueryService> _byEngine =
-            services.ToDictionary(s => s.Engine, StringComparer.OrdinalIgnoreCase);
+            services.ToDictionary(s => s.Engine, s => (IInnerQueryService)new RoutingInnerQueryService(s, rpc), StringComparer.OrdinalIgnoreCase);
 
         // Soft resolve: query console is opt-in per engine. The API returns 400 with a clear
         // message when the engine has no console driver, rather than 500-ing.
@@ -165,10 +167,10 @@ namespace KRINT.Infrastructure.Extensions
         IInnerUserService Resolve(string engine);
     }
 
-    internal sealed class InnerUserServiceResolver(IEnumerable<IInnerUserService> services) : IInnerUserServiceResolver
+    internal sealed class InnerUserServiceResolver(IEnumerable<IInnerUserService> services, INodeRpc rpc) : IInnerUserServiceResolver
     {
         private readonly Dictionary<string, IInnerUserService> _byEngine =
-            services.ToDictionary(s => s.Engine, StringComparer.OrdinalIgnoreCase);
+            services.ToDictionary(s => s.Engine, s => (IInnerUserService)new RoutingInnerUserService(s, rpc), StringComparer.OrdinalIgnoreCase);
 
         public IInnerUserService Resolve(string engine) =>
             _byEngine.TryGetValue(engine, out var svc)

--- a/src/KRINT.Infrastructure/Interfaces/IDockerServiceResolver.cs
+++ b/src/KRINT.Infrastructure/Interfaces/IDockerServiceResolver.cs
@@ -1,0 +1,10 @@
+namespace KRINT.Infrastructure.Interfaces
+{
+    /// <summary>Picks the right <see cref="IDockerService"/> for an instance: the local Docker daemon
+    /// when <paramref name="nodeId"/> is null, or a remote service that dispatches each call to that
+    /// node over SignalR (the node runs it on its own daemon and returns the result).</summary>
+    public interface IDockerServiceResolver
+    {
+        IDockerService Resolve(Guid? nodeId);
+    }
+}

--- a/src/KRINT.Infrastructure/Interfaces/IInnerDatabaseService.cs
+++ b/src/KRINT.Infrastructure/Interfaces/IInnerDatabaseService.cs
@@ -1,6 +1,9 @@
 namespace KRINT.Infrastructure.Interfaces
 {
-    public record InnerDatabaseTarget(string Engine, string Host, int Port, string Username, string Password, string DefaultDatabase);
+    /// <summary>Connection details for an instance's database. <see cref="NodeId"/> is set when the
+    /// instance runs on a remote node: the inner-service resolvers then dispatch the operation to that
+    /// node (which runs it against its own loopback) instead of connecting locally.</summary>
+    public record InnerDatabaseTarget(string Engine, string Host, int Port, string Username, string Password, string DefaultDatabase, Guid? NodeId = null);
 
     public interface IInnerDatabaseService
     {

--- a/src/KRINT.Infrastructure/Interfaces/INodeRpc.cs
+++ b/src/KRINT.Infrastructure/Interfaces/INodeRpc.cs
@@ -1,0 +1,11 @@
+namespace KRINT.Infrastructure.Interfaces
+{
+    /// <summary>Dispatches a typed request/response call to a node over its live SignalR connection.
+    /// Implemented in the API layer (which owns the hub); the inner-service routing wrappers depend
+    /// only on this abstraction so they can stay in Infrastructure. On a node process this is a stub
+    /// that is never invoked (node-side targets never carry a NodeId).</summary>
+    public interface INodeRpc
+    {
+        Task<T> InvokeAsync<T>(Guid nodeId, string method, object?[] args, CancellationToken cancellationToken);
+    }
+}

--- a/src/KRINT.Infrastructure/KrintDbContext.cs
+++ b/src/KRINT.Infrastructure/KrintDbContext.cs
@@ -12,6 +12,7 @@ namespace KRINT.Infrastructure
         public DbSet<ActivityEntry> ActivityEntries => Set<ActivityEntry>();
         public DbSet<BackupEntry> BackupEntries => Set<BackupEntry>();
         public DbSet<BackupSchedule> BackupSchedules => Set<BackupSchedule>();
+        public DbSet<Node> Nodes => Set<Node>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/src/KRINT.Infrastructure/Migrations/20260625173409_AddNodesAndDatabaseInstanceNodeId.Designer.cs
+++ b/src/KRINT.Infrastructure/Migrations/20260625173409_AddNodesAndDatabaseInstanceNodeId.Designer.cs
@@ -3,51 +3,59 @@ using System;
 using KRINT.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace KRINT.Infrastructure.Migrations.Sqlite.Migrations
+namespace KRINT.Infrastructure.Migrations
 {
     [DbContext(typeof(KrintDbContext))]
-    partial class KrintDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260625173409_AddNodesAndDatabaseInstanceNodeId")]
+    partial class AddNodesAndDatabaseInstanceNodeId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "10.0.8");
+            modelBuilder
+                .HasAnnotation("ProductVersion", "10.0.8")
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
+
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("KRINT.Domain.ActivityEntry", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Action")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ActorName")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Details")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Engine")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<Guid?>("InstanceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Target")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("UpdatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -58,35 +66,35 @@ namespace KRINT.Infrastructure.Migrations.Sqlite.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Engine")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("EngineVersion")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("FileName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("FilePath")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<Guid>("InstanceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<long>("SizeBytes")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("bigint");
 
                     b.Property<DateTime>("UpdatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -97,39 +105,39 @@ namespace KRINT.Infrastructure.Migrations.Sqlite.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("CronExpression")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Description")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<Guid>("InstanceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("LastError")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("LastRunAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("LastStatus")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("NextRunAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("UpdatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -140,64 +148,64 @@ namespace KRINT.Infrastructure.Migrations.Sqlite.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("ContainerId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContainerName")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("DatabaseName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("DisplayName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Engine")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Host")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsConfigManaged")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsManaged")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsPublic")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("boolean");
 
                     b.Property<Guid?>("MigratedToInstanceId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<Guid?>("NodeId")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<int>("Port")
-                        .HasColumnType("INTEGER");
+                        .HasColumnType("integer");
 
                     b.Property<string>("PreviousVersion")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("UpdatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Username")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Version")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -212,32 +220,32 @@ namespace KRINT.Infrastructure.Migrations.Sqlite.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("DockerVersion")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("LastSeenAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("MachineName")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<string>("Os")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<DateTime>("UpdatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 
@@ -248,29 +256,29 @@ namespace KRINT.Infrastructure.Migrations.Sqlite.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("uuid");
 
                     b.Property<byte[]>("Ciphertext")
                         .IsRequired()
-                        .HasColumnType("BLOB");
+                        .HasColumnType("bytea");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("TEXT");
+                        .HasColumnType("text");
 
                     b.Property<byte[]>("Nonce")
                         .IsRequired()
-                        .HasColumnType("BLOB");
+                        .HasColumnType("bytea");
 
                     b.Property<byte[]>("Tag")
                         .IsRequired()
-                        .HasColumnType("BLOB");
+                        .HasColumnType("bytea");
 
                     b.Property<DateTime>("UpdatedAt")
-                        .HasColumnType("TEXT");
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
 

--- a/src/KRINT.Infrastructure/Migrations/20260625173409_AddNodesAndDatabaseInstanceNodeId.cs
+++ b/src/KRINT.Infrastructure/Migrations/20260625173409_AddNodesAndDatabaseInstanceNodeId.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace KRINT.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNodesAndDatabaseInstanceNodeId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "NodeId",
+                table: "DatabaseInstances",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "Nodes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "text", nullable: false),
+                    MachineName = table.Column<string>(type: "text", nullable: false),
+                    Os = table.Column<string>(type: "text", nullable: false),
+                    DockerVersion = table.Column<string>(type: "text", nullable: false),
+                    LastSeenAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Nodes", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Nodes");
+
+            migrationBuilder.DropColumn(
+                name: "NodeId",
+                table: "DatabaseInstances");
+        }
+    }
+}

--- a/src/KRINT.Infrastructure/Migrations/KrintDbContextModelSnapshot.cs
+++ b/src/KRINT.Infrastructure/Migrations/KrintDbContextModelSnapshot.cs
@@ -184,6 +184,9 @@ namespace KRINT.Infrastructure.Migrations
                     b.Property<Guid?>("MigratedToInstanceId")
                         .HasColumnType("uuid");
 
+                    b.Property<Guid?>("NodeId")
+                        .HasColumnType("uuid");
+
                     b.Property<int>("Port")
                         .HasColumnType("integer");
 
@@ -208,6 +211,42 @@ namespace KRINT.Infrastructure.Migrations
                         .HasFilter("\"ContainerName\" IS NOT NULL");
 
                     b.ToTable("DatabaseInstances");
+                });
+
+            modelBuilder.Entity("KRINT.Domain.Node", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("DockerVersion")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<DateTime>("LastSeenAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("MachineName")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("Os")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<DateTime>("UpdatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Nodes");
                 });
 
             modelBuilder.Entity("KRINT.Domain.Secret", b =>

--- a/src/KRINT.Infrastructure/Services/NodeRoutingInnerServices.cs
+++ b/src/KRINT.Infrastructure/Services/NodeRoutingInnerServices.cs
@@ -1,0 +1,88 @@
+using KRINT.Infrastructure.Interfaces;
+
+namespace KRINT.Infrastructure.Services
+{
+    // Each wrapper decorates the local engine service. When the target carries a NodeId the call is
+    // dispatched to that node over SignalR (it runs the same engine service against its own loopback
+    // and returns the DTO); otherwise it runs locally as before. The NodeId is stripped from the wire
+    // payload so the node executes locally instead of re-routing. Void engine ops map to a bool result
+    // because SignalR client-result invocations must return a value.
+
+    internal static class NodeRouting
+    {
+        public static InnerDatabaseTarget Wire(InnerDatabaseTarget t) => t with { NodeId = null };
+    }
+
+    internal sealed class RoutingInnerDatabaseService(IInnerDatabaseService local, INodeRpc rpc) : IInnerDatabaseService
+    {
+        public string Engine => local.Engine;
+
+        public Task<IReadOnlyList<string>> ListAsync(InnerDatabaseTarget t, CancellationToken ct = default)
+            => t.NodeId is { } n ? rpc.InvokeAsync<IReadOnlyList<string>>(n, "Db.List", [NodeRouting.Wire(t)], ct) : local.ListAsync(t, ct);
+
+        public Task CreateAsync(InnerDatabaseTarget t, string name, CancellationToken ct = default)
+            => t.NodeId is { } n ? rpc.InvokeAsync<bool>(n, "Db.Create", [NodeRouting.Wire(t), name], ct) : local.CreateAsync(t, name, ct);
+
+        public Task DropAsync(InnerDatabaseTarget t, string name, CancellationToken ct = default)
+            => t.NodeId is { } n ? rpc.InvokeAsync<bool>(n, "Db.Drop", [NodeRouting.Wire(t), name], ct) : local.DropAsync(t, name, ct);
+    }
+
+    internal sealed class RoutingInnerUserService(IInnerUserService local, INodeRpc rpc) : IInnerUserService
+    {
+        public string Engine => local.Engine;
+
+        public Task<IReadOnlyList<string>> ListAsync(InnerDatabaseTarget t, CancellationToken ct = default)
+            => t.NodeId is { } n ? rpc.InvokeAsync<IReadOnlyList<string>>(n, "User.List", [NodeRouting.Wire(t)], ct) : local.ListAsync(t, ct);
+
+        public Task CreateAsync(InnerDatabaseTarget t, string name, string password, CancellationToken ct = default)
+            => t.NodeId is { } n ? rpc.InvokeAsync<bool>(n, "User.Create", [NodeRouting.Wire(t), name, password], ct) : local.CreateAsync(t, name, password, ct);
+
+        public Task DeleteAsync(InnerDatabaseTarget t, string name, CancellationToken ct = default)
+            => t.NodeId is { } n ? rpc.InvokeAsync<bool>(n, "User.Delete", [NodeRouting.Wire(t), name], ct) : local.DeleteAsync(t, name, ct);
+
+        public Task ResetPasswordAsync(InnerDatabaseTarget t, string name, string newPassword, CancellationToken ct = default)
+            => t.NodeId is { } n ? rpc.InvokeAsync<bool>(n, "User.ResetPassword", [NodeRouting.Wire(t), name, newPassword], ct) : local.ResetPasswordAsync(t, name, newPassword, ct);
+
+        public Task GrantAccessAsync(InnerDatabaseTarget t, string user, string database, CancellationToken ct = default)
+            => t.NodeId is { } n ? rpc.InvokeAsync<bool>(n, "User.GrantAccess", [NodeRouting.Wire(t), user, database], ct) : local.GrantAccessAsync(t, user, database, ct);
+    }
+
+    internal sealed class RoutingInnerQueryService(IInnerQueryService local, INodeRpc rpc) : IInnerQueryService
+    {
+        public string Engine => local.Engine;
+
+        public Task<QueryResult> RunAsync(InnerDatabaseTarget t, string database, string sql, int rowLimit, CancellationToken ct = default)
+            => t.NodeId is { } n ? rpc.InvokeAsync<QueryResult>(n, "Query.Run", [NodeRouting.Wire(t), database, sql, rowLimit], ct) : local.RunAsync(t, database, sql, rowLimit, ct);
+    }
+
+    internal sealed class RoutingInnerSchemaService(IInnerSchemaService local, INodeRpc rpc) : IInnerSchemaService
+    {
+        public string Engine => local.Engine;
+
+        public Task<IReadOnlyList<TableSummary>> ListTablesAsync(InnerDatabaseTarget t, string database, CancellationToken ct = default)
+            => t.NodeId is { } n ? rpc.InvokeAsync<IReadOnlyList<TableSummary>>(n, "Schema.ListTables", [NodeRouting.Wire(t), database], ct) : local.ListTablesAsync(t, database, ct);
+
+        public Task<TableRows> FetchRowsAsync(InnerDatabaseTarget t, string database, string table, int limit, int offset, CancellationToken ct = default)
+            => t.NodeId is { } n ? rpc.InvokeAsync<TableRows>(n, "Schema.FetchRows", [NodeRouting.Wire(t), database, table, limit, offset], ct) : local.FetchRowsAsync(t, database, table, limit, offset, ct);
+
+        public Task UpdateRowAsync(InnerDatabaseTarget t, string database, string table, UpdateRowRequest request, CancellationToken ct = default)
+            => t.NodeId is { } n ? rpc.InvokeAsync<bool>(n, "Schema.UpdateRow", [NodeRouting.Wire(t), database, table, request], ct) : local.UpdateRowAsync(t, database, table, request, ct);
+
+        public Task BulkUpdateRowsAsync(InnerDatabaseTarget t, string database, string table, BulkUpdateRowsRequest request, CancellationToken ct = default)
+            => t.NodeId is { } n ? rpc.InvokeAsync<bool>(n, "Schema.BulkUpdateRows", [NodeRouting.Wire(t), database, table, request], ct) : local.BulkUpdateRowsAsync(t, database, table, request, ct);
+
+        public Task InsertRowAsync(InnerDatabaseTarget t, string database, string table, InsertRowRequest request, CancellationToken ct = default)
+            => t.NodeId is { } n ? rpc.InvokeAsync<bool>(n, "Schema.InsertRow", [NodeRouting.Wire(t), database, table, request], ct) : local.InsertRowAsync(t, database, table, request, ct);
+
+        public Task UploadObjectAsync(InnerDatabaseTarget t, string database, string key, Stream content, string? contentType, CancellationToken ct = default)
+            => t.NodeId is not null
+                ? throw new NotSupportedException("Object upload is not supported on remote nodes yet.")
+                : local.UploadObjectAsync(t, database, key, content, contentType, ct);
+
+        public Task DeleteRowAsync(InnerDatabaseTarget t, string database, string table, DeleteRowRequest request, CancellationToken ct = default)
+            => t.NodeId is { } n ? rpc.InvokeAsync<bool>(n, "Schema.DeleteRow", [NodeRouting.Wire(t), database, table, request], ct) : local.DeleteRowAsync(t, database, table, request, ct);
+
+        public Task DropTableAsync(InnerDatabaseTarget t, string database, string table, CancellationToken ct = default)
+            => t.NodeId is { } n ? rpc.InvokeAsync<bool>(n, "Schema.DropTable", [NodeRouting.Wire(t), database, table], ct) : local.DropTableAsync(t, database, table, ct);
+    }
+}


### PR DESCRIPTION
Provision a database onto a remote node and browse/query/manage it through the control plane — every container and DB operation is dispatched over the single node SignalR connection. Adds a persisted Node entity + stable node id, NodeId on instances, Docker + inner-DB routing resolvers with node-side handlers, a create-wizard node picker and instances node badge. Streaming features (logs, console, backups, upgrade) are guarded for node instances pending a follow-up.

Closes #219