### PR TITLE
Docs polish: brand color, concise landing, Diátaxis nav

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -19,20 +19,26 @@ export default defineConfig({
       { text: 'Developer setup', link: '/dev-setup' },
       { text: 'Nodes', link: '/nodes' },
     ],
+    // Grouped Diátaxis-style: get-it-running first, task guides next, concepts last.
     sidebar: [
       {
-        text: 'Getting started',
+        text: 'Get started',
         items: [
           { text: 'Self-hosting', link: '/self-host' },
           { text: 'Desktop app', link: '/desktop' },
+        ],
+      },
+      {
+        text: 'Guides',
+        items: [
+          { text: 'Declarative instances', link: '/declarative-instances' },
           { text: 'Developer setup', link: '/dev-setup' },
         ],
       },
       {
-        text: 'Features',
+        text: 'Concepts',
         items: [
-          { text: 'Nodes (remote Docker workers)', link: '/nodes' },
-          { text: 'Declarative instances', link: '/declarative-instances' },
+          { text: 'Nodes', link: '/nodes' },
         ],
       },
     ],

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,21 @@
+/* KRINT brand color: #325292 (deep blue). Light mode uses it directly; dark mode lightens the
+   link/text shade for contrast while keeping the brand blue on buttons. */
+:root {
+  --vp-c-brand-1: #325292;
+  --vp-c-brand-2: #3f63ac;
+  --vp-c-brand-3: #325292;
+  --vp-c-brand-soft: rgba(50, 82, 146, 0.14);
+}
+
+.dark {
+  --vp-c-brand-1: #7aa2e3;
+  --vp-c-brand-2: #5f86cf;
+  --vp-c-brand-3: #3a5ea0;
+  --vp-c-brand-soft: rgba(50, 82, 146, 0.24);
+}
+
+/* Hero title in the brand blue. */
+:root {
+  --vp-home-hero-name-color: transparent;
+  --vp-home-hero-name-background: linear-gradient(120deg, #325292, #5f86cf);
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,4 @@
+import DefaultTheme from 'vitepress/theme'
+import './custom.css'
+
+export default DefaultTheme

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,11 +21,11 @@ hero:
 
 features:
   - title: 16 engines, one click
-    details: PostgreSQL, MariaDB, MongoDB, MySQL, SQL Server, CockroachDB, TimescaleDB, ClickHouse, Cassandra, CouchDB, Neo4j, Redis, Valkey, Qdrant, plus SeaweedFS (S3) and Azurite (Azure Blob).
-  - title: Browse, query, manage
-    details: Spreadsheet-style row editing, an ad-hoc SQL console, live log tailing and an interactive shell — all from the browser.
+    details: Postgres, MySQL, Mongo, Redis, and 12 more.
+  - title: Browse & query
+    details: In-cell row editing and a SQL console in the browser.
   - title: Backups & upgrades
-    details: Manual or cron-scheduled backups, restore in place, and dump-restore-swap version upgrades that keep the host port.
+    details: Scheduled backups and in-place version upgrades.
   - title: Distributed nodes
-    details: Run the same image as a stripped node that dials into the control plane over SignalR to add remote Docker hosts — every operation tunnels over one connection.
+    details: Run databases on remote Docker hosts over one connection.
 ---


### PR DESCRIPTION
- Brand blue `#325292` applied via a VitePress theme override (hero title + buttons; lighter link shade in dark mode for contrast).
- Home feature cards trimmed to one line each (were too wordy).
- Sidebar regrouped Diátaxis-style: Get started / Guides / Concepts.

Closes #240