### PR TITLE
Route backups, restore and version upgrade to nodes over SignalR

### DIFF
--- a/src/KRINT.API/Nodes/NodeAgentHostedService.cs
+++ b/src/KRINT.API/Nodes/NodeAgentHostedService.cs
@@ -133,6 +133,7 @@ namespace KRINT.API.Nodes
             c.On<string, bool, bool>("RemoveContainer", (id, force) => WithDocker(async d => { await d.RemoveContainerAsync(id, force); return true; }));
             c.On<string, bool, bool>("RemoveVolume", (name, force) => WithDocker(async d => { await d.RemoveVolumeAsync(name, force); return true; }));
             c.On<string, IList<string>, byte[]>("ExecCapture", (id, cmd) => WithDocker(d => d.ExecCaptureAsync(id, cmd)));
+            c.On<string, IList<string>, byte[], bool>("ExecWithStdin", (id, cmd, data) => WithDocker(async d => { await d.ExecWithStdinAsync(id, cmd, new MemoryStream(data)); return true; }));
         }
 
         private async Task<T> WithDocker<T>(Func<IDockerService, Task<T>> work)

--- a/src/KRINT.API/Nodes/RemoteDockerService.cs
+++ b/src/KRINT.API/Nodes/RemoteDockerService.cs
@@ -58,8 +58,15 @@ namespace KRINT.API.Nodes
         public Task<byte[]> ExecCaptureAsync(string containerId, IList<string> command, CancellationToken cancellationToken = default)
             => Node().InvokeAsync<byte[]>("ExecCapture", containerId, command, cancellationToken);
 
