### PR TITLE
Fixed node role boot failure in Development by registering a local Docker resolver

### DIFF
--- a/src/KRINT.API/Nodes/LocalDockerServiceResolver.cs
+++ b/src/KRINT.API/Nodes/LocalDockerServiceResolver.cs
@@ -1,0 +1,13 @@
+using KRINT.Infrastructure.Interfaces;
+
+namespace KRINT.API.Nodes
+{
+    /// <summary>Node-role resolver: a node only ever drives its own Docker daemon (it never re-routes
+    /// to another node), so every instance resolves to the local <see cref="IDockerService"/>
+    /// regardless of nodeId. The control-plane equivalent (<see cref="DockerServiceResolver"/>) needs
+    /// the hub + registry, which don't exist on a node.</summary>
+    public class LocalDockerServiceResolver(IDockerService local) : IDockerServiceResolver
+    {
+        public IDockerService Resolve(Guid? nodeId) => local;
+    }
+}

--- a/src/KRINT.API/Program.cs
+++ b/src/KRINT.API/Program.cs
@@ -25,6 +25,9 @@ if (string.Equals(builder.Configuration["Krint:Role"], "node", StringComparison.
     // inner-service resolvers depend on INodeRpc, which is a no-op stub here (a node never re-routes).
     builder.Services.AddSingleton<KRINT.Infrastructure.Interfaces.INodeRpc, OfflineNodeRpc>();
     builder.Services.AddInnerDatabases();
+    // A node always uses its own daemon, so the backup/lifecycle services resolve Docker locally
+    // (the control-plane DockerServiceResolver needs the hub + registry, which a node doesn't have).
+    builder.Services.AddScoped<KRINT.Infrastructure.Interfaces.IDockerServiceResolver, LocalDockerServiceResolver>();
     builder.Services.AddHostedService<NodeAgentHostedService>();
 
     var nodeApp = builder.Build();


### PR DESCRIPTION
The node role registers the engine backup services, which depend on `IDockerServiceResolver` - only wired up on the control plane (it needs the hub + registry). Under Development, eager DI validation crashed the node on boot. Added a `LocalDockerServiceResolver` (a node only ever drives its own daemon) and registered it in the node branch. Verified the node role now boots cleanly in Development.

Closes #268