### PR TITLE
Slimmed README and collapsed extra screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 <p align="center">
   <a href="https://github.com/PianoNic/KRINT"><img src="https://badgetrack.pianonic.ch/badge?tag=krint&label=visits&color=0d1117&style=flat" alt="visits" /></a>
   <a href="docs/self-host.md"><img src="https://img.shields.io/badge/Self--Host-Instructions-0d1117.svg" alt="Self-hosting" /></a>
-  <a href="#tech-stack"><img src="https://img.shields.io/badge/.NET-10-0d1117.svg" alt=".NET 10" /></a>
-  <a href="#tech-stack"><img src="https://img.shields.io/badge/Angular-21-0d1117.svg" alt="Angular 21" /></a>
+  <img src="https://img.shields.io/badge/.NET-10-0d1117.svg" alt=".NET 10" />
+  <img src="https://img.shields.io/badge/Angular-21-0d1117.svg" alt="Angular 21" />
 </p>
 
 ---
@@ -18,26 +18,7 @@
 
 ## What is KRINT?
 
-KRINT is a self-hosted database-provisioning platform. Pick an engine, click Launch, and KRINT spins up a containerised instance with credentials, a host port, and a connection string already in hand. Browse rows, manage users, schedule backups, install extensions - all from the SPA.
-
-## Features
-
-- **16 engines**: PostgreSQL, MariaDB, MongoDB, MySQL, SQL Server, CockroachDB, TimescaleDB, ClickHouse, Cassandra, CouchDB, Neo4j, Redis, Valkey, Qdrant, plus object storage via SeaweedFS (S3) and Azurite (Azure Blob).
-- **Plugins**: pgvector, PostGIS, pg_trgm, Redis Stack, APOC, Graph Data Science, and more, opt-in at provision time.
-- **Live dashboard**: KPI cards, per-engine breakdown, and recent activity stream in over SignalR so the homepage stays current without refreshes.
-- **Browse & query**: spreadsheet-style in-cell editing of rows + an ad-hoc SQL console for the SQL engines (Ctrl/Cmd+Enter to run).
-- **Container console**: live-tail container logs and open an interactive `bash` / `sh` shell into any provisioned instance, all from the browser via xterm.js over a SignalR stream.
-- **Backups**: manual, cron-scheduled, or upload your own dump from disk; download or restore in place. Each backup is tagged with the source engine version.
-- **Version upgrade**: dump-restore-swap a provisioned instance to a newer engine version without changing its host port. The pre-upgrade snapshot is kept automatically.
-- **Users & access**: create logins, reset passwords, grant per-database access.
-- **OIDC auth**: bring your own provider (Pocket ID, Authentik, Auth0, ...) or use the bundled Keycloak.
-- **Capability-aware UI**: engines without "users" or "rows" simply don't show those controls.
-- **Nodes** (experimental): run the same image in a stripped `node` role that dials into the control plane over SignalR to add remote Docker hosts. Provision a database onto a node and browse, query, back up, upgrade, tail logs and open a shell on it — every operation tunnels over the one connection, so nodes expose no ports. See [docs/nodes.md](docs/nodes.md).
-
-## Documentation
-
-- 📖 **[Self-hosting guide](docs/self-host.md)**: run KRINT against the pre-built image with `docker compose`, configure auth (bundled Keycloak or bring your own OIDC provider), troubleshooting.
-- 🛠️ **[Developer setup](docs/dev-setup.md)**: local dev with `dotnet run` + Bun, EF migrations, the E2E test suite.
+KRINT is a self-hosted database-provisioning platform. Pick an engine, click Launch, and you get a containerised instance with credentials, a host port, and a connection string in hand. Then browse rows, run queries, manage users, and schedule backups - all from one UI.
 
 ## Screenshots
 
@@ -46,12 +27,16 @@ KRINT is a self-hosted database-provisioning platform. Pick an engine, click Lau
   <img src="assets/screenshots/instances.png" width="49%" alt="Instances list" />
 </p>
 <p align="center">
-  <img src="assets/screenshots/create-engine.png" width="49%" alt="Create wizard - engine picker" />
-  <img src="assets/screenshots/create-plugins.png" width="49%" alt="Create wizard - plugins step" />
-</p>
-<p align="center">
+  <img src="assets/screenshots/create-engine.png" width="49%" alt="Create wizard" />
   <img src="assets/screenshots/browser.png" width="49%" alt="Database browser" />
+</p>
+
+<details>
+<summary><strong>Show more screenshots</strong></summary>
+
+<p align="center">
   <img src="assets/screenshots/query.png" width="49%" alt="Query console" />
