### PR TITLE
Grouped provisioned containers into their own Docker Compose project

### DIFF
--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -205,6 +205,8 @@ Migrations run on startup; the vault, metadata, and provisioned containers are p
 
 **Schedule dumps** from the Backups page - they land in `./backups/`.
 
+**Provisioned containers** are labelled as a Compose project named `krint-databases`, so Docker Desktop (and `docker compose ls`) groups them into their own cluster - separate from KRINT's own stack - instead of listing them as loose containers.
+
 ---
 
 ## Troubleshooting

--- a/src/KRINT.Application/Command/Database/CreateDatabaseCommand.cs
+++ b/src/KRINT.Application/Command/Database/CreateDatabaseCommand.cs
@@ -128,12 +128,7 @@ namespace KRINT.Application.Command.Database
                     Binds = new List<string> { bindSpec },
                     RestartPolicy = new RestartPolicy { Name = RestartPolicyKind.UnlessStopped },
                 },
-                Labels = new Dictionary<string, string>
-                {
-                    ["krint.managed"] = "true",
-                    ["krint.engine"] = command.Engine,
-                    ["krint.instance-id"] = instanceId.ToString(),
-                },
+                Labels = Containers.KrintContainerLabels.For(command.Engine, instanceId, command.DisplayName),
             };
 
             var createResult = await docker.CreateContainerAsync(createParams, cancellationToken);

--- a/src/KRINT.Application/Command/Database/UpgradeDatabaseCommand.cs
+++ b/src/KRINT.Application/Command/Database/UpgradeDatabaseCommand.cs
@@ -116,12 +116,7 @@ namespace KRINT.Application.Command.Database
                     Binds = new List<string> { newBindSpec },
                     RestartPolicy = new RestartPolicy { Name = RestartPolicyKind.UnlessStopped },
                 },
-                Labels = new Dictionary<string, string>
-                {
-                    ["krint.managed"] = "true",
-                    ["krint.engine"] = instance.Engine,
-                    ["krint.instance-id"] = instance.Id.ToString(),
-                },
+                Labels = Containers.KrintContainerLabels.For(instance.Engine, instance.Id, instance.DisplayName),
             };
 
             var newCreateResult = await docker.CreateContainerAsync(createParams, cancellationToken);

--- a/src/KRINT.Application/Command/DatabaseInstance/SetInstanceVisibilityCommand.cs
+++ b/src/KRINT.Application/Command/DatabaseInstance/SetInstanceVisibilityCommand.cs
@@ -87,12 +87,7 @@ namespace KRINT.Application.Command.DatabaseInstance
                     Binds = new List<string> { bindSpec },
                     RestartPolicy = new RestartPolicy { Name = RestartPolicyKind.UnlessStopped },
                 },
-                Labels = new Dictionary<string, string>
-                {
-                    ["krint.managed"] = "true",
-                    ["krint.engine"] = instance.Engine,
-                    ["krint.instance-id"] = instance.Id.ToString(),
-                },
+                Labels = Containers.KrintContainerLabels.For(instance.Engine, instance.Id, instance.DisplayName),
             };
 
             var createResult = await docker.CreateContainerAsync(createParams, cancellationToken);

--- a/src/KRINT.Application/Containers/KrintContainerLabels.cs
+++ b/src/KRINT.Application/Containers/KrintContainerLabels.cs
@@ -1,0 +1,51 @@
+using System.Text.RegularExpressions;
+
+namespace KRINT.Application.Containers
+{
+    /// <summary>
+    /// The labels stamped on every KRINT-provisioned container.
+    ///
+    /// Besides the internal <c>krint.*</c> labels (used by discovery to recognise our own
+    /// containers), we set Docker Compose project labels so Docker Desktop - and any tool that
+    /// reads them - groups all provisioned databases into one cluster instead of listing them as
+    /// loose, unrelated containers.
+    /// </summary>
+    public static partial class KrintContainerLabels
+    {
+        /// <summary>
+        /// The Compose project all provisioned databases are grouped under. Deliberately distinct
+        /// from the app's own stack (backend + db + keycloak, whose project is named after the repo
+        /// directory, usually "krint") so the provisioned databases form their own cluster in
+        /// Docker Desktop rather than mixing in with KRINT's own services.
+        /// </summary>
+        public const string ComposeProject = "krint-databases";
+
+        public static Dictionary<string, string> For(string engine, Guid instanceId, string? displayName = null)
+        {
+            return new Dictionary<string, string>
+            {
+                ["krint.managed"] = "true",
+                ["krint.engine"] = engine,
+                ["krint.instance-id"] = instanceId.ToString(),
+                // Compose project labels: make Docker Desktop cluster these under their own
+                // "krint-databases" project. We intentionally omit config_files/working_dir so the
+                // `docker compose` CLI won't try to manage containers with no compose file behind them.
+                ["com.docker.compose.project"] = ComposeProject,
+                ["com.docker.compose.service"] = ServiceName(engine, displayName),
+                ["com.docker.compose.oneoff"] = "False",
+            };
+        }
+
+        // Compose service names allow [a-zA-Z0-9._-]; slugify the display name and fall back to the
+        // engine so each instance shows up under a readable service row in the project.
+        private static string ServiceName(string engine, string? displayName)
+        {
+            var basis = string.IsNullOrWhiteSpace(displayName) ? engine : displayName!;
+            var slug = SlugRegex().Replace(basis.Trim().ToLowerInvariant(), "-").Trim('-');
+            return string.IsNullOrEmpty(slug) ? engine.ToLowerInvariant() : slug;
+        }
+
+        [GeneratedRegex("[^a-z0-9._-]+")]
+        private static partial Regex SlugRegex();
+    }
+}


### PR DESCRIPTION
Centralised the container labels into `KrintContainerLabels` and added Compose project labels so provisioned databases cluster under their own `krint-databases` project in Docker Desktop, separate from KRINT's own stack. Each instance gets its own service row (slugified display name).

Verified end-to-end against a real Docker daemon: the production label helper applied to real containers groups them under `krint-databases`, distinct from the app project, with per-instance services and the internal `krint.managed` label intact.

Closes #254