### PR TITLE
Reached provisioned DBs over KRINT's network; made public URL the single config source

### DIFF
--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -40,14 +40,12 @@ services:
       Database__Provider: "Postgres"
       ConnectionStrings__KrintDatabase: "Host=db;Port=5432;Database=krint;Username=postgres;Password=${POSTGRES_PASSWORD}"
       Vault__MasterKey: ${KRINT_VAULT_KEY}
+      Krint__PublicUrl: ${KRINT_PUBLIC_URL}              # login redirect + CORS are derived from this
+      Cors__AllowedOrigins__0: ${KRINT_PUBLIC_URL}
       Oidc__Authority: ${KRINT_OIDC_AUTHORITY}
       Oidc__ClientId: ${KRINT_OIDC_CLIENT_ID}
-      Oidc__RedirectUri: ${KRINT_OIDC_REDIRECT_URI}
-      Oidc__PostLogoutRedirectUri: ${KRINT_OIDC_REDIRECT_URI}
       Oidc__Scope: "openid profile email roles"
       Oidc__RequireHttpsMetadata: "true"
-      Cors__AllowedOrigins__0: ${KRINT_CORS_ORIGIN}
-      Krint__PublicUrl: ${KRINT_PUBLIC_URL}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock   # Windows: //var/run/docker.sock
       - ./backups:/app/backups
@@ -76,13 +74,12 @@ services:
 POSTGRES_PASSWORD=change-me
 KRINT_VAULT_KEY=GENERATE_ME          # openssl rand -base64 32
 
+# The public URL KRINT is served on. The login redirect URI and CORS origin are derived from it.
+KRINT_PUBLIC_URL=http://localhost:5000
+
+# Your OIDC provider:
 KRINT_OIDC_AUTHORITY=https://auth.example.com/realms/krint
 KRINT_OIDC_CLIENT_ID=krint