+  <img src="assets/screenshots/create-plugins.png" width="49%" alt="Create wizard - plugins step" />
 </p>
 <p align="center">
   <img src="assets/screenshots/console-logs.png" width="49%" alt="Container logs streaming" />
@@ -74,64 +59,34 @@ KRINT is a self-hosted database-provisioning platform. Pick an engine, click Lau
   <img src="assets/screenshots/settings.png" width="49%" alt="Settings" />
 </p>
 
-## Tech stack
+</details>
 
-- **.NET 10** ASP.NET Core API (Mediator pattern, EF Core, Clean Architecture: API / Application / Domain / Infrastructure)
-- **Angular 21** + Signals + Spartan UI (helm/brain) for the SPA
-- **SignalR** hubs for live dashboard updates, container log tailing, and interactive shell over WebSockets
-- **xterm.js** in the browser for the container console (logs + interactive TTY)
-- **Docker.DotNet** drives container lifecycle (create, start, exec, tar-extract for restores); a hand-rolled npipe/unix-socket HTTP upgrade client handles the interactive exec stdin path
-- **Keycloak** for OIDC; Keycloakify for the bundled login theme
-- **TUnit** + **Microsoft.Playwright** for end-to-end tests against a live stack
-- **OpenAPI** at `/openapi/v1.json`; the Angular client is regenerated via `bun run apigen`
+## Features
 
-## Getting started
+- **16 engines** + opt-in plugins (pgvector, PostGIS, Redis Stack, APOC, and more).
+- **Browse & query**: in-cell row editing and an ad-hoc SQL console.
+- **Container console**: live log tailing and an interactive shell, in the browser.
+- **Backups**: manual, scheduled, or upload your own; restore or upgrade in place.
+- **Users & access**: logins, password resets, per-database grants.
+- **OIDC auth**: bring your own provider or use the bundled Keycloak.
+- **Nodes** (experimental): provision onto remote Docker hosts over one connection. See [docs/nodes.md](docs/nodes.md).
 
-### Prerequisites
+## Get started
 
-- Docker Desktop (with Docker daemon reachable on the default socket)
-- .NET 10 SDK
-- Bun (or Node) for the frontend
-- Optional: Keycloak running on `http://localhost:8080` with the bundled `krint` realm
+- 📦 **[Self-hosting guide](docs/self-host.md)** - run the image with `docker compose`.
+- 🛠️ **[Developer setup](docs/dev-setup.md)** - local dev with `dotnet run` + Bun, migrations, tests.
 
-### Run the API
+<details>
+<summary><strong>Tech stack</strong></summary>
 
-```powershell
-dotnet run --project src/KRINT.API
-```
+- **.NET 10** ASP.NET Core API (Mediator, EF Core, Clean Architecture).
+- **Angular 21** + Signals + Spartan UI.
+- **SignalR** for the live dashboard, log tailing, and interactive shell; **xterm.js** for the console.
+- **Docker.DotNet** for container lifecycle.
+- **Keycloak** for OIDC.
+- **TUnit** + **Microsoft.Playwright** for tests; **OpenAPI** client via `bun run apigen`.
 
-Default URLs (see `src/KRINT.API/Properties/launchSettings.json`):
-
-- HTTP: http://localhost:5165
-- HTTPS: https://localhost:7064
-- OpenAPI spec: `/openapi/v1.json`
-- **Scalar API reference**: `/scalar/v1` - interactive docs you can call straight from the browser (Scalar replaces Swagger UI in this project)
-
-### Run the frontend
-
-```powershell
-cd src/KRINT.Frontend
-bun install
-bun start          # ng serve on http://localhost:4200
-bun run apigen     # regenerate the API client after backend changes
-```
-
-### Run in Docker
-
-```powershell
-docker build -t krint-api -f src/KRINT.API/Dockerfile src/KRINT.API
-docker run --rm -p 8080:8080 -p 8081:8081 krint-api
-```
-
-The full stack (Keycloak + API + frontend) lives in the [developer setup guide](docs/dev-setup.md).
-
-## Testing
-
-```powershell
-dotnet run --project src/KRINT.Tests
-```
-
-`KRINT.Tests` uses [TUnit](https://github.com/thomhurst/TUnit). The suite includes both unit tests and a Playwright-driven browser E2E (`E2E/KrintEndToEndTests.cs`) that exercises the wizard, instance dialogs, backups, and activity log against a live Keycloak + API + frontend.
+</details>
 
 ## License
 


### PR DESCRIPTION
Show the 4 key screenshots with the rest behind a "Show more" collapsible, condense features, fold tech stack into a details block, and replace the duplicated getting-started/testing prose with links to the docs.

Closes #250