-        public Task ExecWithStdinAsync(string containerId, IList<string> command, Stream stdin, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("Streaming exec (backup/restore) is not supported on remote nodes yet.");
+        public async Task ExecWithStdinAsync(string containerId, IList<string> command, Stream stdin, CancellationToken cancellationToken = default)
+        {
+            // The local implementation already buffers stdin fully in memory (dumps are bounded), so
+            // sending the whole payload as one byte[] argument matches that and keeps the contract
+            // simple. The node reconstructs a stream and runs the command locally.
+            using var buffer = new MemoryStream();
+            await stdin.CopyToAsync(buffer, cancellationToken);
+            await Node().InvokeAsync<bool>("ExecWithStdin", containerId, command, buffer.ToArray(), cancellationToken);
+        }
 
         // Flatten the Docker.DotNet parameters KRINT sets into a transport-safe spec.
         private static CreateContainerSpec ToSpec(CreateContainerParameters p)

--- a/src/KRINT.API/Program.cs
+++ b/src/KRINT.API/Program.cs
@@ -41,9 +41,9 @@ builder.Services.AddControllers();
 builder.Services.AddSignalR(options =>
 {
     // Container output can burst over the default 32 KB cap when a server logs verbose startup
-    // or a user runs ls in a huge directory. Bumping this lets each Output/Logs frame land
-    // without the connection getting axed.
-    options.MaximumReceiveMessageSize = 1024 * 1024;
+    // or a user runs ls in a huge directory. Node RPC also returns whole backup dumps as one
+    // message. Lift the cap (dumps are already fully buffered in memory) so neither gets axed.
+    options.MaximumReceiveMessageSize = null;
 });
 
 builder.Services.AddHttpContextAccessor();

--- a/src/KRINT.Application/Command/Backup/CreateBackupCommand.cs
+++ b/src/KRINT.Application/Command/Backup/CreateBackupCommand.cs
@@ -17,17 +17,17 @@ namespace KRINT.Application.Command.Backup
         {
             var instance = await db.DatabaseInstances.FirstOrDefaultAsync(d => d.Id == command.InstanceId, cancellationToken)
                 ?? throw new InstanceNotFoundException(command.InstanceId);
-            NodeFeatureGuard.EnsureLocal(instance, "Backups");
 
             // Backups exec inside the container (pg_dump, mysqldump, mongodump). Available
-            // whenever there's a reachable container, including adopted externals.
+            // whenever there's a reachable container, including adopted externals and node-hosted ones
+            // (the exec is dispatched to the node, the dump comes back over the connection).
             if (instance.ContainerName is null || instance.ContainerId is null)
                 throw new InvalidOperationException("Backups require a Docker container - this database isn't reachable that way.");
 
             var password = await vault.RetrieveAsync(ConnectionStringBuilder.VaultKeyFor(instance.ContainerName), cancellationToken)
                 ?? throw new InvalidOperationException($"Vault has no password for instance {instance.Id}.");
 
-            var target = new BackupTarget(instance.ContainerId, instance.ContainerName, instance.Engine, instance.Username, password, instance.DatabaseName);
+            var target = new BackupTarget(instance.ContainerId, instance.ContainerName, instance.Engine, instance.Username, password, instance.DatabaseName, instance.NodeId);
 
             var dump = await resolver.Resolve(instance.Engine).DumpAsync(target, cancellationToken);
 

--- a/src/KRINT.Application/Command/Backup/RestoreBackupCommand.cs
+++ b/src/KRINT.Application/Command/Backup/RestoreBackupCommand.cs
@@ -17,7 +17,6 @@ namespace KRINT.Application.Command.Backup
 
             var instance = await db.DatabaseInstances.FirstOrDefaultAsync(d => d.Id == entry.InstanceId, cancellationToken)
                 ?? throw new InstanceNotFoundException(entry.InstanceId);
-            NodeFeatureGuard.EnsureLocal(instance, "Restore");
 
             if (instance.ContainerName is null || instance.ContainerId is null)
                 throw new InvalidOperationException("Restore requires a Docker container - this database isn't reachable that way.");
@@ -25,7 +24,7 @@ namespace KRINT.Application.Command.Backup
             var password = await vault.RetrieveAsync(ConnectionStringBuilder.VaultKeyFor(instance.ContainerName), cancellationToken)
                 ?? throw new InvalidOperationException($"Vault has no password for instance {instance.Id}.");
 
-            var target = new BackupTarget(instance.ContainerId, instance.ContainerName, instance.Engine, instance.Username, password, instance.DatabaseName);
+            var target = new BackupTarget(instance.ContainerId, instance.ContainerName, instance.Engine, instance.Username, password, instance.DatabaseName, instance.NodeId);
 
             await using var stream = storage.OpenRead(entry.FilePath)
                 ?? throw new InvalidOperationException($"Backup file is missing on disk: {entry.FilePath}");

--- a/src/KRINT.Application/Command/Database/UpgradeDatabaseCommand.cs
+++ b/src/KRINT.Application/Command/Database/UpgradeDatabaseCommand.cs
@@ -22,7 +22,7 @@ namespace KRINT.Application.Command.Database
     /// column carries the old version string so the UI can later offer a Rollback button.
     /// </summary>
     public class UpgradeDatabaseCommandHandler(
-        IDockerService docker,
+        IDockerServiceResolver dockerResolver,
         ISecretsVaultService vault,
         KrintDbContext db,
         IActivityLogger activity,
@@ -38,7 +38,8 @@ namespace KRINT.Application.Command.Database
             var instance = await db.DatabaseInstances.FirstOrDefaultAsync(d => d.Id == command.InstanceId, cancellationToken)
                 ?? throw new InstanceNotFoundException(command.InstanceId);
             guard.EnsureMutable(instance);
-            NodeFeatureGuard.EnsureLocal(instance, "Version upgrade");
+
+            var docker = dockerResolver.Resolve(instance.NodeId);
 
             // Upgrade is dump-restore-swap: it destroys the old container and provisions a fresh
             // one with a new name + image. For externals (typically pinned in the user's
@@ -63,7 +64,7 @@ namespace KRINT.Application.Command.Database
 
             // 1. Auto-backup OLD so a future Rollback can restore from it.
             var dump = await backupResolver.Resolve(instance.Engine).DumpAsync(
-                new BackupTarget(oldContainerId, oldContainerName, instance.Engine, instance.Username, password, instance.DatabaseName),
+                new BackupTarget(oldContainerId, oldContainerName, instance.Engine, instance.Username, password, instance.DatabaseName, instance.NodeId),
                 cancellationToken);
             var stamp = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss");
             var backupFileName = $"pre-upgrade-{oldVersion}-to-{command.TargetVersion}-{stamp}.{dump.FileExtension}";
@@ -110,7 +111,7 @@ namespace KRINT.Application.Command.Database
                     PortBindings = new Dictionary<string, IList<PortBinding>>
                     {
                         // Preserve the old container's visibility setting across the swap.
-                        [$"{spec.InternalPort}/tcp"] = new List<PortBinding> { new() { HostPort = instance.Port.ToString(), HostIP = instance.IsPublic ? "" : "127.0.0.1" } },
+                        [$"{spec.InternalPort}/tcp"] = new List<PortBinding> { new() { HostPort = instance.Port.ToString(), HostIP = instance.NodeId is not null || !instance.IsPublic ? "127.0.0.1" : "" } },
                     },
                     Binds = new List<string> { newBindSpec },
                     RestartPolicy = new RestartPolicy { Name = RestartPolicyKind.UnlessStopped },
@@ -131,14 +132,15 @@ namespace KRINT.Application.Command.Database
 
                 // Wait for the engine inside the new container to accept connections.
                 // ReadinessProbe tries both probe hosts - see its doc comment.
-                var readinessTarget = new InnerDatabaseTarget(instance.Engine, CreateDatabaseCommandHandler.ResolveProbeHost(instance.IsPublic), instance.Port, spec.DefaultUsername, password, spec.DefaultDatabase);
+                var probeHost = instance.NodeId is not null ? "127.0.0.1" : CreateDatabaseCommandHandler.ResolveProbeHost(instance.IsPublic);
+                var readinessTarget = new InnerDatabaseTarget(instance.Engine, probeHost, instance.Port, spec.DefaultUsername, password, spec.DefaultDatabase, instance.NodeId);
                 await ReadinessProbe.WaitForReadyAsync(innerDbs.Resolve(instance.Engine), readinessTarget, instance.IsPublic, cancellationToken);
 
                 // 5. Restore the pre-upgrade dump into NEW.
                 await using (var stream = backupStorage.OpenRead(backupPath)
                     ?? throw new InvalidOperationException($"Pre-upgrade backup vanished: {backupPath}"))
                 {
-                    var restoreTarget = new BackupTarget(newCreateResult.ID, newContainerName, instance.Engine, instance.Username, password, instance.DatabaseName);
+                    var restoreTarget = new BackupTarget(newCreateResult.ID, newContainerName, instance.Engine, instance.Username, password, instance.DatabaseName, instance.NodeId);
                     await backupResolver.Resolve(instance.Engine).RestoreAsync(restoreTarget, stream, cancellationToken);
                 }
 

--- a/src/KRINT.Infrastructure/Interfaces/IBackupService.cs
+++ b/src/KRINT.Infrastructure/Interfaces/IBackupService.cs
@@ -1,6 +1,6 @@
 namespace KRINT.Infrastructure.Interfaces
 {
-    public record BackupTarget(string ContainerId, string ContainerName, string Engine, string Username, string Password, string DefaultDatabase);
+    public record BackupTarget(string ContainerId, string ContainerName, string Engine, string Username, string Password, string DefaultDatabase, Guid? NodeId = null);
 
     public record BackupOutput(byte[] Content, string FileExtension);
 

--- a/src/KRINT.Infrastructure/Services/MariaDbServices.cs
+++ b/src/KRINT.Infrastructure/Services/MariaDbServices.cs
@@ -19,7 +19,7 @@ namespace KRINT.Infrastructure.Services
         public override string Engine => "mariadb";
     }
 
-    public sealed class MariaDbBackupService(IDockerService docker) : MySqlBackupService(docker)
+    public sealed class MariaDbBackupService(IDockerServiceResolver dockerResolver) : MySqlBackupService(dockerResolver)
     {
         public override string Engine => "mariadb";
     }

--- a/src/KRINT.Infrastructure/Services/MongoBackupService.cs
+++ b/src/KRINT.Infrastructure/Services/MongoBackupService.cs
@@ -2,7 +2,7 @@ using KRINT.Infrastructure.Interfaces;
 
 namespace KRINT.Infrastructure.Services
 {
-    public class MongoBackupService(IDockerService docker) : IBackupService
+    public class MongoBackupService(IDockerServiceResolver dockerResolver) : IBackupService
     {
         public string Engine => "mongo";
 
@@ -14,7 +14,7 @@ namespace KRINT.Infrastructure.Services
                 "bash", "-c",
                 $"mongodump --host 127.0.0.1 --username {target.Username} --password '{target.Password}' --authenticationDatabase admin --archive",
             };
-            var bytes = await docker.ExecCaptureAsync(target.ContainerId, cmd, cancellationToken);
+            var bytes = await dockerResolver.Resolve(target.NodeId).ExecCaptureAsync(target.ContainerId, cmd, cancellationToken);
             return new BackupOutput(bytes, "archive");
         }
 
@@ -26,7 +26,7 @@ namespace KRINT.Infrastructure.Services
                 "bash", "-c",
                 $"mongorestore --host 127.0.0.1 --username {target.Username} --password '{target.Password}' --authenticationDatabase admin --archive --drop",
             };
-            await docker.ExecWithStdinAsync(target.ContainerId, cmd, dump, cancellationToken);
+            await dockerResolver.Resolve(target.NodeId).ExecWithStdinAsync(target.ContainerId, cmd, dump, cancellationToken);
         }
     }
 }