-KRINT_OIDC_REDIRECT_URI=http://localhost:5000/
-KRINT_CORS_ORIGIN=http://localhost:5000
-
-# The public URL KRINT is served on - used to pre-fill the Add-node compose.
-KRINT_PUBLIC_URL=http://localhost:5000
 ```
 
 **`krint.yaml`** - the host-port ranges KRINT allocates from per engine. Copy as-is:
@@ -265,7 +262,7 @@ Migrations run on startup; the vault, metadata, and provisioned containers are p
 | "You're not allowed to access this service" | IdP authenticated the user but the client policy denies them - allow the user/group. |
 | CORS error on `/api/*` | `Cors__AllowedOrigins__0` must match the SPA origin (no trailing slash). |
 | `Cannot connect to the Docker daemon` | The `/var/run/docker.sock` bind is missing from the `krint` service. |
-| `Failed to connect to 127.0.0.1:<port>` on provision | Add `extra_hosts: ["host.docker.internal:host-gateway"]`. |
+| `<engine> container did not become ready` on provision | KRINT reaches provisioned DBs over its own Docker network (the default compose network) and falls back to the host port - keep `extra_hosts: ["host.docker.internal:host-gateway"]` on the krint service for that fallback. |
 | `SocketException (13): Permission denied` | Running as non-root without socket access - keep the default root user or `group_add` the docker GID. |
 | `No free host port in range` | `krint.yaml` `port_ranges` exhausted - delete an instance or widen the range. |
 | DB auth fails after changing the password | `POSTGRES_PASSWORD` only applies on first init - reset in-DB or wipe the volume. |

--- a/src/KRINT.API/Controllers/AppController.cs
+++ b/src/KRINT.API/Controllers/AppController.cs
@@ -22,7 +22,7 @@ namespace KRINT.API.Controllers
             // bundled image reached via a host-assigned random port (Testcontainers), or a split-origin
             // dev setup. The old code always overrode it, which behind a TLS-terminating proxy produced
             // an http:// URL the IdP rejects even when the admin set the right https URL.
-            if (string.IsNullOrWhiteSpace(configuration["Oidc:RedirectUri"]))
+            if (string.IsNullOrWhiteSpace(configuration["Oidc:RedirectUri"]) && string.IsNullOrWhiteSpace(configuration["Krint:PublicUrl"]))
             {
                 var request = HttpContext.Request;
                 var browserOrigin = request.Headers.Origin.ToString();

--- a/src/KRINT.API/Controllers/NodesController.cs
+++ b/src/KRINT.API/Controllers/NodesController.cs
@@ -48,11 +48,13 @@ namespace KRINT.API.Controllers
         [ProducesResponseType(typeof(NodeDraftDto), StatusCodes.Status200OK)]
         public IActionResult Draft()
         {
-            var controlPlaneUrl = configuration["Krint:PublicUrl"] ?? options.Value.PublicUrl;
+            // Krint:PublicUrl is required for self-hosting (it also drives the OIDC redirect + CORS),
+            // so it's always present here.
+            var controlPlaneUrl = (configuration["Krint:PublicUrl"] ?? options.Value.PublicUrl ?? "").TrimEnd('/');
             return Ok(new NodeDraftDto(
                 SuggestedName: GenerateNodeName(),
                 Token: NodeTokenHasher.Generate(),
-                ControlPlaneUrl: string.IsNullOrWhiteSpace(controlPlaneUrl) ? null : controlPlaneUrl.TrimEnd('/')));
+                ControlPlaneUrl: controlPlaneUrl));
         }
 
         // A fun, docker-style adjective-animal name (e.g. "brave-otter") via RandomFriendlyNameGenerator,

--- a/src/KRINT.API/Controllers/NodesController.cs
+++ b/src/KRINT.API/Controllers/NodesController.cs
@@ -4,6 +4,7 @@ using KRINT.API.Nodes;
 using KRINT.Application.Options;
 using KRINT.Domain;
 using KRINT.Infrastructure;
+using KRINT.Infrastructure.Interfaces;
 using KRINT.Infrastructure.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
@@ -19,7 +20,8 @@ namespace KRINT.API.Controllers
         INodeRegistry registry,
         IHubContext<NodeHub> hub,
         IConfiguration configuration,
-        IOptions<KrintOptions> options) : ControllerBase
+        IOptions<KrintOptions> options,
+        IActivityLogger activity) : ControllerBase
     {
         [HttpGet]
         [ProducesResponseType(typeof(IReadOnlyList<NodeDto>), StatusCodes.Status200OK)]
@@ -78,6 +80,7 @@ namespace KRINT.API.Controllers
             var node = new Node { Name = name, TokenHash = NodeTokenHasher.Hash(request.Token) };
             db.Nodes.Add(node);
             await db.SaveChangesAsync(cancellationToken);
+            await activity.LogAsync("node.create", node.Name, cancellationToken: cancellationToken);
 
             var dto = new NodeDto(node.Id, node.Name, node.MachineName, node.Os, node.DockerVersion,
                 Online: false, Pending: true, node.IsConfigManaged, node.CreatedAt, node.LastSeenAt);
@@ -98,6 +101,7 @@ namespace KRINT.API.Controllers
 
             db.Nodes.Remove(node);
             await db.SaveChangesAsync(cancellationToken);
+            await activity.LogAsync("node.delete", node.Name, cancellationToken: cancellationToken);
             return NoContent();
         }
 

--- a/src/KRINT.API/Nodes/NodeDtos.cs
+++ b/src/KRINT.API/Nodes/NodeDtos.cs
@@ -26,7 +26,7 @@ namespace KRINT.API.Nodes
     /// <summary>A not-yet-saved node: a freshly generated token + the control-plane URL the node
     /// should dial. The UI builds the compose from these and only persists on save. ControlPlaneUrl
     /// is null when Krint:PublicUrl isn't configured (the UI warns and uses a placeholder).</summary>
-    public record NodeDraftDto(string SuggestedName, string Token, string? ControlPlaneUrl);
+    public record NodeDraftDto(string SuggestedName, string Token, string ControlPlaneUrl);
 
     /// <summary>Persist a node from the Add-node modal. The token is the one shown in the draft;
     /// only its hash is stored.</summary>

--- a/src/KRINT.Application/Command/Database/CreateDatabaseCommand.cs
+++ b/src/KRINT.Application/Command/Database/CreateDatabaseCommand.cs
@@ -169,7 +169,9 @@ namespace KRINT.Application.Command.Database
                     innerDbs.Resolve(command.Engine),
                     new InnerDatabaseTarget(command.Engine, probeHostInitial, hostPort, spec.DefaultUsername, password, probeDatabase, command.NodeId),
                     command.IsPublic,
-                    cancellationToken);
+                    cancellationToken,
+                    containerName,
+                    spec.InternalPort);
 
                 if (needsExplicitDefaultDb)
                 {

--- a/src/KRINT.Application/Command/Database/UpgradeDatabaseCommand.cs
+++ b/src/KRINT.Application/Command/Database/UpgradeDatabaseCommand.cs
@@ -129,7 +129,7 @@ namespace KRINT.Application.Command.Database
                 // ReadinessProbe tries both probe hosts - see its doc comment.
                 var probeHost = instance.NodeId is not null ? "127.0.0.1" : CreateDatabaseCommandHandler.ResolveProbeHost(instance.IsPublic);
                 var readinessTarget = new InnerDatabaseTarget(instance.Engine, probeHost, instance.Port, spec.DefaultUsername, password, spec.DefaultDatabase, instance.NodeId);
-                await ReadinessProbe.WaitForReadyAsync(innerDbs.Resolve(instance.Engine), readinessTarget, instance.IsPublic, cancellationToken);
+                await ReadinessProbe.WaitForReadyAsync(innerDbs.Resolve(instance.Engine), readinessTarget, instance.IsPublic, cancellationToken, newContainerName, spec.InternalPort);
 
                 // 5. Restore the pre-upgrade dump into NEW.
                 await using (var stream = backupStorage.OpenRead(backupPath)

--- a/src/KRINT.Application/Command/DatabaseInstance/SetInstanceRootPasswordCommand.cs
+++ b/src/KRINT.Application/Command/DatabaseInstance/SetInstanceRootPasswordCommand.cs
@@ -74,7 +74,8 @@ namespace KRINT.Application.Command.DatabaseInstance
             try
             {
                 var target = CreateDatabaseCommandHandler.BuildProbeTarget(instance, oldPassword);
-                await WaitForReadyAsync(target, cancellationToken);
+                await ReadinessProbe.WaitForReadyAsync(innerDbs.Resolve(target.Engine), target, instance.IsPublic, cancellationToken,
+                    instance.ContainerName, InnerDatabaseTargetLoader.EngineInternalPort(instance.Engine));
 
                 await innerUsers.Resolve(instance.Engine).ResetPasswordAsync(target, instance.Username, newPassword, cancellationToken);
                 await vault.StoreAsync(ConnectionStringBuilder.VaultKeyFor(instance), newPassword, cancellationToken);
@@ -98,28 +99,5 @@ namespace KRINT.Application.Command.DatabaseInstance
             return new InnerUserPasswordDto { Name = instance.Username, Password = newPassword };
         }
 
-        private async Task WaitForReadyAsync(InnerDatabaseTarget target, CancellationToken cancellationToken)
-        {
-            var inner = innerDbs.Resolve(target.Engine);
-            var ceiling = target.Engine switch
-            {
-                "cassandra" or "neo4j" => 180,
-                _ => 60,
-            };
-            var deadline = DateTime.UtcNow.AddSeconds(ceiling);
-            var delayMs = 500;
-            Exception? last = null;
-            while (DateTime.UtcNow < deadline)
-            {
-                try { await inner.ListAsync(target, cancellationToken); return; }
-                catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
-                {
-                    last = ex;
-                    await Task.Delay(delayMs, cancellationToken);
-                    delayMs = Math.Min(delayMs * 2, 3000);
-                }
-            }
-            throw new InvalidOperationException($"{target.Engine} container did not become ready within {ceiling}s after start.", last);
-        }
     }
 }

--- a/src/KRINT.Application/Command/DatabaseInstance/SetInstanceVisibilityCommand.cs
+++ b/src/KRINT.Application/Command/DatabaseInstance/SetInstanceVisibilityCommand.cs
@@ -98,7 +98,8 @@ namespace KRINT.Application.Command.DatabaseInstance
             // see the failure surfaced from this command.
             // After the swap the binding is whatever the caller asked for; probe via the right host.
             var probeTarget = new InnerDatabaseTarget(instance.Engine, CreateDatabaseCommandHandler.ResolveProbeHost(command.IsPublic), instance.Port, spec.DefaultUsername, password, spec.DefaultDatabase);
-            await WaitForReadyAsync(probeTarget, cancellationToken);
+            await ReadinessProbe.WaitForReadyAsync(innerDbs.Resolve(instance.Engine), probeTarget, command.IsPublic, cancellationToken,
+                instance.ContainerName, InnerDatabaseTargetLoader.EngineInternalPort(instance.Engine));
 
             instance.ContainerId = createResult.ID;
             instance.IsPublic = command.IsPublic;
@@ -115,28 +116,5 @@ namespace KRINT.Application.Command.DatabaseInstance
             return instance.ToDto();
         }
 
-        private async Task WaitForReadyAsync(InnerDatabaseTarget target, CancellationToken cancellationToken)
-        {
-            var inner = innerDbs.Resolve(target.Engine);
-            var ceiling = target.Engine switch
-            {
-                "cassandra" or "neo4j" => 180,
-                _ => 60,
-            };
-            var deadline = DateTime.UtcNow.AddSeconds(ceiling);
-            var delayMs = 500;
-            Exception? last = null;
-            while (DateTime.UtcNow < deadline)
-            {
-                try { await inner.ListAsync(target, cancellationToken); return; }
-                catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
-                {
-                    last = ex;
-                    await Task.Delay(delayMs, cancellationToken);
-                    delayMs = Math.Min(delayMs * 2, 3000);
-                }
-            }
-            throw new InvalidOperationException($"{target.Engine} container did not become ready within {ceiling}s after visibility change.", last);
-        }
     }
 }

--- a/src/KRINT.Application/Command/DatabaseInstance/StartInstanceCommand.cs
+++ b/src/KRINT.Application/Command/DatabaseInstance/StartInstanceCommand.cs
@@ -40,34 +40,11 @@ namespace KRINT.Application.Command.DatabaseInstance
             var password = await vault.RetrieveAsync(ConnectionStringBuilder.VaultKeyFor(instance), cancellationToken)
                 ?? throw new InvalidOperationException($"Vault has no password for instance {instance.Id}.");
             var target = CreateDatabaseCommandHandler.BuildProbeTarget(instance, password);
-            await WaitForReadyAsync(target, cancellationToken);
+            await ReadinessProbe.WaitForReadyAsync(innerDbs.Resolve(target.Engine), target, instance.IsPublic, cancellationToken,
+                instance.ContainerName, InnerDatabaseTargetLoader.EngineInternalPort(instance.Engine));
 
             await activity.LogAsync("instance.start", instance.ContainerName ?? instance.DisplayName, instance.Id, instance.Engine, null, cancellationToken);
             return Unit.Value;
-        }
-
-        private async Task WaitForReadyAsync(InnerDatabaseTarget target, CancellationToken cancellationToken)
-        {
-            var inner = innerDbs.Resolve(target.Engine);
-            var ceiling = target.Engine switch
-            {
-                "cassandra" or "neo4j" => 180,
-                _ => 60,
-            };
-            var deadline = DateTime.UtcNow.AddSeconds(ceiling);
-            var delayMs = 500;
-            Exception? last = null;
-            while (DateTime.UtcNow < deadline)
-            {
-                try { await inner.ListAsync(target, cancellationToken); return; }
-                catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
-                {
-                    last = ex;
-                    await Task.Delay(delayMs, cancellationToken);
-                    delayMs = Math.Min(delayMs * 2, 3000);
-                }
-            }
-            throw new InvalidOperationException($"{target.Engine} container did not become ready within {ceiling}s after start.", last);
         }
     }
 }

--- a/src/KRINT.Application/InnerDatabaseTargetLoader.cs
+++ b/src/KRINT.Application/InnerDatabaseTargetLoader.cs
@@ -28,10 +28,58 @@ namespace KRINT.Application
                 return new InnerDatabaseTarget(instance.Engine, "127.0.0.1", instance.Port, instance.Username, password, instance.DatabaseName, nodeId);
 
             var preferred = ResolveTargetHost(instance.Host, instance.IsManaged, instance.IsPublic);
-            var host = await PickReachableHostAsync(preferred, instance.Port, cancellationToken);
+            var (host, port) = await PickReachableEndpointAsync(
+                instance.ContainerName, EngineInternalPort(instance.Engine), preferred, instance.Port, cancellationToken);
 
-            return new InnerDatabaseTarget(instance.Engine, host, instance.Port, instance.Username, password, instance.DatabaseName);
+            return new InnerDatabaseTarget(instance.Engine, host, port, instance.Username, password, instance.DatabaseName);
         }
+
+        // Prefers reaching a KRINT-provisioned container directly over the shared Docker network
+        // (containerName:internalPort) - which works for private instances a containerized KRINT
+        // can't otherwise reach - and falls back to the host-published port when that's unavailable
+        // (host-run KRINT, or the container isn't on our network). Cached per endpoint.
+        public static async Task<(string Host, int Port)> PickReachableEndpointAsync(
+            string? containerName, int internalPort, string fallbackHost, int fallbackPort, CancellationToken cancellationToken)
+        {
+            if (!string.IsNullOrEmpty(containerName) && internalPort > 0)
+            {
+                var key = $"net:{containerName}:{internalPort}";
+                if (ReachableHostCache.TryGetValue(key, out var cached))
+                {
+                    if (cached == "1") return (containerName, internalPort);
+                }
+                else if (await CanConnectAsync(containerName, internalPort, cancellationToken))
+                {
+                    ReachableHostCache[key] = "1";
+                    return (containerName, internalPort);
+                }
+                else
+                {
+                    ReachableHostCache[key] = "0";
+                }
+            }
+
+            var host = await PickReachableHostAsync(fallbackHost, fallbackPort, cancellationToken);
+            return (host, fallbackPort);
+        }
+
+        // Internal (in-container) port each engine listens on - used to reach a provisioned container
+        // directly over KRINT's Docker network. Mirrors the engine catalog; 0 = no direct route.
+        public static int EngineInternalPort(string engine) => engine switch
+        {
+            "postgres" or "pgvector" or "timescaledb" => 5432,
+            "mysql" or "mariadb" => 3306,
+            "mongo" => 27017,
+            "redis" or "valkey" => 6379,
+            "cockroachdb" => 26257,
+            "clickhouse" => 8123,
+            "cassandra" => 9042,
+            "couchdb" => 5984,
+            "neo4j" => 7687,
+            "qdrant" => 6333,
+            "mssql" => 1433,
+            _ => 0,
+        };
 
         // Resolved (preferred, port) -> reachable host, so the probe runs once per instance
         // instead of once per operation. Without this every browse/list/rows call paid the

--- a/src/KRINT.Application/Queries/App/AppQuery.cs
+++ b/src/KRINT.Application/Queries/App/AppQuery.cs
@@ -21,12 +21,18 @@ namespace KRINT.Application.Queries.App
 
         public ValueTask<AppDto> Handle(AppQuery query, CancellationToken cancellationToken)
         {
+            // The login redirect is just the app's public URL, so derive it from Krint:PublicUrl when
+            // Oidc:RedirectUri isn't set explicitly - one less thing to configure (and to get wrong).
+            var publicUrl = configuration["Krint:PublicUrl"];
+            var fromPublicUrl = string.IsNullOrWhiteSpace(publicUrl) ? null : publicUrl.TrimEnd('/') + "/";
+            var redirectUri = configuration["Oidc:RedirectUri"] ?? fromPublicUrl ?? "http://localhost:4200/";
+
             return ValueTask.FromResult(new AppDto
             {
                 Authority = configuration["Oidc:Authority"] ?? string.Empty,
                 ClientId = configuration["Oidc:ClientId"] ?? string.Empty,
-                RedirectUri = configuration["Oidc:RedirectUri"] ?? "http://localhost:4200/",
-                PostLogoutRedirectUri = configuration["Oidc:PostLogoutRedirectUri"] ?? "http://localhost:4200/",
+                RedirectUri = redirectUri,
+                PostLogoutRedirectUri = configuration["Oidc:PostLogoutRedirectUri"] ?? redirectUri,
                 Scope = configuration["Oidc:Scope"] ?? "openid profile email roles",
                 Version = AppVersion,
             });

--- a/src/KRINT.Application/ReadinessProbe.cs
+++ b/src/KRINT.Application/ReadinessProbe.cs
@@ -20,17 +20,25 @@ namespace KRINT.Application
             _ => 60,
         };
 
-        public static async Task<InnerDatabaseTarget> WaitForReadyAsync(IInnerDatabaseService inner, InnerDatabaseTarget target, bool isPublic, CancellationToken cancellationToken)
+        public static async Task<InnerDatabaseTarget> WaitForReadyAsync(IInnerDatabaseService inner, InnerDatabaseTarget target, bool isPublic, CancellationToken cancellationToken, string? containerName = null, int internalPort = 0)
         {
             // Node-hosted: the probe runs ON the node against its own loopback (the inner service
             // dispatches there), so there are no host candidates to try - use the target verbatim.
-            var candidates = target.NodeId is not null
-                ? [target]
-                : new[]
-                {
-                    target with { Host = Command.Database.CreateDatabaseCommandHandler.ResolveProbeHost(isPublic) },
-                    target with { Host = Command.Database.CreateDatabaseCommandHandler.ResolveProbeHost(isPublic) == "127.0.0.1" ? Command.Database.CreateDatabaseCommandHandler.ProbeHost : "127.0.0.1" },
-                };
+            List<InnerDatabaseTarget> candidates;
+            if (target.NodeId is not null)
+            {
+                candidates = [target];
+            }
+            else
+            {
+                // Prefer reaching the container directly over KRINT's Docker network (works for private
+                // instances a containerized KRINT can't reach via host ports); host ports are the fallback.
+                candidates = [];
+                if (!string.IsNullOrEmpty(containerName) && internalPort > 0)
+                    candidates.Add(target with { Host = containerName, Port = internalPort });
+                candidates.Add(target with { Host = Command.Database.CreateDatabaseCommandHandler.ResolveProbeHost(isPublic) });
+                candidates.Add(target with { Host = Command.Database.CreateDatabaseCommandHandler.ResolveProbeHost(isPublic) == "127.0.0.1" ? Command.Database.CreateDatabaseCommandHandler.ProbeHost : "127.0.0.1" });
+            }
 
             var ceilingSeconds = CeilingSecondsFor(target.Engine);
             var deadline = DateTime.UtcNow.AddSeconds(ceilingSeconds);

--- a/src/KRINT.Frontend/src/app/api/model/nodeDraftDto.ts
+++ b/src/KRINT.Frontend/src/app/api/model/nodeDraftDto.ts
@@ -12,6 +12,6 @@
 export interface NodeDraftDto { 
     suggestedName: string;
     token: string;
-    controlPlaneUrl: string | null;
+    controlPlaneUrl: string;
 }
 

--- a/src/KRINT.Frontend/src/app/nodes/add-node-dialog.ts
+++ b/src/KRINT.Frontend/src/app/nodes/add-node-dialog.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, computed, inject, Injectable, signal } from '@angular/core';
 import { BrnDialogRef } from '@spartan-ng/brain/dialog';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { lucideCopy, lucideCheck, lucideRefreshCw, lucideTriangleAlert } from '@ng-icons/lucide';
+import { lucideCopy, lucideCheck, lucideRefreshCw } from '@ng-icons/lucide';
 import { HlmButtonImports } from '@spartan-ng/helm/button';
 import { HlmDialogDescription, HlmDialogHeader, HlmDialogService, HlmDialogTitle } from '@spartan-ng/helm/dialog';
 import { HlmInputImports } from '@spartan-ng/helm/input';
@@ -9,12 +9,10 @@ import { HlmLabelImports } from '@spartan-ng/helm/label';
 import { NodesService } from '../api/api/nodes.service';
 import { NodeDto } from '../api/model/nodeDto';
 
-const URL_PLACEHOLDER = 'https://your-krint-url';
-
 @Component({
   selector: 'app-add-node-dialog',
   imports: [NgIcon, HlmButtonImports, HlmDialogHeader, HlmDialogTitle, HlmDialogDescription, HlmInputImports, HlmLabelImports],
-  providers: [provideIcons({ lucideCopy, lucideCheck, lucideRefreshCw, lucideTriangleAlert })],
+  providers: [provideIcons({ lucideCopy, lucideCheck, lucideRefreshCw })],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: { class: 'flex flex-col gap-4' },
   template: `
@@ -29,16 +27,6 @@ const URL_PLACEHOLDER = 'https://your-krint-url';
       <label hlmLabel for="node-name">Node name <span class="text-muted-foreground">(optional)</span></label>
       <input hlmInput id="node-name" [value]="name()" (input)="onName($event)" placeholder="node-1" />
     </div>
-
-    @if (!controlPlaneUrl()) {
-      <div class="border-destructive/40 bg-destructive/10 text-destructive flex items-start gap-2 rounded-md border p-3 text-xs">
-        <ng-icon name="lucideTriangleAlert" size="16" class="mt-0.5 shrink-0" />
-        <span>
-          <code class="font-mono">Krint__PublicUrl</code> isn't set, so the URL below is a placeholder.
-          Set it in your env file to the URL this app is served on, then reopen this dialog.
-        </span>
-      </div>
-    }
 
     <div class="flex flex-col gap-2">
       <div class="flex items-center justify-between">
@@ -75,7 +63,7 @@ export class AddNodeDialog {
 
   protected readonly name = signal('');
   protected readonly token = signal('');
-  protected readonly controlPlaneUrl = signal<string | null>(null);
+  protected readonly controlPlaneUrl = signal('');
   protected readonly loading = signal(true);
   protected readonly saving = signal(false);
   protected readonly error = signal<string | null>(null);
@@ -84,7 +72,7 @@ export class AddNodeDialog {
   // The compose mirrors docs/nodes.md. No Node__Id: the control plane derives the node's identity
   // from its token, so the node never needs to know its own id.
   protected readonly compose = computed(() => {
-    const url = this.controlPlaneUrl() ?? URL_PLACEHOLDER;
+    const url = this.controlPlaneUrl();
     const name = this.name().trim() || 'node';
     return [
       'services:',
@@ -114,7 +102,7 @@ export class AddNodeDialog {
       next: (draft) => {
         if (!this.name()) this.name.set(draft.suggestedName);
         this.token.set(draft.token);
-        this.controlPlaneUrl.set(draft.controlPlaneUrl ?? null);
+        this.controlPlaneUrl.set(draft.controlPlaneUrl);
         this.loading.set(false);
       },
       error: (err) => {

--- a/src/KRINT.Infrastructure/Services/DockerService.cs
+++ b/src/KRINT.Infrastructure/Services/DockerService.cs
@@ -91,9 +91,50 @@ namespace KRINT.Infrastructure.Services
                 cancellationToken: cancellationToken);
         }
 
-        public Task<CreateContainerResponse> CreateContainerAsync(CreateContainerParameters parameters, CancellationToken cancellationToken = default)
+        public async Task<CreateContainerResponse> CreateContainerAsync(CreateContainerParameters parameters, CancellationToken cancellationToken = default)
         {
-            return client.Containers.CreateContainerAsync(parameters, cancellationToken);
+            var result = await client.Containers.CreateContainerAsync(parameters, cancellationToken);
+            // Join the new container to KRINT's own Docker network(s) so KRINT can reach it by name on
+            // its internal port. A containerized KRINT can't reach a private (127.0.0.1-bound) host
+            // port, but it CAN reach the container directly over a shared user-defined network.
+            await AttachToOwnNetworksAsync(result.ID, cancellationToken);
+            return result;
+        }
+
+        // KRINT's user-defined networks, detected once. Empty when KRINT runs on the host (desktop /
+        // dev) or only on the default bridge - those cases keep using host-published ports.
+        private IReadOnlyList<string>? _ownNetworks;
+        private readonly SemaphoreSlim _ownNetworksLock = new(1, 1);
+
+        private async Task AttachToOwnNetworksAsync(string containerId, CancellationToken ct)
+        {
+            foreach (var network in await GetOwnNetworksAsync(ct))
+            {
+                try { await client.Networks.ConnectNetworkAsync(network, new NetworkConnectParameters { Container = containerId }, ct); }
+                catch { /* already connected / network gone - non-fatal; the host-port path still works */ }
+            }
+        }
+
+        private async Task<IReadOnlyList<string>> GetOwnNetworksAsync(CancellationToken ct)
+        {
+            if (_ownNetworks is not null) return _ownNetworks;
+            await _ownNetworksLock.WaitAsync(ct);
+            try
+            {
+                if (_ownNetworks is not null) return _ownNetworks;
+                try
+                {
+                    // KRINT's container hostname defaults to its short id; inspecting it finds our
+                    // networks. Off the default bridge (no name-based DNS) and the loopback nets.
+                    var self = await client.Containers.InspectContainerAsync(System.Net.Dns.GetHostName(), ct);
+                    _ownNetworks = self.NetworkSettings?.Networks?.Keys
+                        .Where(n => n is not ("bridge" or "host" or "none"))
+                        .ToList() ?? [];
+                }
+                catch { _ownNetworks = []; }   // not in a container (host-run KRINT) - use host ports
+                return _ownNetworks;
+            }
+            finally { _ownNetworksLock.Release(); }
         }
 
         public Task<bool> StartContainerAsync(string id, CancellationToken cancellationToken = default)


### PR DESCRIPTION
**Private provisioning fix:** provisioned containers now join KRINT's own Docker network (additive - host ports and external connection strings are unchanged), and KRINT reaches them by container name on their internal port, falling back to the host port. This makes the default private-instance provisioning work on a containerized Linux self-host (the readiness probe could previously never reach a 127.0.0.1-bound port). Routed all readiness checks (create/upgrade/start/visibility/root-password) and post-provision ops through this.

**Public URL consolidation:** `Krint:PublicUrl` is the single source - the OIDC redirect URI is derived from it (CORS too, in the quickstart), so the `.env` has one URL var instead of three. Removed the "public URL not set" placeholder/warning from the Add-node modal and made the draft's control-plane URL non-nullable. No Program.cs changes.

Closes #287