### PR TITLE
Stamped the real version into the Docker image (was defaulting to 1.0.0)

### DIFF
--- a/src/KRINT.API/Dockerfile
+++ b/src/KRINT.API/Dockerfile
@@ -23,6 +23,10 @@ RUN dotnet restore "KRINT.API/KRINT.API.csproj"
 FROM backend-deps AS backend-build
 ARG BUILD_CONFIGURATION=Release
 COPY src .
+# Directory.Build.props (at /src/backend) reads ..\application.properties to stamp the version - i.e.
+# /src/application.properties. It lives at the repo root, not under src/, so copy it explicitly;
+# without it the assembly version falls back to .NET's default 1.0.0 and the UI shows "v1.0.0".
+COPY application.properties /src/application.properties
 RUN dotnet publish "KRINT.API/KRINT.API.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 # ---------- Stage 4: runtime (distroless Azure Linux) ----------


### PR DESCRIPTION
The Dockerfile never copied application.properties into the build, so Directory.Build.props' version-stamp target found nothing and the assembly fell back to .NET's default 1.0.0 - which the UI showed as "v1.0.0". Copy application.properties to /src/application.properties (where Directory.Build.props' `..\application.properties` resolves) before publish. Verified a clean build stamps the real version (2.9.0).

Closes #283