### PR TITLE
Count node containers in dashboard stats; refresh node docs

### DIFF
--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -1,10 +1,10 @@
 # Nodes (experimental)
 
 > A node is a stateless worker that runs database containers on a remote host. You can provision a
-> database onto a node and browse / query / manage it entirely through the control plane — **every
-> operation travels over the one SignalR connection**, and nodes expose no ports. Streaming features
-> (logs, interactive console, backups/restore, version upgrade) are not routed to nodes yet and are
-> blocked with a clear message for node-hosted instances.
+> database onto a node and then do **everything** with it through the control plane — browse, query,
+> manage users, back up and restore, upgrade the engine version, tail container logs, and open an
+> interactive shell. **Every operation travels over the one SignalR connection**, and nodes expose no
+> ports.
 
 KRINT normally provisions database containers on its own Docker daemon. A **node** is the *same*
 KRINT image started in a stripped role that does nothing but execute Docker (and database) work on
@@ -21,9 +21,11 @@ bind to localhost only and never publish a port.
 
 - **Control plane** (default role): the full KRINT app — UI, API, database, the works. It keeps an
   allow-list of node tokens (`Node__Tokens`) and exposes the node hub at `/hubs/node`.
-- **Node** (`Krint__Role=node`): no UI, no app database, no auth — just the Docker client and an agent
-  that connects to the control plane, registers (name, machine, OS, Docker version) and stays
-  connected. Only a `/health` endpoint is served.
+- **Node** (`Krint__Role=node`): no UI, no app database, no auth. It bundles the Docker client and the
+  database drivers and runs an agent that connects to the control plane, registers (name, machine, OS,
+  Docker version) and stays connected, executing whatever the control plane sends — container
+  lifecycle, SQL/queries, dumps/restores, log follows and interactive shells — against its own daemon.
+  Only a `/health` endpoint is served.
 
 A connected node appears on the control plane's **Nodes** page, where you can see its details and
 **Ping** it to confirm the channel is live.

--- a/src/KRINT.API/Nodes/NodeAgentHostedService.cs
+++ b/src/KRINT.API/Nodes/NodeAgentHostedService.cs
@@ -131,6 +131,7 @@ namespace KRINT.API.Nodes
             c.On("GetVersion", () => WithDocker(d => d.GetVersionAsync()));
             c.On<bool, IList<ContainerListResponse>>("ListContainers", all => WithDocker(d => d.ListContainersAsync(all)));
             c.On<string, ContainerInspectResponse>("InspectContainer", id => WithDocker(d => d.InspectContainerAsync(id)));
+            c.On<string, ContainerResourceSample?>("GetContainerResourceUsage", id => WithDocker(d => d.GetContainerResourceUsageAsync(id)));
             c.On<string, string, bool>("PullImage", (image, tag) => WithDocker(async d => { await d.PullImageAsync(image, tag); return true; }));
             c.On<CreateContainerSpec, CreateContainerResponse>("CreateContainer", spec => WithDocker(d => d.CreateContainerAsync(ToParameters(spec))));
             c.On<string, bool>("StartContainer", id => WithDocker(d => d.StartContainerAsync(id)));

--- a/src/KRINT.API/Nodes/RemoteDockerService.cs
+++ b/src/KRINT.API/Nodes/RemoteDockerService.cs
@@ -33,9 +33,13 @@ namespace KRINT.API.Nodes
         public Task<ContainerInspectResponse> InspectContainerAsync(string id, CancellationToken cancellationToken = default)
             => Node().InvokeAsync<ContainerInspectResponse>("InspectContainer", id, cancellationToken);
 
-        // Per-container stats aren't proxied; node-hosted instances just report no live CPU/mem.
+        // The full stats response is a large Docker.DotNet type that doesn't round-trip over STJ;
+        // the dashboard uses the primitive GetContainerResourceUsageAsync instead, so this stays null.
         public Task<ContainerStatsResponse?> GetContainerStatsOnceAsync(string id, CancellationToken cancellationToken = default)
             => Task.FromResult<ContainerStatsResponse?>(null);
+
+        public Task<ContainerResourceSample?> GetContainerResourceUsageAsync(string id, CancellationToken cancellationToken = default)
+            => Node().InvokeAsync<ContainerResourceSample?>("GetContainerResourceUsage", id, cancellationToken);
 
         public Task PullImageAsync(string image, string tag = "latest", CancellationToken cancellationToken = default)
             => Node().InvokeAsync<bool>("PullImage", image, tag, cancellationToken);