--- a/src/KRINT.Infrastructure/Services/MsSqlBackupService.cs
+++ b/src/KRINT.Infrastructure/Services/MsSqlBackupService.cs
@@ -22,7 +22,7 @@ namespace KRINT.Infrastructure.Services
     ///     Restoring an arbitrary .bak into a renamed database would need RESTORE FILELISTONLY +
     ///     dynamic MOVE clauses, which is out of scope for v1.
     /// </summary>
-    public sealed class MsSqlBackupService(IDockerService docker) : IBackupService
+    public sealed class MsSqlBackupService(IDockerServiceResolver dockerResolver) : IBackupService
     {
         public string Engine => "mssql";
 
@@ -43,7 +43,7 @@ namespace KRINT.Infrastructure.Services
             // ends up in our captured stdout.
             var script = $"{backup} 1>&2 && cat '{tmp}' && rm -f '{tmp}'";
 
-            var bytes = await docker.ExecCaptureAsync(target.ContainerId, new List<string> { "bash", "-c", script }, cancellationToken);
+            var bytes = await dockerResolver.Resolve(target.NodeId).ExecCaptureAsync(target.ContainerId, new List<string> { "bash", "-c", script }, cancellationToken);
             return new BackupOutput(bytes, "bak");
         }
 
@@ -56,7 +56,7 @@ namespace KRINT.Infrastructure.Services
             // would corrupt the operation.
             var script = $"cat > '{tmp}' && {restore} && rm -f '{tmp}'";
 
