### PR TITLE
Fixed node-hosted readiness probe using unreachable loopback

### DIFF
--- a/src/KRINT.API/Nodes/NodeAgentHostedService.cs
+++ b/src/KRINT.API/Nodes/NodeAgentHostedService.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using Docker.DotNet.Models;
+using KRINT.Application;
 using KRINT.Infrastructure.Extensions;
 using KRINT.Infrastructure.Interfaces;
 using Microsoft.AspNetCore.SignalR.Client;
@@ -255,36 +256,43 @@ namespace KRINT.API.Nodes
         // against the container on this node's loopback, and returns the same DTO the UI consumes.
         private void RegisterInnerDbHandlers(HubConnection c)
         {
-            c.On<InnerDatabaseTarget, IReadOnlyList<string>>("Db.List", t => Inner(s => s.GetRequiredService<IInnerDatabaseServiceResolver>().Resolve(t.Engine).ListAsync(t)));
-            c.On<InnerDatabaseTarget, string, bool>("Db.Create", (t, n) => Inner(async s => { await s.GetRequiredService<IInnerDatabaseServiceResolver>().Resolve(t.Engine).CreateAsync(t, n); return true; }));
-            c.On<InnerDatabaseTarget, string, bool>("Db.Drop", (t, n) => Inner(async s => { await s.GetRequiredService<IInnerDatabaseServiceResolver>().Resolve(t.Engine).DropAsync(t, n); return true; }));
+            c.On<InnerDatabaseTarget, IReadOnlyList<string>>("Db.List", t => Inner(t, (s, rt) => s.GetRequiredService<IInnerDatabaseServiceResolver>().Resolve(rt.Engine).ListAsync(rt)));
+            c.On<InnerDatabaseTarget, string, bool>("Db.Create", (t, n) => Inner(t, async (s, rt) => { await s.GetRequiredService<IInnerDatabaseServiceResolver>().Resolve(rt.Engine).CreateAsync(rt, n); return true; }));
+            c.On<InnerDatabaseTarget, string, bool>("Db.Drop", (t, n) => Inner(t, async (s, rt) => { await s.GetRequiredService<IInnerDatabaseServiceResolver>().Resolve(rt.Engine).DropAsync(rt, n); return true; }));
 
-            c.On<InnerDatabaseTarget, IReadOnlyList<string>>("User.List", t => Inner(s => s.GetRequiredService<IInnerUserServiceResolver>().Resolve(t.Engine).ListAsync(t)));
-            c.On<InnerDatabaseTarget, string, string, bool>("User.Create", (t, n, p) => Inner(async s => { await s.GetRequiredService<IInnerUserServiceResolver>().Resolve(t.Engine).CreateAsync(t, n, p); return true; }));
-            c.On<InnerDatabaseTarget, string, bool>("User.Delete", (t, n) => Inner(async s => { await s.GetRequiredService<IInnerUserServiceResolver>().Resolve(t.Engine).DeleteAsync(t, n); return true; }));
-            c.On<InnerDatabaseTarget, string, string, bool>("User.ResetPassword", (t, n, p) => Inner(async s => { await s.GetRequiredService<IInnerUserServiceResolver>().Resolve(t.Engine).ResetPasswordAsync(t, n, p); return true; }));
-            c.On<InnerDatabaseTarget, string, string, bool>("User.GrantAccess", (t, u, d) => Inner(async s => { await s.GetRequiredService<IInnerUserServiceResolver>().Resolve(t.Engine).GrantAccessAsync(t, u, d); return true; }));
+            c.On<InnerDatabaseTarget, IReadOnlyList<string>>("User.List", t => Inner(t, (s, rt) => s.GetRequiredService<IInnerUserServiceResolver>().Resolve(rt.Engine).ListAsync(rt)));
+            c.On<InnerDatabaseTarget, string, string, bool>("User.Create", (t, n, p) => Inner(t, async (s, rt) => { await s.GetRequiredService<IInnerUserServiceResolver>().Resolve(rt.Engine).CreateAsync(rt, n, p); return true; }));
+            c.On<InnerDatabaseTarget, string, bool>("User.Delete", (t, n) => Inner(t, async (s, rt) => { await s.GetRequiredService<IInnerUserServiceResolver>().Resolve(rt.Engine).DeleteAsync(rt, n); return true; }));
+            c.On<InnerDatabaseTarget, string, string, bool>("User.ResetPassword", (t, n, p) => Inner(t, async (s, rt) => { await s.GetRequiredService<IInnerUserServiceResolver>().Resolve(rt.Engine).ResetPasswordAsync(rt, n, p); return true; }));
+            c.On<InnerDatabaseTarget, string, string, bool>("User.GrantAccess", (t, u, d) => Inner(t, async (s, rt) => { await s.GetRequiredService<IInnerUserServiceResolver>().Resolve(rt.Engine).GrantAccessAsync(rt, u, d); return true; }));
 
-            c.On<InnerDatabaseTarget, string, string, int, QueryResult>("Query.Run", (t, db, sql, lim) => Inner(s =>
+            c.On<InnerDatabaseTarget, string, string, int, QueryResult>("Query.Run", (t, db, sql, lim) => Inner(t, (s, rt) =>
             {
-                var svc = s.GetRequiredService<IInnerQueryServiceResolver>().TryResolve(t.Engine)
-                          ?? throw new NotSupportedException($"Query console not available for engine '{t.Engine}'.");
-                return svc.RunAsync(t, db, sql, lim);
+                var svc = s.GetRequiredService<IInnerQueryServiceResolver>().TryResolve(rt.Engine)
+                          ?? throw new NotSupportedException($"Query console not available for engine '{rt.Engine}'.");
+                return svc.RunAsync(rt, db, sql, lim);
             }));
 
-            c.On<InnerDatabaseTarget, string, IReadOnlyList<TableSummary>>("Schema.ListTables", (t, db) => Inner(s => s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(t.Engine).ListTablesAsync(t, db)));
-            c.On<InnerDatabaseTarget, string, string, int, int, TableRows>("Schema.FetchRows", (t, db, table, lim, off) => Inner(s => s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(t.Engine).FetchRowsAsync(t, db, table, lim, off)));
-            c.On<InnerDatabaseTarget, string, string, UpdateRowRequest, bool>("Schema.UpdateRow", (t, db, table, r) => Inner(async s => { await s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(t.Engine).UpdateRowAsync(t, db, table, r); return true; }));
-            c.On<InnerDatabaseTarget, string, string, BulkUpdateRowsRequest, bool>("Schema.BulkUpdateRows", (t, db, table, r) => Inner(async s => { await s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(t.Engine).BulkUpdateRowsAsync(t, db, table, r); return true; }));
-            c.On<InnerDatabaseTarget, string, string, InsertRowRequest, bool>("Schema.InsertRow", (t, db, table, r) => Inner(async s => { await s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(t.Engine).InsertRowAsync(t, db, table, r); return true; }));
-            c.On<InnerDatabaseTarget, string, string, DeleteRowRequest, bool>("Schema.DeleteRow", (t, db, table, r) => Inner(async s => { await s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(t.Engine).DeleteRowAsync(t, db, table, r); return true; }));
-            c.On<InnerDatabaseTarget, string, string, bool>("Schema.DropTable", (t, db, table) => Inner(async s => { await s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(t.Engine).DropTableAsync(t, db, table); return true; }));
+            c.On<InnerDatabaseTarget, string, IReadOnlyList<TableSummary>>("Schema.ListTables", (t, db) => Inner(t, (s, rt) => s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(rt.Engine).ListTablesAsync(rt, db)));
+            c.On<InnerDatabaseTarget, string, string, int, int, TableRows>("Schema.FetchRows", (t, db, table, lim, off) => Inner(t, (s, rt) => s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(rt.Engine).FetchRowsAsync(rt, db, table, lim, off)));
+            c.On<InnerDatabaseTarget, string, string, UpdateRowRequest, bool>("Schema.UpdateRow", (t, db, table, r) => Inner(t, async (s, rt) => { await s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(rt.Engine).UpdateRowAsync(rt, db, table, r); return true; }));
+            c.On<InnerDatabaseTarget, string, string, BulkUpdateRowsRequest, bool>("Schema.BulkUpdateRows", (t, db, table, r) => Inner(t, async (s, rt) => { await s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(rt.Engine).BulkUpdateRowsAsync(rt, db, table, r); return true; }));
+            c.On<InnerDatabaseTarget, string, string, InsertRowRequest, bool>("Schema.InsertRow", (t, db, table, r) => Inner(t, async (s, rt) => { await s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(rt.Engine).InsertRowAsync(rt, db, table, r); return true; }));
+            c.On<InnerDatabaseTarget, string, string, DeleteRowRequest, bool>("Schema.DeleteRow", (t, db, table, r) => Inner(t, async (s, rt) => { await s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(rt.Engine).DeleteRowAsync(rt, db, table, r); return true; }));
+            c.On<InnerDatabaseTarget, string, string, bool>("Schema.DropTable", (t, db, table) => Inner(t, async (s, rt) => { await s.GetRequiredService<IInnerSchemaServiceResolver>().Resolve(rt.Engine).DropTableAsync(rt, db, table); return true; }));
         }
 
-        private async Task<T> Inner<T>(Func<IServiceProvider, Task<T>> work)
+        // Runs inner-DB work against the right local address. The control plane ships the container
+        // name + internal port; here on the node we pick the reachable endpoint - the container over
+        // our own Docker network when our loopback can't see the host-published port, else the host
+        // port verbatim - so the same code path works whether the node runs in a container or on the host.
+        private async Task<T> Inner<T>(InnerDatabaseTarget target, Func<IServiceProvider, InnerDatabaseTarget, Task<T>> work)
         {
+            var (host, port) = await InnerDatabaseTargetLoader.PickReachableEndpointAsync(
+                target.ContainerName, target.InternalPort, target.Host, target.Port, CancellationToken.None);
+            var resolved = target with { Host = host, Port = port };
             using var scope = services.CreateScope();
-            return await work(scope.ServiceProvider);
+            return await work(scope.ServiceProvider, resolved);
         }
 
         private static CreateContainerParameters ToParameters(CreateContainerSpec spec)

--- a/src/KRINT.Application/Command/DatabaseInstance/SetInstanceRootPasswordCommand.cs
+++ b/src/KRINT.Application/Command/DatabaseInstance/SetInstanceRootPasswordCommand.cs
@@ -74,10 +74,13 @@ namespace KRINT.Application.Command.DatabaseInstance
             try
             {
                 var target = CreateDatabaseCommandHandler.BuildProbeTarget(instance, oldPassword);
-                await ReadinessProbe.WaitForReadyAsync(innerDbs.Resolve(target.Engine), target, instance.IsPublic, cancellationToken,
+                // WaitForReadyAsync returns the target whose host actually responded (for a node that's
+                // the container-name or loopback candidate it reached); reuse it so the reset runs
+                // against the same address instead of the unresolved probe target.
+                var readyTarget = await ReadinessProbe.WaitForReadyAsync(innerDbs.Resolve(target.Engine), target, instance.IsPublic, cancellationToken,
                     instance.ContainerName, InnerDatabaseTargetLoader.EngineInternalPort(instance.Engine));
 
-                await innerUsers.Resolve(instance.Engine).ResetPasswordAsync(target, instance.Username, newPassword, cancellationToken);
+                await innerUsers.Resolve(instance.Engine).ResetPasswordAsync(readyTarget, instance.Username, newPassword, cancellationToken);
                 await vault.StoreAsync(ConnectionStringBuilder.VaultKeyFor(instance), newPassword, cancellationToken);
             }
             finally

--- a/src/KRINT.Application/InnerDatabaseTargetLoader.cs
+++ b/src/KRINT.Application/InnerDatabaseTargetLoader.cs
@@ -21,11 +21,12 @@ namespace KRINT.Application
             var password = await vault.RetrieveAsync(ConnectionStringBuilder.VaultKeyFor(instance), cancellationToken)
                 ?? throw new InvalidOperationException($"Vault has no password for instance {instanceId}.");
 
-            // Node-hosted: the operation is dispatched to the node and runs against the container on
-            // the node's own loopback, so there's no host to probe from here - carry the NodeId so the
-            // inner-service resolver routes it.
+            // Node-hosted: the operation is dispatched to the node, which runs it against the container.
+            // Carry the NodeId so the resolver routes it, plus the container name + internal port so the
+            // node can reach the container over its own Docker network (a containerized node can't see
+            // 127.0.0.1:<hostPort> on its host); the node falls back to that host port when it can't.
             if (instance.NodeId is { } nodeId)
-                return new InnerDatabaseTarget(instance.Engine, "127.0.0.1", instance.Port, instance.Username, password, instance.DatabaseName, nodeId);
+                return new InnerDatabaseTarget(instance.Engine, "127.0.0.1", instance.Port, instance.Username, password, instance.DatabaseName, nodeId, instance.ContainerName, EngineInternalPort(instance.Engine));
 
             var preferred = ResolveTargetHost(instance.Host, instance.IsManaged, instance.IsPublic);
             var (host, port) = await PickReachableEndpointAsync(

--- a/src/KRINT.Application/ReadinessProbe.cs
+++ b/src/KRINT.Application/ReadinessProbe.cs
@@ -22,12 +22,19 @@ namespace KRINT.Application
 
         public static async Task<InnerDatabaseTarget> WaitForReadyAsync(IInnerDatabaseService inner, InnerDatabaseTarget target, bool isPublic, CancellationToken cancellationToken, string? containerName = null, int internalPort = 0)
         {
-            // Node-hosted: the probe runs ON the node against its own loopback (the inner service
-            // dispatches there), so there are no host candidates to try - use the target verbatim.
+            // Node-hosted: the probe runs ON the node (the inner service dispatches there). The node
+            // reaches its container either over its own Docker network (containerName:internalPort -
+            // a containerized node) or via the host-published port on its loopback (a host-run node),
+            // so try both as explicit candidates and let whichever responds win. These carry no
+            // ContainerName, so the node connects to Host:Port verbatim - it must not re-probe a
+            // not-yet-listening container here and cache a negative for the rest of its lifetime.
             List<InnerDatabaseTarget> candidates;
             if (target.NodeId is not null)
             {
-                candidates = [target];
+                candidates = [];
+                if (!string.IsNullOrEmpty(containerName) && internalPort > 0)
+                    candidates.Add(target with { Host = containerName, Port = internalPort });
+                candidates.Add(target);
             }
             else
             {

--- a/src/KRINT.Infrastructure/Interfaces/IInnerDatabaseService.cs
+++ b/src/KRINT.Infrastructure/Interfaces/IInnerDatabaseService.cs
@@ -2,8 +2,13 @@ namespace KRINT.Infrastructure.Interfaces
 {
     /// <summary>Connection details for an instance's database. <see cref="NodeId"/> is set when the
     /// instance runs on a remote node: the inner-service resolvers then dispatch the operation to that
-    /// node (which runs it against its own loopback) instead of connecting locally.</summary>
-    public record InnerDatabaseTarget(string Engine, string Host, int Port, string Username, string Password, string DefaultDatabase, Guid? NodeId = null);
+    /// node (which runs it against its own loopback) instead of connecting locally.
+    /// <para><see cref="ContainerName"/>/<see cref="InternalPort"/> let the node reach the provisioned
+    /// container directly over its own Docker network (containerName:internalPort) when its loopback
+    /// can't see the host-published port - a containerized node can't reach 127.0.0.1:&lt;hostPort&gt;
+    /// on its host. They ride the RPC payload so the node resolves the reachable endpoint locally,
+    /// falling back to <see cref="Host"/>:<see cref="Port"/>.</para></summary>
+    public record InnerDatabaseTarget(string Engine, string Host, int Port, string Username, string Password, string DefaultDatabase, Guid? NodeId = null, string? ContainerName = null, int InternalPort = 0);
 
     public interface IInnerDatabaseService
     {


### PR DESCRIPTION
Node instances now reach their container over the node's own Docker network instead of an unreachable host loopback.

Closes #291