### PR TITLE
Inferred database provider from connection string to avoid SQLite/Postgres mismatch

### DIFF
--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -50,6 +50,9 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock   # Windows: //var/run/docker.sock
       - ./backups:/app/backups
+      # Optional: mount a krint.yaml to set port ranges, storage, declarative instances, or nodes.
+      # Without it KRINT logs "No krint.yaml found" and runs with sensible defaults - that's fine.
+      # - ./krint.yaml:/app/krint.yaml:ro
 
   db:
     image: postgres:18.4

--- a/src/KRINT.Infrastructure/Extensions/DatabaseExtensions.cs
+++ b/src/KRINT.Infrastructure/Extensions/DatabaseExtensions.cs
@@ -20,7 +20,7 @@ namespace KRINT.Infrastructure.Extensions
         private const string DefaultSqliteConnectionString = "Data Source=krint.db";
 
         public static DatabaseProvider GetDatabaseProvider(this IConfiguration configuration) =>
-            ParseProvider(configuration["Database:Provider"]);
+            ResolveProvider(configuration["Database:Provider"], configuration.GetConnectionString("KrintDatabase"));
 
         public static DatabaseProvider ParseProvider(string? value) => (value ?? string.Empty).Trim().ToLowerInvariant() switch
         {
@@ -30,10 +30,27 @@ namespace KRINT.Infrastructure.Extensions
                 $"Unknown Database:Provider '{value}'. Supported values are 'Sqlite' and 'Postgres'.")
         };
 
+        /// <summary>
+        /// Picks the provider. An explicit <c>Database:Provider</c> wins; when it's unset we infer
+        /// from the connection string, so a Postgres string (e.g. <c>Host=db;…</c>) isn't fed to the
+        /// SQLite provider - which otherwise crashes with "Connection string keyword 'host' is not
+        /// supported". Falls back to SQLite when there's nothing to go on.
+        /// </summary>
+        public static DatabaseProvider ResolveProvider(string? providerValue, string? connectionString)
+        {
+            if (!string.IsNullOrWhiteSpace(providerValue))
+                return ParseProvider(providerValue);
+
+            var cs = (connectionString ?? string.Empty).ToLowerInvariant();
+            var looksPostgres = cs.Contains("host=") || cs.Contains("server=")
+                || cs.Contains("username=") || cs.Contains("user id=");
+            return looksPostgres ? DatabaseProvider.Postgres : DatabaseProvider.Sqlite;
+        }
+
         public static IServiceCollection AddKrintDatabase(this IServiceCollection services, IConfiguration configuration)
         {
-            var provider = configuration.GetDatabaseProvider();
             var connectionString = configuration.GetConnectionString("KrintDatabase");
+            var provider = ResolveProvider(configuration["Database:Provider"], connectionString);
 
             services.AddDbContext<KrintDbContext>(options => options.ConfigureKrintProvider(provider, connectionString));
             return services;

--- a/src/KRINT.Infrastructure/KrintDbContext.cs
+++ b/src/KRINT.Infrastructure/KrintDbContext.cs
@@ -49,8 +49,8 @@ namespace KRINT.Infrastructure
         {
             // Used by the EF Core CLI. Provider and connection string are read straight from
             // the environment so `dotnet ef` targets the same database the app would at runtime.
-            var provider = DatabaseExtensions.ParseProvider(Environment.GetEnvironmentVariable("Database__Provider"));
             var connectionString = Environment.GetEnvironmentVariable("ConnectionStrings__KrintDatabase");
+            var provider = DatabaseExtensions.ResolveProvider(Environment.GetEnvironmentVariable("Database__Provider"), connectionString);
 
             var optionsBuilder = new DbContextOptionsBuilder<KrintDbContext>();
             optionsBuilder.ConfigureKrintProvider(provider, connectionString);


### PR DESCRIPTION
When `Database:Provider` is unset, infer it from the connection string (a `Host=` / `Server=` / `Username=` string selects Postgres) instead of always defaulting to SQLite - which crashed with `Connection string keyword 'host' is not supported`. Explicit `Database:Provider` still wins; empty falls back to SQLite. Also documented the optional `krint.yaml` mount in the Quickstart (the config file isn't visible in the container otherwise, hence "No krint.yaml found").

Closes #275