### PR TITLE
Pre-set Krint__PublicUrl in quickstart and showed node names in the target-node picker

### DIFF
--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -47,6 +47,7 @@ services:
       Oidc__Scope: "openid profile email roles"
       Oidc__RequireHttpsMetadata: "true"
       Cors__AllowedOrigins__0: ${KRINT_CORS_ORIGIN}
+      Krint__PublicUrl: ${KRINT_PUBLIC_URL}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock   # Windows: //var/run/docker.sock
       - ./backups:/app/backups
@@ -79,6 +80,9 @@ KRINT_OIDC_AUTHORITY=https://auth.example.com/realms/krint
 KRINT_OIDC_CLIENT_ID=krint
 KRINT_OIDC_REDIRECT_URI=http://localhost:5000/
 KRINT_CORS_ORIGIN=http://localhost:5000
+
+# The public URL KRINT is served on - used to pre-fill the Add-node compose.
+KRINT_PUBLIC_URL=http://localhost:5000
 ```
 
 **`krint.yaml`** - the host-port ranges KRINT allocates from per engine. Copy as-is:

--- a/src/KRINT.Frontend/src/app/create/create.html
+++ b/src/KRINT.Frontend/src/app/create/create.html
@@ -165,6 +165,7 @@
                 <hlm-select
                   [value]="selectedNodeId() ?? ''"
                   (valueChange)="selectedNodeId.set($event || null)"
+                  [itemToString]="nodeLabel"
                 >
                   <hlm-select-trigger class="w-full">
                     <hlm-select-value placeholder="Local (control plane)" />

--- a/src/KRINT.Frontend/src/app/create/create.ts
+++ b/src/KRINT.Frontend/src/app/create/create.ts
@@ -124,6 +124,12 @@ export class Create {
   // Target node for provisioning: null = the control plane's local Docker. Only online nodes are offered.
   protected readonly onlineNodes = signal<ReadonlyArray<NodeDto>>([]);
   protected readonly selectedNodeId = signal<string | null>(null);
+  // Maps the selected node id back to its name for the trigger label (the lazy *hlmSelectPortal
+  // options aren't available to brn-select, so without this it shows the raw GUID).
+  protected readonly nodeLabel = (id: string): string => {
+    if (!id) return 'Local (control plane)';
+    return this.onlineNodes().find((n) => n.id === id)?.name ?? id;
+  };
   // Root password: empty string = auto-generate at provision time.
   protected readonly customRootPassword = signal('');
   // Per-user custom passwords - empty string at index n means auto-generate.


### PR DESCRIPTION
Set `Krint__PublicUrl` in the self-host Quickstart compose + .env so the Add-node modal is pre-filled instead of warning. Also added `[itemToString]` to the create wizard's "Target node" select so it shows the node name instead of the raw GUID (same fix as #103).

Closes #285