### PR TITLE
Linked README to official docs and added engine capability matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 <p align="center">
   <a href="https://github.com/PianoNic/KRINT"><img src="https://badgetrack.pianonic.ch/badge?tag=krint&label=visits&color=0d1117&style=flat" alt="visits" /></a>
-  <a href="docs/self-host.md"><img src="https://img.shields.io/badge/Self--Host-Instructions-0d1117.svg" alt="Self-hosting" /></a>
+  <a href="https://docs.krint.pianonic.ch/self-host"><img src="https://img.shields.io/badge/Self--Host-Instructions-0d1117.svg" alt="Self-hosting" /></a>
   <img src="https://img.shields.io/badge/.NET-10-0d1117.svg" alt=".NET 10" />
   <img src="https://img.shields.io/badge/Angular-21-0d1117.svg" alt="Angular 21" />
 </p>
@@ -73,8 +73,10 @@ KRINT is a self-hosted database-provisioning platform. Pick an engine, click Lau
 
 ## Get started
 
-- 📦 **[Self-hosting guide](docs/self-host.md)** - run the image with `docker compose`.
-- 🛠️ **[Developer setup](docs/dev-setup.md)** - local dev with `dotnet run` + Bun, migrations, tests.
+- 📦 **[Self-hosting guide](https://docs.krint.pianonic.ch/self-host)** - run the image with `docker compose`.
+- 🛠️ **[Developer setup](https://docs.krint.pianonic.ch/dev-setup)** - local dev with `dotnet run` + Bun, migrations, tests.
+
+Full documentation: **[docs.krint.pianonic.ch](https://docs.krint.pianonic.ch)**
 
 <details>
 <summary><strong>Tech stack</strong></summary>

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ KRINT is a self-hosted database-provisioning platform. Pick an engine, click Lau
 
 ## Features
 
-- **16 engines** + opt-in plugins (pgvector, PostGIS, Redis Stack, APOC, and more).
+- **[16 engines](https://docs.krint.pianonic.ch/engines)** + opt-in plugins (pgvector, PostGIS, Redis Stack, APOC, and more).
 - **Browse & query**: in-cell row editing and an ad-hoc SQL console.
 - **Container console**: live log tailing and an interactive shell, in the browser.
 - **Backups**: manual, scheduled, or upload your own; restore or upgrade in place.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
   themeConfig: {
     nav: [
       { text: 'Self-host', link: '/self-host' },
+      { text: 'Engines', link: '/engines' },
       { text: 'Developer setup', link: '/dev-setup' },
       { text: 'Nodes', link: '/nodes' },
     ],
@@ -26,6 +27,7 @@ export default defineConfig({
         items: [
           { text: 'Self-hosting', link: '/self-host' },
           { text: 'Desktop app', link: '/desktop' },
+          { text: 'Supported engines', link: '/engines' },
         ],
       },
       {

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -1,0 +1,34 @@
+# Supported engines
+
+KRINT supports 16 engines. **Every** engine lets you browse data and use the container console (live
+logs + an interactive shell). The table below shows the capabilities that differ between engines.
+
+| Engine | Edit rows | Multiple DBs | Users & grants | Backups | Plugins |
+| --- | :---: | :---: | :---: | :---: | :---: |
+| PostgreSQL | ✅ | ✅ | ✅ | ✅ | ✅ |
+| MariaDB | ✅ | ✅ | ✅ | ✅ | ❌ |
+| MySQL | ✅ | ✅ | ✅ | ✅ | ❌ |
+| SQL Server | ✅ | ✅ | ✅ | ✅ | ❌ |
+| MongoDB | ✅ | ✅ | ✅ | ✅ | ❌ |
+| TimescaleDB | ✅ | ✅ | ✅ | ✅ | ✅ |
+| CockroachDB | ✅ | ✅ | ✅ | ❌ | ❌ |
+| ClickHouse | ✅ | ✅ | ✅ | ❌ | ❌ |
+| Cassandra | ✅ | ✅ | ❌ | ❌ | ❌ |
+| CouchDB | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Redis | ✅ | ❌ | ❌ | ✅ | ✅ |
+| Valkey | ✅ | ❌ | ❌ | ✅ | ❌ |
+| Qdrant | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Neo4j | ❌ | ❌ | ❌ | ❌ | ✅ |
+| SeaweedFS (S3) | ⬆️ | ✅ | ❌ | ❌ | ❌ |
+| Azurite (Azure Blob) | ⬆️ | ✅ | ❌ | ❌ | ❌ |
+
+- **Edit rows** - in-cell editing of table rows. ⬆️ = object stores use file upload instead.
+- **Multiple DBs** - create more than one database/keyspace/bucket per instance.
+- **Users & grants** - manage logins and per-database access.
+- **Backups** - scheduled or manual dump/restore, plus in-place version upgrade.
+- **Plugins** - opt-in extensions at provision time: pgvector, PostGIS, pg_trgm and more (Postgres),
+  Redis Stack (Redis), APOC and Graph Data Science (Neo4j).
+
+> Engines use their own terms in the UI - Mongo shows collections/documents, Redis shows DB
+> numbers/keys, Neo4j shows labels/nodes, object stores show buckets/objects - and controls that
+> don't apply to an engine simply don't appear.


### PR DESCRIPTION
Point the README links and badge at docs.krint.pianonic.ch, and add a Supported engines page with a per-engine checkmark/X capability table (sourced from the engine definitions), wired into the docs nav and sidebar.

Closes #252