### PR TITLE
Reworked docs to match Komodo's content and chapter style

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -15,32 +15,43 @@ export default defineConfig({
   ],
   themeConfig: {
     nav: [
-      { text: 'Self-host', link: '/self-host' },
-      { text: 'Engines', link: '/engines' },
-      { text: 'Developer setup', link: '/dev-setup' },
+      { text: 'Intro', link: '/intro' },
+      { text: 'Setup', link: '/self-host' },
+      { text: 'Databases', link: '/engines' },
       { text: 'Nodes', link: '/nodes' },
+      { text: 'Development', link: '/dev-setup' },
     ],
-    // Grouped Diátaxis-style: get-it-running first, task guides next, concepts last.
+    // Komodo-style chapters: a flat intro first, then topic categories.
     sidebar: [
+      { text: 'What is KRINT?', link: '/intro' },
       {
-        text: 'Get started',
+        text: 'Setup',
+        collapsed: false,
         items: [
           { text: 'Self-hosting', link: '/self-host' },
           { text: 'Desktop app', link: '/desktop' },
+        ],
+      },
+      {
+        text: 'Databases',
+        collapsed: false,
+        items: [
           { text: 'Supported engines', link: '/engines' },
-        ],
-      },
-      {
-        text: 'Guides',
-        items: [
           { text: 'Declarative instances', link: '/declarative-instances' },
-          { text: 'Developer setup', link: '/dev-setup' },
         ],
       },
       {
-        text: 'Concepts',
+        text: 'Nodes',
+        collapsed: false,
         items: [
-          { text: 'Nodes', link: '/nodes' },
+          { text: 'Overview', link: '/nodes' },
+        ],
+      },
+      {
+        text: 'Development',
+        collapsed: false,
+        items: [
+          { text: 'Developer setup', link: '/dev-setup' },
         ],
       },
     ],

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -78,8 +78,10 @@ cargo build --release --features portable --manifest-path src-tauri/Cargo.toml
 
 The release workflow builds and uploads this as `KRINT-portable-win-x64.exe` alongside the NSIS installer.
 
-> First run also needs app icons. Generate them once with `bun run tauri icon path/to/icon.png`
-> (writes into `src-tauri/icons/`, which is gitignored).
+::: tip
+First run also needs app icons. Generate them once with `bun run tauri icon path/to/icon.png`
+(writes into `src-tauri/icons/`, which is gitignored).
+:::
 
 ### .NET RID ↔ Tauri target triple
 

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -38,9 +38,13 @@ dotnet user-secrets --project src/KRINT.API set "Vault:MasterKey" "$(openssl ran
 
 Verify with `dotnet user-secrets list --project src/KRINT.API`.
 
-> `appsettings.json` and `appsettings.Development.json` only carry ASP.NET framework defaults (logging, allowed hosts). Application config goes in user-secrets.
+::: info
+`appsettings.json` and `appsettings.Development.json` only carry ASP.NET framework defaults (logging, allowed hosts). Application config goes in user-secrets.
+:::
 
-> **Don't rotate `Vault:MasterKey` while you have encrypted secrets in the DB**: anything written with the old key becomes unreadable. There's no key-rotation flow yet.
+::: warning
+**Don't rotate `Vault:MasterKey` while you have encrypted secrets in the DB**: anything written with the old key becomes unreadable. There's no key-rotation flow yet.
+:::
 
 ## 2. Application config: `krint.yaml`
 

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -29,6 +29,8 @@ logs + an interactive shell). The table below shows the capabilities that differ
 - **Plugins** - opt-in extensions at provision time: pgvector, PostGIS, pg_trgm and more (Postgres),
   Redis Stack (Redis), APOC and Graph Data Science (Neo4j).
 
-> Engines use their own terms in the UI - Mongo shows collections/documents, Redis shows DB
-> numbers/keys, Neo4j shows labels/nodes, object stores show buckets/objects - and controls that
-> don't apply to an engine simply don't appear.
+::: info
+Engines use their own terms in the UI - Mongo shows collections/documents, Redis shows DB
+numbers/keys, Neo4j shows labels/nodes, object stores show buckets/objects - and controls that
+don't apply to an engine simply don't appear.
+:::

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,0 +1,39 @@
+# What is KRINT?
+
+KRINT is a self-hosted platform for provisioning and operating databases. Pick an engine, click Launch, and you get a containerised instance with credentials, a host port, and a connection string already in hand.
+
+- **Provision in one click**. 16 engines (Postgres, MySQL, Mongo, Redis, and more), each with opt-in plugins like pgvector and PostGIS.
+- **Browse and query**. Spreadsheet-style in-cell row editing and an ad-hoc SQL console, in the browser.
+- **Container console**. Live log tailing and an interactive shell into any provisioned instance.
+- **Back up and upgrade**. Manual or cron-scheduled dumps; restore or upgrade the engine version in place.
+- **Manage users and access**. Create logins, reset passwords, grant per-database access.
+- **Distribute across nodes**. Provision databases onto remote Docker hosts over a single connection.
+- **Bring your own auth**. OIDC with any provider (Pocket ID, Authentik, Auth0…), or the bundled Keycloak.
+
+There is no limit to the number of databases or nodes you can run.
+
+## Architecture
+
+KRINT runs from one image in one of two roles.
+
+| Role | What it does |
+| --- | --- |
+| **Control plane** (default) | The full app: UI, API, metadata database, and the secrets vault. All user interaction flows through it. |
+| **Node** (`Krint__Role=node`) | A stripped, stateless worker that runs database containers on its own host and dials **out** to the control plane over one SignalR connection. Owns no state. |
+
+Each database is provisioned as an isolated **sibling container** on the Docker host - not a child of KRINT - which is why KRINT mounts the Docker socket.
+
+## Distributions
+
+KRINT ships two ways from the same codebase.
+
+| Distribution | Metadata DB | Auth | Use case |
+| --- | --- | --- | --- |
+| **Docker image** | Postgres or SQLite | OIDC (bring-your-own or bundled Keycloak) | Servers, multi-user, always-on |
+| **Desktop app** | SQLite | Built-in, zero-config | A single user on their own machine |
+
+## Get started
+
+- **[Self-hosting](./self-host)** - run the image with `docker compose`.
+- **[Desktop app](./desktop)** - the single-user build.
+- **[Developer setup](./dev-setup)** - local dev with `dotnet run` + Bun.

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -1,47 +1,56 @@
-# Nodes (experimental)
+# Nodes
 
-A **node** runs database containers on a remote host. Provision a database onto it, then do
-**everything** through the control plane - browse, query, manage users, back up, upgrade, tail logs,
-open a shell. Every operation rides one SignalR connection, and nodes expose no ports.
+A **node** runs database containers on a remote host. Provision a database onto a node and then do everything with it through the control plane - browse, query, manage users, back up, upgrade, tail logs, and open a shell. Every operation rides a single SignalR connection, and nodes expose no ports.
 
-A node is the *same* KRINT image in a stripped role. It dials **out** to the control plane (so it
-works behind NAT/firewalls) and authenticates with a pre-shared token. The control plane keeps all
-state; the node holds nothing - it just runs the commands it's sent against its own loopback and
-returns the result.
+::: warning
+Nodes are experimental.
+:::
+
+A node is the *same* KRINT image started in a stripped role. It dials **out** to the control plane (so it works behind NAT and firewalls) and authenticates with a pre-shared token. The control plane keeps all state; the node holds nothing - it just runs the commands it's sent against its own loopback and returns the result.
+
+Connecting a node has 3 steps:
+
+1. **Set the control plane's public URL** so the generated compose can point back at it.
+2. **Add the node** (UI or config) to mint a token and save it.
+3. **Deploy the node** with that token. It dials in and shows up online.
 
 ## How it works
 
-- **Control plane** (default role): the full KRINT app - UI, API, database, the works. It keeps an
-  allow-list of node tokens (`Node__Tokens`) and exposes the node hub at `/hubs/node`.
-- **Node** (`Krint__Role=node`): no UI, no app database, no auth. It bundles the Docker client and the
-  database drivers and runs an agent that connects to the control plane, registers (name, machine, OS,
-  Docker version) and stays connected, executing whatever the control plane sends - container
-  lifecycle, SQL/queries, dumps/restores, log follows and interactive shells - against its own daemon.
-  Only a `/health` endpoint is served.
+- **Control plane** (default role): the full KRINT app - UI, API, database, vault. It exposes the node hub at `/hubs/node` and authorizes nodes by their token.
+- **Node** (`Krint__Role=node`): no UI, no app database, no auth. It bundles the Docker client and the database drivers, connects to the control plane, registers (name, machine, OS, Docker version), and stays connected - executing container lifecycle, queries, dumps/restores, log follows, and interactive shells against its own daemon. Only a `/health` endpoint is served.
 
-A connected node appears on the control plane's **Nodes** page, where you can see its details and
-**Ping** it to confirm the channel is live.
+A connected node appears on the control plane's **Nodes** page, where you can see its details and **Ping** it to confirm the channel is live. The node pings back every 5 seconds to keep its *last seen* current.
 
-## Add a node (recommended)
+## Set the public URL
 
-The easiest way: on the **Nodes** page press **Add node**. KRINT shows a ready-to-deploy compose with
-a freshly generated token and the control-plane URL baked in. Edit the node name if you like, then
-**Add node** to save it (nothing is stored until you do). Deploy the compose on the target host and
-it dials in - showing as *pending* until it first connects, then *online*.
-
-For the URL to be filled in automatically, set the public URL this control plane is served on in the
-**env file**:
+Set the public URL this control plane is served on in your **env file** so the Add-node compose is filled in automatically:
 
 ```env
 Krint__PublicUrl=https://krint.example.com
 ```
 
+::: info
+If `Krint__PublicUrl` is unset, the Add-node modal still works but uses a placeholder URL you'll need to edit by hand.
+:::
+
+## Add a node
+
+On the **Nodes** page, press **Add node**. KRINT generates a token and a ready-to-deploy compose with the control-plane URL baked in.
+
+1. Edit the node name if you like (optional).
+2. Copy the compose.
+3. Press **Add node** to save it. Nothing is stored until you do.
+4. Deploy the compose on the target host (see [Running a node](#running-a-node)).
+
+The node shows as **pending** until it first connects, then **online**.
+
+::: tip
 The node's identity is derived from its token, so the generated compose needs no `Node__Id`.
+:::
 
 ## Declare nodes in config
 
-Nodes can also be declared up front in `krint.yaml`, just like instances - each is a name and a
-secret. On startup KRINT ensures a matching node exists (token stored hashed):
+Nodes can also be declared up front in `krint.yaml`, just like instances - each is a name and a secret. On startup KRINT ensures a matching node exists (the secret is stored hashed):
 
 ```yaml
 krint:
@@ -52,28 +61,18 @@ krint:
       secret: another-long-random-secret
 ```
 
-Deploy each node with its secret as `Node__Token` (see below). Removing a node from the config stops
-re-asserting it; delete it from the UI to revoke access.
+Deploy each node with its secret as `Node__Token`. Removing a node from the config stops re-asserting it; delete it from the UI to revoke access.
 
 ## Running a node
 
 Set these on the node process (environment variables; `__` maps to nested config):
 
-| Setting | Purpose |
-| --- | --- |
-| `Krint__Role=node` | Boot in node role. |
-| `Node__ControlPlaneUrl` | Base URL of the control plane, e.g. `https://krint.example.com`. |
-| `Node__Token` | The token from the Add-node modal or the secret you declared in `krint.yaml`. |
-| `Node__Name` | Optional display name (defaults to the machine name). Ignored if the node was named in the UI/config. |
-
-> Legacy: a static `Node__Tokens` allow-list on the control plane still works; those nodes self-report
-> a `Node__Id` (a stable GUID) instead of having their identity derived from the token.
-
-Provision onto a node from the create wizard's **Target node** dropdown (it appears once a node is
-online), or pass `nodeId` in the provision request. The instance then shows a node badge on the
-instances list.
-
-### Compose snippet (node)
+| Variable | Description | Default |
+| --- | --- | --- |
+| `Krint__Role` | Set to `node` to boot in node role. | `control plane` |
+| `Node__ControlPlaneUrl` | Base URL of the control plane, e.g. `https://krint.example.com`. | — |
+| `Node__Token` | The token from the Add-node modal, or the secret you declared in `krint.yaml`. | — |
+| `Node__Name` | Display name. Ignored if the node was named in the UI or config. | machine name |
 
 ```yaml
 services:
@@ -91,5 +90,12 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 ```
 
-The node pings the control plane every 5 seconds so its *last seen* stays current, retries on its own
-if the control plane is unreachable at boot, and re-registers automatically after a reconnect.
+The node retries on its own if the control plane is unreachable at boot, and re-registers automatically after a reconnect.
+
+::: info
+**Legacy:** a static `Node__Tokens` allow-list on the control plane still works; those nodes self-report a `Node__Id` (a stable GUID) instead of deriving their identity from the token.
+:::
+
+## Provision onto a node
+
+Pick the node from the create wizard's **Target node** dropdown (it appears once a node is online), or pass `nodeId` in the provision request. The instance then shows a node badge on the instances list.

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -112,6 +112,7 @@ Set these on the `krint` service (the Quickstart pulls them from `.env`).
 | `Oidc__Scope` | `openid profile email roles` (`roles` optional). |
 | `Oidc__RequireHttpsMetadata` | `true` (set `false` only for a plain-HTTP IdP). |
 | `Cors__AllowedOrigins__0` | Browser origin allowed to call the API - KRINT URL **without** trailing slash. Add more as `__1`, `__2`. |
+| `Krint__PublicUrl` | Public URL this control plane is served on (e.g. `https://krint.example.com`). Used to pre-fill the [Add-node](./nodes#add-a-node-recommended) compose. Optional. |
 
 > ⚠️ **Never lose or rotate `Vault__MasterKey` once you have data.** There's no recovery and no key-rotation flow.
 

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -114,7 +114,9 @@ Set these on the `krint` service (the Quickstart pulls them from `.env`).
 | `Cors__AllowedOrigins__0` | Browser origin allowed to call the API - KRINT URL **without** trailing slash. Add more as `__1`, `__2`. |
 | `Krint__PublicUrl` | Public URL this control plane is served on (e.g. `https://krint.example.com`). Used to pre-fill the [Add-node](./nodes#add-a-node-recommended) compose. Optional. |
 
-> ⚠️ **Never lose or rotate `Vault__MasterKey` once you have data.** There's no recovery and no key-rotation flow.
+::: danger
+**Never lose or rotate `Vault__MasterKey` once you have data.** There's no recovery and no key-rotation flow.
+:::
 
 </details>
 

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -112,7 +112,9 @@ Set these on the `krint` service (the Quickstart pulls them from `.env`).
 | `Oidc__Scope` | `openid profile email roles` (`roles` optional). |
 | `Oidc__RequireHttpsMetadata` | `true` (set `false` only for a plain-HTTP IdP). |
 | `Cors__AllowedOrigins__0` | Browser origin allowed to call the API - KRINT URL **without** trailing slash. Add more as `__1`, `__2`. |
-| `Krint__PublicUrl` | Public URL this control plane is served on (e.g. `https://krint.example.com`). Used to pre-fill the [Add-node](./nodes#add-a-node-recommended) compose. Optional. |
+| `Krint__PublicUrl` | Public URL this control plane is served on (e.g. `https://krint.example.com`). Used to pre-fill the [Add-node](./nodes#add-a-node) compose. Optional. |
+| `Backup__Directory` | Where dumps are written. Optional - defaults to `/app/backups` (the path the compose bind-mounts). |
+| `Docker__Endpoint` | Docker daemon URI, e.g. `unix:///var/run/docker.sock`. Optional - auto-detected (Unix socket / Windows named pipe) when unset. |
 
 ::: danger
 **Never lose or rotate `Vault__MasterKey` once you have data.** There's no recovery and no key-rotation flow.


### PR DESCRIPTION
Makes the docs closely follow Komodo content- and chapter-wise:

- **Chapters**: topic-based collapsible sidebar (Setup / Databases / Nodes / Development) with a flat "What is KRINT?" intro first.
- **Intro page** in Komodo's shape: one-line summary, bold-lead feature bullets, Architecture table, Distributions table.
- **Admonitions** (`::: info` / `::: tip` / `::: warning` / `::: danger`) replacing plain blockquote notes across all pages.
- **Numbered step procedures** and a fields table (`Variable | Description | Default`) in nodes.md, mirroring Komodo's "Connect Servers" page.
- Documented the missing `Krint__PublicUrl` env var.

Closes #270