### PR TITLE
Respected configured Oidc redirect URI instead of overriding it

### DIFF
--- a/src/KRINT.API/Controllers/AppController.cs
+++ b/src/KRINT.API/Controllers/AppController.cs
@@ -8,7 +8,7 @@ namespace KRINT.API.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
-    public class AppController(IMediator mediator) : ControllerBase
+    public class AppController(IMediator mediator, IConfiguration configuration) : ControllerBase
     {
         [AllowAnonymous]
         [HttpGet]
@@ -17,21 +17,24 @@ namespace KRINT.API.Controllers
         {
             var result = await mediator.Send(new AppQuery(), cancellationToken);
 
-            // The redirect target must match whatever URL the browser is currently on  - 
-            // important when the bundled image is reached via a host-assigned random port
-            // (Testcontainers) or behind a proxy. Prefer the caller's Origin header so a
-            // split-origin dev setup (SPA on :4200, API on :5165) still points back at the
-            // SPA; fall back to the request host for same-origin / bundled deployments.
-            var request = HttpContext.Request;
-            var browserOrigin = request.Headers.Origin.ToString();
-            var origin = !string.IsNullOrWhiteSpace(browserOrigin)
-                ? browserOrigin.TrimEnd('/') + "/"
-                : $"{request.Scheme}://{request.Host.Value}/";
-            result = result with
+            // Respect an explicitly configured Oidc:RedirectUri (e.g. a fixed public HTTPS URL behind
+            // a reverse proxy). Only DERIVE it from the current request when it isn't configured - the
+            // bundled image reached via a host-assigned random port (Testcontainers), or a split-origin
+            // dev setup. The old code always overrode it, which behind a TLS-terminating proxy produced
+            // an http:// URL the IdP rejects even when the admin set the right https URL.
+            if (string.IsNullOrWhiteSpace(configuration["Oidc:RedirectUri"]))
             {
-                RedirectUri = origin,
-                PostLogoutRedirectUri = origin,
-            };
+                var request = HttpContext.Request;
+                var browserOrigin = request.Headers.Origin.ToString();
+                var origin = !string.IsNullOrWhiteSpace(browserOrigin)
+                    ? browserOrigin.TrimEnd('/') + "/"
+                    : $"{request.Scheme}://{request.Host.Value}/";
+                result = result with
+                {
+                    RedirectUri = origin,
+                    PostLogoutRedirectUri = origin,
+                };
+            }
 
             return Ok(result);
         }


### PR DESCRIPTION
`/api/App` always replaced `Oidc:RedirectUri` with a value derived from the request, which behind a TLS-terminating reverse proxy is `http://…` - and the IdP rejected it ("Invalid callback URL") even when `Oidc__RedirectUri` was set correctly to the https URL. Now KRINT respects the configured `Oidc:RedirectUri`/`PostLogoutRedirectUri` and only derives from the request when it isn't set (e.g. the bundled image on a random host port).

Closes #280