### PR TITLE
Showed both registries and replaced dashes in the docs

### DIFF
--- a/docs/declarative-instances.md
+++ b/docs/declarative-instances.md
@@ -1,7 +1,7 @@
 # Declarative instances (`instances.yaml`)
 
 Infrastructure-as-code for your databases: declare instances in a YAML file and KRINT provisions
-anything missing and reconciles passwords, databases, and users on startup — no clicking around the UI.
+anything missing and reconciles passwords, databases, and users on startup - no clicking around the UI.
 
 ## Wiring it up
 

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -9,7 +9,7 @@ KRINT ships two ways from one codebase:
 
 The desktop build is a [Tauri v2](https://v2.tauri.app) window wrapped around the **same
 `KRINT.API` binary** the Docker image runs. The API serves the SPA + its OIDC config itself
-(Production `MapFallbackToFile`), so the webview just points at the local backend — no separate
+(Production `MapFallbackToFile`), so the webview just points at the local backend - no separate
 frontend build, no API changes.
 
 ## How it works
@@ -18,7 +18,7 @@ On launch the desktop shell (`src-tauri/src/lib.rs`):
 
 1. Creates an app-data dir and a stable `vault.key` (AES-256, generated once, reused).
 2. Starts a tiny **in-process OIDC issuer** (`src-tauri/src/oidc.rs`) that auto-issues tokens
-   (no login screen) — zero-config local sign-in, no Docker or Java needed.
+   (no login screen) - zero-config local sign-in, no Docker or Java needed.
 3. Spawns `KRINT.API` as a **sidecar** with `Database__Provider=Sqlite` and the SQLite file in
    the app-data dir.
 4. Waits for the API to log `Application started`, then navigates the window to
@@ -27,8 +27,8 @@ On launch the desktop shell (`src-tauri/src/lib.rs`):
 
 ### Why Docker is still required
 
-KRINT provisions database instances as **sibling Docker containers**, so the desktop app — like
-the server — needs a Docker engine (Docker Desktop on Windows/macOS) running on the host. Auth,
+KRINT provisions database instances as **sibling Docker containers**, so the desktop app - like
+the server - needs a Docker engine (Docker Desktop on Windows/macOS) running on the host. Auth,
 however, no longer needs Docker: it's the in-process issuer above.
 
 ## Prerequisites
@@ -68,7 +68,7 @@ bun run desktop:build            # installers under src-tauri/target/release/bun
 
 For a no-install build, compile with the `portable` Cargo feature. It embeds the API sidecar +
 resources into `krint-desktop.exe` and self-extracts them to
-`%APPDATA%/app.krint.desktop/runtime-<version>/` on first launch — one ~150 MB double-clickable file:
+`%APPDATA%/app.krint.desktop/runtime-<version>/` on first launch - one ~150 MB double-clickable file:
 
 ```bash
 bun run publish:sidecar                                            # produce the sidecar + wwwroot to embed
@@ -95,7 +95,7 @@ Find the host triple with `rustc --print host-tuple`.
 ## Auto-updates
 
 The app checks for updates on launch (`tauri-plugin-updater`). If a newer signed release is
-available it downloads, installs, and restarts — replacing the whole bundle (API sidecar +
+available it downloads, installs, and restarts - replacing the whole bundle (API sidecar +
 resources included), so one update covers everything.
 
 How it fits together:
@@ -107,7 +107,7 @@ How it fits together:
 - Windows ships the **NSIS `.exe`** installer only (per-user, x64 + arm64, best updater support);
   MSI is intentionally not built.
 - Updatable formats: **AppImage** (Linux), **NSIS `.exe`** (Windows), **.app** (macOS). `.deb`/`.rpm`
-  are install-only (no self-update) — that's a Tauri limitation, not ours.
+  are install-only (no self-update) - that's a Tauri limitation, not ours.
 
 ### One-time setup (required before releases self-update)
 
@@ -122,14 +122,14 @@ How it fits together:
    - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
 
 Until the real pubkey + secrets are in place, signed builds (`tauri build`) and auto-update won't
-work — the rest of the desktop build still does.
+work - the rest of the desktop build still does.
 
 ## Notes / TODO
 
 - **Keep ICU**: the sidecar is published *without* `InvariantGlobalization` because the MSSQL
   client needs ICU. Single-file self-contained bundles ICU by default.
 - **Ports** (`5111` API, `18080` OIDC) are currently fixed in `src-tauri/src/lib.rs`. Binding the
-  API to port `0` and parsing the chosen port from stdout would avoid collisions — a good
+  API to port `0` and parsing the chosen port from stdout would avoid collisions - a good
   follow-up.
 - The desktop SQLite database lives in the OS app-data dir (e.g. `%APPDATA%/app.krint.desktop`,
   `~/Library/Application Support/app.krint.desktop`, `~/.local/share/app.krint.desktop`).

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -50,7 +50,7 @@ Node__Tokens__1=another-node-secret
 ```yaml
 services:
   krint-node:
-    image: ghcr.io/pianonic/krint:latest
+    image: ghcr.io/pianonic/krint:latest   # or pianonic/krint:latest (Docker Hub)
     container_name: krint-node
     restart: unless-stopped
     environment:

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -1,22 +1,22 @@
 # Nodes (experimental)
 
 A **node** runs database containers on a remote host. Provision a database onto it, then do
-**everything** through the control plane — browse, query, manage users, back up, upgrade, tail logs,
+**everything** through the control plane - browse, query, manage users, back up, upgrade, tail logs,
 open a shell. Every operation rides one SignalR connection, and nodes expose no ports.
 
 A node is the *same* KRINT image in a stripped role. It dials **out** to the control plane (so it
 works behind NAT/firewalls) and authenticates with a pre-shared token. The control plane keeps all
-state; the node holds nothing — it just runs the commands it's sent against its own loopback and
+state; the node holds nothing - it just runs the commands it's sent against its own loopback and
 returns the result.
 
 ## How it works
 
-- **Control plane** (default role): the full KRINT app — UI, API, database, the works. It keeps an
+- **Control plane** (default role): the full KRINT app - UI, API, database, the works. It keeps an
   allow-list of node tokens (`Node__Tokens`) and exposes the node hub at `/hubs/node`.
 - **Node** (`Krint__Role=node`): no UI, no app database, no auth. It bundles the Docker client and the
   database drivers and runs an agent that connects to the control plane, registers (name, machine, OS,
-  Docker version) and stays connected, executing whatever the control plane sends — container
-  lifecycle, SQL/queries, dumps/restores, log follows and interactive shells — against its own daemon.
+  Docker version) and stays connected, executing whatever the control plane sends - container
+  lifecycle, SQL/queries, dumps/restores, log follows and interactive shells - against its own daemon.
   Only a `/health` endpoint is served.
 
 A connected node appears on the control plane's **Nodes** page, where you can see its details and

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -1,6 +1,11 @@
 # Self-host KRINT
 
