### PR TITLE
Fix desktop release: strip any-case v prefix from the release tag version

### DIFF
--- a/.github/workflows/desktop-release.yaml
+++ b/.github/workflows/desktop-release.yaml
@@ -68,7 +68,10 @@ jobs:
         env:
           TAG: ${{ github.event.release.tag_name }}
         run: |
-          export VERSION="${TAG#v}"
+          # Strip any leading non-digit prefix (v, V, etc.) so the version is valid semver no matter
+          # how the release tag is cased - tags have shipped as both "v2.6.0" and "V2.6.2", and tauri
+          # rejects a non-semver version.
+          export VERSION="$(printf '%s' "$TAG" | sed -E 's/^[^0-9]*//')"
           node -e "
             const fs = require('fs');
             const conf = 'src-tauri/tauri.conf.json';


### PR DESCRIPTION
Release tags have shipped as both `v2.6.0` and `V2.6.2`; the stamp step only stripped a lowercase `v`, leaving `V2.6.2` which tauri rejects as a non-semver version, failing all three desktop builds. Strip any leading non-digit prefix so the stamped version is always valid semver.

Closes #235