--- a/src/KRINT.Application/Queries/Dashboard/GetDashboardStatsQuery.cs
+++ b/src/KRINT.Application/Queries/Dashboard/GetDashboardStatsQuery.cs
@@ -9,53 +9,45 @@ namespace KRINT.Application.Queries.Dashboard
 {
     public record GetDashboardStatsQuery : IQuery<DashboardStatsDto>;
 
-    public class GetDashboardStatsQueryHandler(KrintDbContext db, IDockerService docker)
+    public class GetDashboardStatsQueryHandler(KrintDbContext db, IDockerServiceResolver dockerResolver)
         : IQueryHandler<GetDashboardStatsQuery, DashboardStatsDto>
     {
         public async ValueTask<DashboardStatsDto> Handle(GetDashboardStatsQuery query, CancellationToken cancellationToken)
         {
             var instances = await db.DatabaseInstances
-                .Select(d => new { d.Engine, d.ContainerName })
+                .Select(d => new { d.Engine, d.ContainerName, d.NodeId })
                 .ToListAsync(cancellationToken);
 
-            // One docker call gives us state for every container; cheaper than N inspects.
-            // Match by name (Docker prefixes names with '/' in the API response).
-            var containers = await docker.ListContainersAsync(all: true, cancellationToken);
-            var stateByName = containers
-                .SelectMany(c => (c.Names ?? new List<string>()).Select(n => (Name: n.TrimStart('/'), c.State, c.ID)))
-                .ToDictionary(x => x.Name, x => (x.State, x.ID), StringComparer.OrdinalIgnoreCase);
-
-            // Pull memory snapshots for running containers in parallel. Stopped or unknown ones
-            // contribute 0. A null snapshot (transient daemon error) also collapses to 0 instead
-            // of failing the whole dashboard.
-            var runningIds = instances
-                .Select(i => i.ContainerName is not null && stateByName.TryGetValue(i.ContainerName, out var s) && string.Equals(s.State, "running", StringComparison.OrdinalIgnoreCase) ? s.ID : null)
-                .Where(id => id is not null)
-                .Select(id => id!)
-                .ToArray();
-
-            var snapshots = await Task.WhenAll(runningIds.Select(id => docker.GetContainerStatsOnceAsync(id, cancellationToken)));
-            var totalMemoryBytes = snapshots
-                .Where(s => s?.MemoryStats is not null)
-                .Sum(s => (long)s!.MemoryStats.Usage);
-
-            // CPU% per container = (cpuDelta / systemDelta) * 100. systemDelta is host-wide CPU
-            // nanoseconds across the sample window, so the ratio is already "fraction of total
-            // host CPU consumed by this container". Summing across containers gives the share of
-            // host CPU eaten by managed containers only - excluding everything else on the host.
-            // Bounded to 100 because rounding + multi-core jitter can push the sum a hair over.
-            double totalCpuPercent = 0d;
-            foreach (var snap in snapshots)
+            // Containers live on whichever daemon owns the instance (local or a node), so query each
+            // distinct target once and collect the running containers' ids paired with their node, so
+            // the stats call below hits the right daemon. An offline node / dead daemon just drops out.
+            var runningContainers = new List<(Guid? NodeId, string Id)>();
+            foreach (var group in instances.Where(i => i.ContainerName is not null).GroupBy(i => i.NodeId))
             {
-                if (snap?.CPUStats is null || snap.PreCPUStats is null) continue;
-                var cpuDelta = (double)snap.CPUStats.CPUUsage.TotalUsage - (double)snap.PreCPUStats.CPUUsage.TotalUsage;
-                var systemDelta = (double)snap.CPUStats.SystemUsage - (double)snap.PreCPUStats.SystemUsage;
-                if (cpuDelta > 0 && systemDelta > 0)
+                IList<Docker.DotNet.Models.ContainerListResponse> containers;
+                try { containers = await dockerResolver.Resolve(group.Key).ListContainersAsync(all: true, cancellationToken); }
+                catch { continue; }
+
+                var stateByName = containers
+                    .SelectMany(c => (c.Names ?? new List<string>()).Select(n => (Name: n.TrimStart('/'), c.State, c.ID)))
+                    .ToDictionary(x => x.Name, x => (x.State, x.ID), StringComparer.OrdinalIgnoreCase);
+
+                foreach (var inst in group)
                 {
-                    totalCpuPercent += cpuDelta / systemDelta * 100d;
+                    if (inst.ContainerName is not null && stateByName.TryGetValue(inst.ContainerName, out var s)
+                        && string.Equals(s.State, "running", StringComparison.OrdinalIgnoreCase))
+                        runningContainers.Add((group.Key, s.ID));
                 }
             }
-            totalCpuPercent = Math.Round(Math.Clamp(totalCpuPercent, 0, 100), 1);
+
+            // Per-container memory + CPU%, each computed on the daemon that owns it (the node computes
+            // its own so only primitives cross the wire). A null sample (transient error) contributes 0.
+            var samples = await Task.WhenAll(runningContainers.Select(rc => dockerResolver.Resolve(rc.NodeId).GetContainerResourceUsageAsync(rc.Id, cancellationToken)));
+            var totalMemoryBytes = samples.Where(s => s is not null).Sum(s => s!.MemoryBytes);
+
+            // Summing each container's share of host CPU gives the share eaten by managed containers.
+            // Bounded to 100 because rounding + multi-core jitter can push the sum a hair over.
+            var totalCpuPercent = Math.Round(Math.Clamp(samples.Where(s => s is not null).Sum(s => s!.CpuPercent), 0, 100), 1);
 
             var perEngine = instances
                 .GroupBy(i => i.Engine, StringComparer.OrdinalIgnoreCase)
@@ -73,7 +65,7 @@ namespace KRINT.Application.Queries.Dashboard
             return new DashboardStatsDto
             {
                 TotalInstances = instances.Count,
-                RunningInstances = runningIds.Length,
+                RunningInstances = runningContainers.Count,
                 TotalMemoryBytes = totalMemoryBytes,
                 TotalCpuPercent = totalCpuPercent,
                 PerEngine = perEngine,

--- a/src/KRINT.Infrastructure/Interfaces/IDockerService.cs
+++ b/src/KRINT.Infrastructure/Interfaces/IDockerService.cs
@@ -2,6 +2,10 @@ using Docker.DotNet.Models;
 
 namespace KRINT.Infrastructure.Interfaces
 {
+    /// <summary>A container's instantaneous resource use: memory in bytes and CPU as a fraction of
+    /// total host CPU (0-100).</summary>
+    public record ContainerResourceSample(long MemoryBytes, double CpuPercent);
+
     public interface IDockerService
     {
         Task<bool> PingAsync(CancellationToken cancellationToken = default);
@@ -15,6 +19,10 @@ namespace KRINT.Infrastructure.Interfaces
 
         /// <summary>One-shot stats snapshot (Stream=false). Returns null if the container is stopped or unreachable.</summary>
         Task<ContainerStatsResponse?> GetContainerStatsOnceAsync(string id, CancellationToken cancellationToken = default);
+
+        /// <summary>Memory bytes + CPU% for a single container, computed from one stats snapshot. Returns
+        /// null if unavailable. Primitive-only so it round-trips when this runs on a remote node.</summary>
+        Task<ContainerResourceSample?> GetContainerResourceUsageAsync(string id, CancellationToken cancellationToken = default);
 
         Task PullImageAsync(string image, string tag = "latest", CancellationToken cancellationToken = default);
 

--- a/src/KRINT.Infrastructure/Services/DockerService.cs
+++ b/src/KRINT.Infrastructure/Services/DockerService.cs
@@ -61,6 +61,27 @@ namespace KRINT.Infrastructure.Services
             }
         }
 
+        public async Task<ContainerResourceSample?> GetContainerResourceUsageAsync(string id, CancellationToken cancellationToken = default)
+        {
+            var snap = await GetContainerStatsOnceAsync(id, cancellationToken);
+            if (snap is null) return null;
+
+            var memoryBytes = snap.MemoryStats is not null ? (long)snap.MemoryStats.Usage : 0L;
+
+            // CPU% = (cpuDelta / systemDelta) * 100, where systemDelta is host-wide CPU nanoseconds
+            // over the sample window - so the ratio is already this container's share of total host CPU.
+            double cpuPercent = 0d;
+            if (snap.CPUStats is not null && snap.PreCPUStats is not null)
+            {
+                var cpuDelta = (double)snap.CPUStats.CPUUsage.TotalUsage - (double)snap.PreCPUStats.CPUUsage.TotalUsage;
+                var systemDelta = (double)snap.CPUStats.SystemUsage - (double)snap.PreCPUStats.SystemUsage;
+                if (cpuDelta > 0 && systemDelta > 0)
+                    cpuPercent = cpuDelta / systemDelta * 100d;
+            }
+
+            return new ContainerResourceSample(memoryBytes, cpuPercent);
+        }
+
         public Task PullImageAsync(string image, string tag = "latest", CancellationToken cancellationToken = default)
         {
             return client.Images.CreateImageAsync(


### PR DESCRIPTION
The dashboard now lists containers on each node's daemon (not just local), so node-hosted instances count toward running/memory/CPU. Memory and CPU are computed on the node and returned as primitives (the full stats response doesn't round-trip), summed per daemon. Docs updated: all operations now work on nodes.

Closes #227