-Run KRINT from the pre-built image: `ghcr.io/pianonic/krint:latest`.
+Run KRINT from the pre-built image, on either registry:
+
+- **GitHub Container Registry** — `ghcr.io/pianonic/krint:latest`
+- **Docker Hub** — `pianonic/krint:latest`
+
+The two are identical; use whichever you prefer. Examples below use the GHCR tag.
 
 You need a Linux/Windows host with **Docker + Compose v2**, and a directory to keep state in.
 
@@ -21,7 +26,7 @@ Drop these two files in an empty folder and run `docker compose up -d`. Open <ht
 ```yaml
 services:
   krint:
-    image: ghcr.io/pianonic/krint:latest
+    image: ghcr.io/pianonic/krint:latest   # or pianonic/krint:latest (Docker Hub)
     container_name: krint
     restart: unless-stopped
     extra_hosts:

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -2,8 +2,8 @@
 
 Run KRINT from the pre-built image, on either registry:
 
-- **GitHub Container Registry** — `ghcr.io/pianonic/krint:latest`
-- **Docker Hub** — `pianonic/krint:latest`
+- **GitHub Container Registry** - `ghcr.io/pianonic/krint:latest`
+- **Docker Hub** - `pianonic/krint:latest`
 
 The two are identical; use whichever you prefer. Examples below use the GHCR tag.
 
@@ -13,9 +13,9 @@ You need a Linux/Windows host with **Docker + Compose v2**, and a directory to k
 
 | You have… | Do this |
 | --- | --- |
-| Your own OIDC provider (Pocket ID, Authentik, Auth0, Keycloak…) | [Quickstart](#quickstart) below — two files, no clone. |
-| Nothing yet, want zero-config auth | [Bundled Keycloak](#no-oidc-provider-bundled-keycloak) — clone the repo. |
-| A single machine, just you | The [desktop app](./desktop.md) — SQLite, built-in login, no Docker auth setup. |
+| Your own OIDC provider (Pocket ID, Authentik, Auth0, Keycloak…) | [Quickstart](#quickstart) below - two files, no clone. |
+| Nothing yet, want zero-config auth | [Bundled Keycloak](#no-oidc-provider-bundled-keycloak) - clone the repo. |
+| A single machine, just you | The [desktop app](./desktop.md) - SQLite, built-in login, no Docker auth setup. |
 
 ## Quickstart
 
@@ -78,7 +78,7 @@ KRINT_OIDC_REDIRECT_URI=http://localhost:5000/
 KRINT_CORS_ORIGIN=http://localhost:5000
 ```
 
-On your IdP, register KRINT as a **public client** (PKCE, no secret) with redirect URI `http://localhost:5000/*`. That's it — the rest is reference below.
+On your IdP, register KRINT as a **public client** (PKCE, no secret) with redirect URI `http://localhost:5000/*`. That's it - the rest is reference below.
 
 ## No OIDC provider? Bundled Keycloak
 
