### PR TITLE
Stream node container logs to the browser over SignalR

### DIFF
--- a/src/KRINT.API/Hubs/ContainerHub.cs
+++ b/src/KRINT.API/Hubs/ContainerHub.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Mediator;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
+using KRINT.API.Nodes;
 using KRINT.Application;
 using KRINT.Application.Command.Container;
 using KRINT.Application.Queries.Container;
@@ -12,7 +13,7 @@ using KRINT.Infrastructure.Interfaces;
 namespace KRINT.API.Hubs
 {
     [Authorize]
-    public class ContainerHub(IMediator mediator, IContainerExecRegistry registry, IHubContext<ContainerHub> hubContext) : Hub
+    public class ContainerHub(IMediator mediator, IContainerExecRegistry registry, IHubContext<ContainerHub> hubContext, INodeRpc nodeRpc, INodeStreamRelay streamRelay) : Hub
     {
         // Tracks live exec sessions per connection so OnDisconnectedAsync can tear them down.
         // Without this a closed browser tab would leave a docker exec session running.
@@ -20,6 +21,28 @@ namespace KRINT.API.Hubs
 
         public async IAsyncEnumerable<string> StreamLogs(Guid instanceId, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
+            var route = await mediator.Send(new GetContainerRouteQuery(instanceId), cancellationToken);
+
+            if (route.NodeId is { } nodeId)
+            {
+                // Node-hosted: the node follows the logs and pushes frames to us via the relay.
+                var streamId = Guid.NewGuid().ToString("N");
+                var reader = streamRelay.OpenLog(streamId);
+                await nodeRpc.InvokeAsync<bool>(nodeId, "StartLogStream", [streamId, route.ContainerId, 200], cancellationToken);
+                try
+                {
+                    await foreach (var frame in reader.ReadAllAsync(cancellationToken))
+                        yield return frame;
+                }
+                finally
+                {
+                    streamRelay.CloseLog(streamId);
+                    // Best-effort tell the node to stop following (browser unsubscribed or connection gone).
+                    try { await nodeRpc.InvokeAsync<bool>(nodeId, "StopLogStream", [streamId], CancellationToken.None); } catch { }
+                }
+                yield break;
+            }
+
             await foreach (var chunk in mediator.CreateStream(new StreamContainerLogsQuery(instanceId), cancellationToken))
             {
                 yield return chunk;

--- a/src/KRINT.API/Hubs/NodeHub.cs
+++ b/src/KRINT.API/Hubs/NodeHub.cs
@@ -15,6 +15,7 @@ namespace KRINT.API.Hubs
     [AllowAnonymous]
     public class NodeHub(
         INodeRegistry registry,
+        INodeStreamRelay streamRelay,
         IConfiguration configuration,
         IServiceScopeFactory scopeFactory,
         ILogger<NodeHub> logger) : Hub
@@ -79,6 +80,20 @@ namespace KRINT.API.Hubs
         public Task Heartbeat()
         {
             registry.Touch(Context.ConnectionId);
+            return Task.CompletedTask;
+        }
+
+        /// <summary>A log frame the node read from a container it's following on our behalf.</summary>
+        public Task LogFrame(string streamId, string frame)
+        {
+            streamRelay.PushLog(streamId, frame);
+            return Task.CompletedTask;
+        }
+
+        /// <summary>The node's log follow ended (container stopped/removed) - close the browser stream.</summary>
+        public Task LogStreamCompleted(string streamId)
+        {
+            streamRelay.CompleteLog(streamId);
             return Task.CompletedTask;
         }
 

--- a/src/KRINT.API/Nodes/NodeAgentHostedService.cs
+++ b/src/KRINT.API/Nodes/NodeAgentHostedService.cs
@@ -18,6 +18,8 @@ namespace KRINT.API.Nodes
     {
         private HubConnection? _connection;
         private string _nodeId = "";
+        // Active log follows started by the control plane, so StopLogStream can cancel them.
+        private readonly System.Collections.Concurrent.ConcurrentDictionary<string, CancellationTokenSource> _logStreams = new();
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
@@ -134,6 +136,43 @@ namespace KRINT.API.Nodes
             c.On<string, bool, bool>("RemoveVolume", (name, force) => WithDocker(async d => { await d.RemoveVolumeAsync(name, force); return true; }));
             c.On<string, IList<string>, byte[]>("ExecCapture", (id, cmd) => WithDocker(d => d.ExecCaptureAsync(id, cmd)));
             c.On<string, IList<string>, byte[], bool>("ExecWithStdin", (id, cmd, data) => WithDocker(async d => { await d.ExecWithStdinAsync(id, cmd, new MemoryStream(data)); return true; }));
+
+            // Log streaming: follow the container's logs locally and push each frame back; the control
+            // plane relays them to the browser. Returns immediately - the follow runs in the background.
+            c.On<string, string, int, bool>("StartLogStream", (streamId, containerId, tail) =>
+            {
+                var cts = new CancellationTokenSource();
+                _logStreams[streamId] = cts;
+                _ = Task.Run(() => PumpLogsAsync(streamId, containerId, tail, cts.Token));
+                return Task.FromResult(true);
+            });
+            c.On<string, bool>("StopLogStream", streamId =>
+            {
+                if (_logStreams.TryRemove(streamId, out var cts)) cts.Cancel();
+                return Task.FromResult(true);
+            });
+        }
+
+        private async Task PumpLogsAsync(string streamId, string containerId, int tail, CancellationToken cancellationToken)
+        {
+            try
+            {
+                using var scope = services.CreateScope();
+                var docker = scope.ServiceProvider.GetRequiredService<IDockerService>();
+                await foreach (var frame in docker.StreamLogsAsync(containerId, tail, cancellationToken))
+                {
+                    if (_connection is null) break;
+                    await _connection.SendAsync("LogFrame", streamId, frame, cancellationToken);
+                }
+            }
+            catch (OperationCanceledException) { /* StopLogStream */ }
+            catch (Exception ex) { logger.LogWarning("Log follow {StreamId} ended: {Message}", streamId, ex.Message); }
+            finally
+            {
+                _logStreams.TryRemove(streamId, out _);
+                if (_connection is not null)
+                    try { await _connection.SendAsync("LogStreamCompleted", streamId, CancellationToken.None); } catch { }
+            }
         }
 
         private async Task<T> WithDocker<T>(Func<IDockerService, Task<T>> work)

--- a/src/KRINT.API/Nodes/NodeStreamRelay.cs
+++ b/src/KRINT.API/Nodes/NodeStreamRelay.cs
@@ -1,0 +1,53 @@
+using System.Threading.Channels;
+
+namespace KRINT.API.Nodes
+{
+    /// <summary>Bridges streamed output that originates on a node back to the browser. A node-hosted
+    /// log stream runs on the node, which pushes frames to the control plane (NodeHub); those frames
+    /// land in a channel here that the browser-facing ContainerHub reads from. Keyed by an opaque
+    /// streamId minted per browser subscription.</summary>
+    public interface INodeStreamRelay
+    {
+        /// <summary>Open a channel for a new log stream and return its reader for the browser hub.</summary>
+        ChannelReader<string> OpenLog(string streamId);
+
+        /// <summary>Push a frame arriving from the node into the stream's channel.</summary>
+        void PushLog(string streamId, string frame);
+
+        /// <summary>The node signalled the stream ended naturally - complete the channel.</summary>
+        void CompleteLog(string streamId);
+
+        /// <summary>The browser stopped reading - drop the channel (the caller also tells the node to stop).</summary>
+        void CloseLog(string streamId);
+    }
+
+    public class NodeStreamRelay : INodeStreamRelay
+    {
+        private readonly System.Collections.Concurrent.ConcurrentDictionary<string, Channel<string>> _logs = new();
+
+        public ChannelReader<string> OpenLog(string streamId)
+        {
+            var channel = Channel.CreateUnbounded<string>(new UnboundedChannelOptions { SingleReader = true });
+            _logs[streamId] = channel;
+            return channel.Reader;
+        }
+
+        public void PushLog(string streamId, string frame)
+        {
+            if (_logs.TryGetValue(streamId, out var channel))
+                channel.Writer.TryWrite(frame);
+        }
+
+        public void CompleteLog(string streamId)
+        {
+            if (_logs.TryGetValue(streamId, out var channel))
+                channel.Writer.TryComplete();
+        }
+
+        public void CloseLog(string streamId)
+        {
+            if (_logs.TryRemove(streamId, out var channel))
+                channel.Writer.TryComplete();
+        }
+    }
+}

--- a/src/KRINT.API/Nodes/RemoteDockerService.cs
+++ b/src/KRINT.API/Nodes/RemoteDockerService.cs
@@ -58,6 +58,11 @@ namespace KRINT.API.Nodes
         public Task<byte[]> ExecCaptureAsync(string containerId, IList<string> command, CancellationToken cancellationToken = default)
             => Node().InvokeAsync<byte[]>("ExecCapture", containerId, command, cancellationToken);
 
+        // Node log streaming is relayed frame-by-frame through INodeStreamRelay (the node pushes
+        // frames over its connection), not pulled through this per-call service.
+        public IAsyncEnumerable<string> StreamLogsAsync(string containerId, int tailLines, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Log streaming to a node is handled by the node stream relay.");
+
         public async Task ExecWithStdinAsync(string containerId, IList<string> command, Stream stdin, CancellationToken cancellationToken = default)
         {
             // The local implementation already buffers stdin fully in memory (dumps are bounded), so

--- a/src/KRINT.API/Program.cs
+++ b/src/KRINT.API/Program.cs
@@ -73,6 +73,8 @@ builder.Services.AddSingleton<INodeRegistry, NodeRegistry>();
 builder.Services.AddScoped<KRINT.Infrastructure.Interfaces.IDockerServiceResolver, DockerServiceResolver>();
 // Dispatches inner-DB operations to a node when the target carries a NodeId (used by the routing resolvers).
 builder.Services.AddSingleton<KRINT.Infrastructure.Interfaces.INodeRpc, NodeRpc>();
+// Bridges node-originated streamed output (container logs) back to the browser hub.
+builder.Services.AddSingleton<INodeStreamRelay, NodeStreamRelay>();
 
 builder.Services.AddHostedService<KRINT.API.BackupSchedulerHostedService>();
 builder.Services.AddHostedService<KRINT.API.InstanceReconciliationHostedService>();

--- a/src/KRINT.Application/Queries/Container/GetContainerRouteQuery.cs
+++ b/src/KRINT.Application/Queries/Container/GetContainerRouteQuery.cs
@@ -1,0 +1,28 @@
+using Mediator;
+using Microsoft.EntityFrameworkCore;
+using KRINT.Infrastructure;
+
+namespace KRINT.Application.Queries.Container
+{
+    /// <summary>Where an instance's container lives: its id plus the node it runs on (null = local).
+    /// Used by the container hub to decide whether to talk to the local Docker daemon or relay to a node.</summary>
+    public record ContainerRoute(string ContainerId, Guid? NodeId);
+
+    public record GetContainerRouteQuery(Guid InstanceId) : IQuery<ContainerRoute>;
+
+    public class GetContainerRouteQueryHandler(KrintDbContext db) : IQueryHandler<GetContainerRouteQuery, ContainerRoute>
+    {
+        public async ValueTask<ContainerRoute> Handle(GetContainerRouteQuery query, CancellationToken cancellationToken)
+        {
+            var instance = await db.DatabaseInstances
+                .AsNoTracking()
+                .FirstOrDefaultAsync(d => d.Id == query.InstanceId, cancellationToken)
+                ?? throw new InstanceNotFoundException(query.InstanceId);
+
+            var containerId = instance.ContainerId
+                ?? throw new InvalidOperationException("Container operations are not available for externally-registered databases.");
+
+            return new ContainerRoute(containerId, instance.NodeId);
+        }
+    }
+}

--- a/src/KRINT.Infrastructure/Interfaces/IDockerService.cs
+++ b/src/KRINT.Infrastructure/Interfaces/IDockerService.cs
@@ -28,6 +28,10 @@ namespace KRINT.Infrastructure.Interfaces
 
         Task RemoveVolumeAsync(string name, bool force = false, CancellationToken cancellationToken = default);
 
+        /// <summary>Follows a container's combined stdout/stderr, yielding decoded text chunks until
+        /// the stream ends or is cancelled. Used to stream logs (locally, or on a node).</summary>
+        IAsyncEnumerable<string> StreamLogsAsync(string containerId, int tailLines, CancellationToken cancellationToken = default);
+
         /// <summary>Runs a command inside a running container and returns its stdout as raw bytes.</summary>
         Task<byte[]> ExecCaptureAsync(string containerId, IList<string> command, CancellationToken cancellationToken = default);
 

--- a/src/KRINT.Infrastructure/Services/DockerService.cs
+++ b/src/KRINT.Infrastructure/Services/DockerService.cs
@@ -95,6 +95,37 @@ namespace KRINT.Infrastructure.Services
             return client.Volumes.RemoveAsync(name, force, cancellationToken);
         }
 
+        public async IAsyncEnumerable<string> StreamLogsAsync(string containerId, int tailLines, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var parameters = new ContainerLogsParameters
+            {
+                ShowStdout = true,
+                ShowStderr = true,
+                Follow = true,
+                Tail = tailLines.ToString(),
+                Timestamps = false,
+            };
+
+            using var stream = await client.Containers.GetContainerLogsAsync(containerId, tty: false, parameters, cancellationToken);
+
+            var buffer = new byte[16 * 1024];
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                MultiplexedStream.ReadResult read;
+                try
+                {
+                    read = await stream.ReadOutputAsync(buffer, 0, buffer.Length, cancellationToken);
+                }
+                catch (OperationCanceledException) { yield break; }
+                catch (IOException) { yield break; }
+
+                if (read.EOF) yield break;
+                if (read.Count == 0) continue;
+
+                yield return System.Text.Encoding.UTF8.GetString(buffer, 0, read.Count);
+            }
+        }
+
         public async Task<byte[]> ExecCaptureAsync(string containerId, IList<string> command, CancellationToken cancellationToken = default)
         {
             // Cap any single exec at 2 minutes. Without this a stuck pg_dump/mysqldump call would


### PR DESCRIPTION
Container log streaming now works for node-hosted instances: the node follows the container's logs and pushes each frame over its connection, a control-plane relay channels them into the browser-facing container hub, and the hub branches by the instance's node. Adds INodeStreamRelay, a GetContainerRoute query, and IDockerService.StreamLogsAsync. The interactive console remains the last guarded feature.

Closes #223