-            await docker.ExecWithStdinAsync(target.ContainerId, new List<string> { "bash", "-c", script }, dump, cancellationToken);
+            await dockerResolver.Resolve(target.NodeId).ExecWithStdinAsync(target.ContainerId, new List<string> { "bash", "-c", script }, dump, cancellationToken);
         }
 
         // sqlcmd's -P argument is passed inside single quotes in the bash script, so any single

--- a/src/KRINT.Infrastructure/Services/MySqlBackupService.cs
+++ b/src/KRINT.Infrastructure/Services/MySqlBackupService.cs
@@ -2,7 +2,7 @@ using KRINT.Infrastructure.Interfaces;
 
 namespace KRINT.Infrastructure.Services
 {
-    public class MySqlBackupService(IDockerService docker) : IBackupService
+    public class MySqlBackupService(IDockerServiceResolver dockerResolver) : IBackupService
     {
         public virtual string Engine => "mysql";
 
@@ -24,7 +24,7 @@ namespace KRINT.Infrastructure.Services
                 "bash", "-c",
                 $"{bin} -h 127.0.0.1 -u {target.Username} -p'{target.Password}' --single-transaction --all-databases",
             };
-            var bytes = await docker.ExecCaptureAsync(target.ContainerId, cmd, cancellationToken);
+            var bytes = await dockerResolver.Resolve(target.NodeId).ExecCaptureAsync(target.ContainerId, cmd, cancellationToken);
             return new BackupOutput(bytes, "sql");
         }
 
@@ -37,7 +37,7 @@ namespace KRINT.Infrastructure.Services
                 "bash", "-c",
                 $"{bin} -h 127.0.0.1 -u {target.Username} -p'{target.Password}'",
             };
-            await docker.ExecWithStdinAsync(target.ContainerId, cmd, dump, cancellationToken);
+            await dockerResolver.Resolve(target.NodeId).ExecWithStdinAsync(target.ContainerId, cmd, dump, cancellationToken);
         }
     }
 }

--- a/src/KRINT.Infrastructure/Services/PgVectorServices.cs
+++ b/src/KRINT.Infrastructure/Services/PgVectorServices.cs
@@ -20,7 +20,7 @@ namespace KRINT.Infrastructure.Services
         public override string Engine => "pgvector";
     }
 
-    public sealed class PgVectorBackupService(IDockerService docker) : PostgresBackupService(docker)
+    public sealed class PgVectorBackupService(IDockerServiceResolver dockerResolver) : PostgresBackupService(dockerResolver)
     {
         public override string Engine => "pgvector";
     }

--- a/src/KRINT.Infrastructure/Services/PostgresBackupService.cs
+++ b/src/KRINT.Infrastructure/Services/PostgresBackupService.cs
@@ -2,8 +2,10 @@ using KRINT.Infrastructure.Interfaces;
 
 namespace KRINT.Infrastructure.Services
 {
-    public class PostgresBackupService(IDockerService docker) : IBackupService
+    public class PostgresBackupService(IDockerServiceResolver dockerResolver) : IBackupService
     {
+        protected IDockerService Docker(BackupTarget target) => dockerResolver.Resolve(target.NodeId);
+
         public virtual string Engine => "postgres";
 
         public async Task<BackupOutput> DumpAsync(BackupTarget target, CancellationToken cancellationToken = default)
@@ -14,7 +16,7 @@ namespace KRINT.Infrastructure.Services
                 "bash", "-c",
                 $"PGPASSWORD='{target.Password}' pg_dump -h 127.0.0.1 -U {target.Username} -d {target.DefaultDatabase} -F c",
             };
-            var bytes = await docker.ExecCaptureAsync(target.ContainerId, cmd, cancellationToken);
+            var bytes = await Docker(target).ExecCaptureAsync(target.ContainerId, cmd, cancellationToken);
             return new BackupOutput(bytes, "dump");
         }
 
