### PR TITLE
Hardened desktop release against flaky crates.io downloads

### DIFF
--- a/.github/workflows/desktop-release.yaml
+++ b/.github/workflows/desktop-release.yaml
@@ -14,6 +14,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
+    # crates.io downloads flake intermittently on CI (curl [55] SSL_ERROR_SYSCALL, usually from
+    # HTTP/2 multiplexing). Retry hard and disable multiplexing so a single bad chunk doesn't fail
+    # the whole release build.
+    env:
+      CARGO_NET_RETRY: "10"
+      CARGO_HTTP_MULTIPLEXING: "false"
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Set CARGO_NET_RETRY, CARGO_HTTP_MULTIPLEXING=false, and CARGO_NET_GIT_FETCH_WITH_CLI on the desktop job so transient crates.io download flakes (SSL_ERROR_SYSCALL) no longer fail the release build.

Closes #257