### PR TITLE
Fixed self-host quickstart missing Database__Provider for Postgres

### DIFF
--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -37,6 +37,7 @@ services:
     ports:
       - "5000:8080"
     environment:
+      Database__Provider: "Postgres"
       ConnectionStrings__KrintDatabase: "Host=db;Port=5432;Database=krint;Username=postgres;Password=${POSTGRES_PASSWORD}"
       Vault__MasterKey: ${KRINT_VAULT_KEY}
       Oidc__Authority: ${KRINT_OIDC_AUTHORITY}


### PR DESCRIPTION
The Quickstart compose ships a Postgres connection string but left `Database__Provider` unset, so it defaulted to SQLite and crashed with `Connection string keyword 'host' is not supported`. Added `Database__Provider: "Postgres"` to the Quickstart `krint` service.

Closes #273