@@ -90,7 +90,7 @@ cp .env.example .env     # edit before first start
 docker compose up -d     # postgres + keycloak + krint
 ```
 
-First boot imports the `krint` realm (~30–60s). Then open Keycloak at <http://localhost:8080>, log in as the bootstrap admin from `.env`, switch to the **krint** realm, and add a user under **Users → Add user**. Log in to KRINT at <http://localhost:5000>.
+First boot imports the `krint` realm (~30-60s). Then open Keycloak at <http://localhost:8080>, log in as the bootstrap admin from `.env`, switch to the **krint** realm, and add a user under **Users → Add user**. Log in to KRINT at <http://localhost:5000>.
 
 ---
 
@@ -111,7 +111,7 @@ Set these on the `krint` service (the Quickstart pulls them from `.env`).
 | `Oidc__RedirectUri` / `…PostLogoutRedirectUri` | Return URL after login/logout. Must be registered on the IdP, keep the trailing slash. |
 | `Oidc__Scope` | `openid profile email roles` (`roles` optional). |
 | `Oidc__RequireHttpsMetadata` | `true` (set `false` only for a plain-HTTP IdP). |
-| `Cors__AllowedOrigins__0` | Browser origin allowed to call the API — KRINT URL **without** trailing slash. Add more as `__1`, `__2`. |
+| `Cors__AllowedOrigins__0` | Browser origin allowed to call the API - KRINT URL **without** trailing slash. Add more as `__1`, `__2`. |
 
 > ⚠️ **Never lose or rotate `Vault__MasterKey` once you have data.** There's no recovery and no key-rotation flow.
 
@@ -162,10 +162,10 @@ KRINT's SPA uses Authorization Code Flow + **PKCE**, so register a **public clie
 | Web origins / CORS | KRINT origin, no trailing slash |
 | Scopes | `openid profile email` (`roles` optional) |
 
-- **Pocket ID** — toggle **Public Client**; allow your user/group. `*` wildcards work.
-- **Authentik** — use the *Provider*'s issuer (`/application/o/<slug>/`) as the authority, not the Application URL.
-- **Auth0** — authority is `https://<tenant>.auth0.com/` (trailing slash); app type **SPA**.
-- **External Keycloak** — authority is `https://<host>/realms/<realm>`.
+- **Pocket ID** - toggle **Public Client**; allow your user/group. `*` wildcards work.
+- **Authentik** - use the *Provider*'s issuer (`/application/o/<slug>/`) as the authority, not the Application URL.
+- **Auth0** - authority is `https://<tenant>.auth0.com/` (trailing slash); app type **SPA**.
+- **External Keycloak** - authority is `https://<host>/realms/<realm>`.
 
 </details>
 
@@ -203,7 +203,7 @@ Migrations run on startup; the vault, metadata, and provisioned containers are p
 
 **Back up** the `./db/` (or `postgres-data` volume) and `./backups/` directories before major upgrades. Provisioned-instance volumes are independent and survive `docker compose down`.
 
-**Schedule dumps** from the Backups page — they land in `./backups/`.
+**Schedule dumps** from the Backups page - they land in `./backups/`.
 
 ---
 
@@ -216,14 +216,14 @@ Migrations run on startup; the vault, metadata, and provisioned containers are p
 | --- | --- |
 | `Vault:MasterKey must decode to 32 bytes` | Regenerate with `openssl rand -base64 32`. |
 | `401 invalid_token: issuer is invalid` | `Oidc__Authority` must match the IdP's `issuer` byte-for-byte. |
-| `401: signature key was not found` | API can't reach JWKS — check `Oidc__InternalAuthority` / `KC_HOSTNAME_BACKCHANNEL_DYNAMIC`. |
-| "You're not allowed to access this service" | IdP authenticated the user but the client policy denies them — allow the user/group. |
+| `401: signature key was not found` | API can't reach JWKS - check `Oidc__InternalAuthority` / `KC_HOSTNAME_BACKCHANNEL_DYNAMIC`. |
+| "You're not allowed to access this service" | IdP authenticated the user but the client policy denies them - allow the user/group. |
 | CORS error on `/api/*` | `Cors__AllowedOrigins__0` must match the SPA origin (no trailing slash). |
 | `Cannot connect to the Docker daemon` | The `/var/run/docker.sock` bind is missing from the `krint` service. |
 | `Failed to connect to 127.0.0.1:<port>` on provision | Add `extra_hosts: ["host.docker.internal:host-gateway"]`. |
-| `SocketException (13): Permission denied` | Running as non-root without socket access — keep the default root user or `group_add` the docker GID. |
-| `No free host port in range` | `krint.yaml` `port_ranges` exhausted — delete an instance or widen the range. |
-| DB auth fails after changing the password | `POSTGRES_PASSWORD` only applies on first init — reset in-DB or wipe the volume. |
+| `SocketException (13): Permission denied` | Running as non-root without socket access - keep the default root user or `group_add` the docker GID. |
+| `No free host port in range` | `krint.yaml` `port_ranges` exhausted - delete an instance or widen the range. |
+| DB auth fails after changing the password | `POSTGRES_PASSWORD` only applies on first init - reset in-DB or wipe the volume. |
 
 </details>
 


### PR DESCRIPTION
List both GHCR and Docker Hub in the self-host intro and compose snippets, and replace all em/en dashes with normal hyphens across the docs.

Closes #248