@@ -28,7 +30,7 @@ namespace KRINT.Infrastructure.Services
                 "bash", "-c",
                 $"PGPASSWORD='{target.Password}' pg_restore -h 127.0.0.1 -U {target.Username} -d {target.DefaultDatabase} --clean --if-exists --no-owner",
             };
-            await docker.ExecWithStdinAsync(target.ContainerId, cmd, dump, cancellationToken);
+            await Docker(target).ExecWithStdinAsync(target.ContainerId, cmd, dump, cancellationToken);
         }
     }
 }

--- a/src/KRINT.Infrastructure/Services/RedisServices.cs
+++ b/src/KRINT.Infrastructure/Services/RedisServices.cs
@@ -203,7 +203,7 @@ namespace KRINT.Infrastructure.Services
         }
     }
 
-    public class RedisBackupService(IDockerService docker) : IBackupService
+    public class RedisBackupService(IDockerServiceResolver dockerResolver) : IBackupService
     {
         public virtual string Engine => "redis";
 
@@ -216,7 +216,7 @@ namespace KRINT.Infrastructure.Services
                 "sh", "-c",
                 $"redis-cli {AuthFlag(target.Password)} save >/dev/null && cat /data/dump.rdb",
             };
-            var bytes = await docker.ExecCaptureAsync(target.ContainerId, cmd, cancellationToken);
+            var bytes = await dockerResolver.Resolve(target.NodeId).ExecCaptureAsync(target.ContainerId, cmd, cancellationToken);
             return new BackupOutput(bytes, "rdb");
         }
 
@@ -229,7 +229,7 @@ namespace KRINT.Infrastructure.Services
                 "sh", "-c",
                 $"cat > /data/dump.rdb && redis-cli {AuthFlag(target.Password)} DEBUG RELOAD >/dev/null",
             };
-            await docker.ExecWithStdinAsync(target.ContainerId, cmd, dump, cancellationToken);
+            await dockerResolver.Resolve(target.NodeId).ExecWithStdinAsync(target.ContainerId, cmd, dump, cancellationToken);
         }
 
         private static string AuthFlag(string password)

--- a/src/KRINT.Infrastructure/Services/TimescaleDbServices.cs
+++ b/src/KRINT.Infrastructure/Services/TimescaleDbServices.cs
@@ -20,7 +20,7 @@ namespace KRINT.Infrastructure.Services
         public override string Engine => "timescaledb";
     }
 
-    public sealed class TimescaleDbBackupService(IDockerService docker) : PostgresBackupService(docker)
+    public sealed class TimescaleDbBackupService(IDockerServiceResolver dockerResolver) : PostgresBackupService(dockerResolver)
     {
         public override string Engine => "timescaledb";
     }

--- a/src/KRINT.Infrastructure/Services/ValkeyServices.cs
+++ b/src/KRINT.Infrastructure/Services/ValkeyServices.cs
@@ -8,5 +8,5 @@ namespace KRINT.Infrastructure.Services
     public sealed class ValkeyInnerDatabaseService : RedisInnerDatabaseService { public override string Engine => "valkey"; }
     public sealed class ValkeyInnerUserService     : RedisInnerUserService     { public override string Engine => "valkey"; }
     public sealed class ValkeyInnerSchemaService   : RedisInnerSchemaService   { public override string Engine => "valkey"; }
-    public sealed class ValkeyBackupService(IDockerService docker) : RedisBackupService(docker) { public override string Engine => "valkey"; }
+    public sealed class ValkeyBackupService(IDockerServiceResolver dockerResolver) : RedisBackupService(dockerResolver) { public override string Engine => "valkey"; }
 }


### PR DESCRIPTION
Backups (dump), restore and dump-restore-swap upgrade now work on node-hosted instances: ExecWithStdin is proxied as a bounded byte[] over the node connection, backup services resolve Docker by the instance's node, and the node guards on create/restore/upgrade are lifted. Logs and the interactive console remain guarded pending the final streaming pass.

Closes #221