### PR TITLE
Failed node-draft loudly when Krint__PublicUrl is unset

### DIFF
--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -29,8 +29,8 @@ Set the public URL this control plane is served on in your **env file** so the A
 Krint__PublicUrl=https://krint.example.com
 ```
 
-::: info
-If `Krint__PublicUrl` is unset, the Add-node modal still works but uses a placeholder URL you'll need to edit by hand.
+::: warning
+`Krint__PublicUrl` is **required to add nodes**, and it must be reachable from each node's host - use the control plane's LAN or public address, never `localhost`/`127.0.0.1`. If it's unset the Add-node dialog refuses to generate a compose and tells you to set it.
 :::
 
 ## Add a node

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -147,7 +147,7 @@ Set these on the `krint` service (the Quickstart pulls them from `.env`).
 | `Oidc__Scope` | `openid profile email roles` (`roles` optional). |
 | `Oidc__RequireHttpsMetadata` | `true` (set `false` only for a plain-HTTP IdP). |
 | `Cors__AllowedOrigins__0` | Browser origin allowed to call the API - KRINT URL **without** trailing slash. Add more as `__1`, `__2`. |
-| `Krint__PublicUrl` | Public URL this control plane is served on (e.g. `https://krint.example.com`). Used to pre-fill the [Add-node](./nodes#add-a-node) compose. Optional. |
+| `Krint__PublicUrl` | Public URL this control plane is served on (e.g. `https://krint.example.com`). Drives the [Add-node](./nodes#add-a-node) compose, and backs the OIDC redirect + CORS when those aren't set explicitly. **Required to add nodes** - it must be reachable from each node's host (not `localhost`); the Add-node dialog refuses to generate a compose until it's set. |
 | `Backup__Directory` | Where dumps are written. Optional - defaults to `/app/backups` (the path the compose bind-mounts). |
 | `Docker__Endpoint` | Docker daemon URI, e.g. `unix:///var/run/docker.sock`. Optional - auto-detected (Unix socket / Windows named pipe) when unset. |
 

--- a/src/KRINT.API/Controllers/NodesController.cs
+++ b/src/KRINT.API/Controllers/NodesController.cs
@@ -48,11 +48,20 @@ namespace KRINT.API.Controllers
         /// anything. The UI builds the copy-paste compose from this and only saves on demand.</summary>
         [HttpGet("draft")]
         [ProducesResponseType(typeof(NodeDraftDto), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public IActionResult Draft()
         {
-            // Krint:PublicUrl is required for self-hosting (it also drives the OIDC redirect + CORS),
-            // so it's always present here.
+            // A node dials Krint:PublicUrl to reach the control plane, so it must be set (and reachable
+            // from the node host). Without it the generated compose would carry an empty ControlPlaneUrl
+            // and the node would silently fail to connect - fail loudly here instead so the UI can tell
+            // the operator exactly what to configure.
             var controlPlaneUrl = (configuration["Krint:PublicUrl"] ?? options.Value.PublicUrl ?? "").TrimEnd('/');
+            if (string.IsNullOrEmpty(controlPlaneUrl))
+                return Problem(
+                    title: "Public URL not configured",
+                    detail: "Set Krint__PublicUrl on the control plane to the URL nodes should dial (e.g. https://krint.example.com) - it must be reachable from the node's host, not localhost. Then reopen this dialog.",
+                    statusCode: StatusCodes.Status400BadRequest);
+
             return Ok(new NodeDraftDto(
                 SuggestedName: GenerateNodeName(),
                 Token: NodeTokenHasher.Generate(),

--- a/src/KRINT.Frontend/src/app/nodes/add-node-dialog.ts
+++ b/src/KRINT.Frontend/src/app/nodes/add-node-dialog.ts
@@ -28,30 +28,36 @@ import { NodeDto } from '../api/model/nodeDto';
       <input hlmInput id="node-name" [value]="name()" (input)="onName($event)" placeholder="node-1" />
     </div>
 
-    <div class="flex flex-col gap-2">
-      <div class="flex items-center justify-between">
-        <label hlmLabel>Compose</label>
-        <div class="flex gap-2">
-          <button hlmBtn variant="outline" size="sm" type="button" (click)="regenerate()" [disabled]="loading()">
-            <ng-icon name="lucideRefreshCw" size="14" />
-            New token
-          </button>
-          <button hlmBtn variant="outline" size="sm" type="button" (click)="copy()">
-            <ng-icon [name]="copied() ? 'lucideCheck' : 'lucideCopy'" size="14" />
-            {{ copied() ? 'Copied' : 'Copy' }}
-          </button>
+    @if (!ready()) {
+      @if (error(); as err) {
+        <p class="text-destructive text-sm">{{ err }}</p>
+      }
+    } @else {
+      <div class="flex flex-col gap-2">
+        <div class="flex items-center justify-between">
+          <label hlmLabel>Compose</label>
+          <div class="flex gap-2">
+            <button hlmBtn variant="outline" size="sm" type="button" (click)="regenerate()" [disabled]="loading()">
+              <ng-icon name="lucideRefreshCw" size="14" />
+              New token
+            </button>
+            <button hlmBtn variant="outline" size="sm" type="button" (click)="copy()">
+              <ng-icon [name]="copied() ? 'lucideCheck' : 'lucideCopy'" size="14" />
+              {{ copied() ? 'Copied' : 'Copy' }}
+            </button>
+          </div>
         </div>
+        <pre class="bg-muted max-h-72 overflow-auto rounded-md border p-3 font-mono text-xs leading-relaxed">{{ compose() }}</pre>
       </div>
-      <pre class="bg-muted max-h-72 overflow-auto rounded-md border p-3 font-mono text-xs leading-relaxed">{{ compose() }}</pre>
-    </div>
 
-    @if (error(); as err) {
-      <p class="text-destructive text-sm">{{ err }}</p>
+      @if (error(); as err) {
+        <p class="text-destructive text-sm">{{ err }}</p>
+      }
     }
 
     <div class="flex justify-end gap-2">
       <button hlmBtn variant="ghost" type="button" (click)="cancel()" [disabled]="saving()">Cancel</button>
-      <button hlmBtn type="button" (click)="save()" [disabled]="saving() || loading()">
+      <button hlmBtn type="button" (click)="save()" [disabled]="saving() || loading() || !ready()">
         {{ saving() ? 'Adding…' : 'Add node' }}
       </button>
     </div>
@@ -68,6 +74,9 @@ export class AddNodeDialog {
   protected readonly saving = signal(false);
   protected readonly error = signal<string | null>(null);
   protected readonly copied = signal(false);
+  // True once a draft with a real control-plane URL loaded. When the control plane has no
+  // Krint__PublicUrl the draft endpoint returns 400, so there's no valid compose to show.
+  protected readonly ready = signal(false);
 
   // The compose mirrors docs/nodes.md. No Node__Id: the control plane derives the node's identity
   // from its token, so the node never needs to know its own id.
@@ -103,13 +112,23 @@ export class AddNodeDialog {
         if (!this.name()) this.name.set(draft.suggestedName);
         this.token.set(draft.token);
         this.controlPlaneUrl.set(draft.controlPlaneUrl);
+        this.ready.set(true);
         this.loading.set(false);
       },
       error: (err) => {
-        this.error.set(err instanceof Error ? err.message : 'Failed to prepare a node');
+        this.ready.set(false);
+        this.error.set(this.messageFrom(err, 'Failed to prepare a node'));
         this.loading.set(false);
       },
     });
+  }
+
+  // Prefer the ProblemDetails `detail` a 400 carries (e.g. the "set Krint__PublicUrl" guidance)
+  // over the generic HTTP error message.
+  private messageFrom(err: unknown, fallback: string): string {
+    const problem = (err as { error?: { detail?: string } } | null)?.error;
+    if (problem?.detail) return problem.detail;
+    return err instanceof Error ? err.message : fallback;
   }
 
   protected onName(event: Event): void {
@@ -133,7 +152,7 @@ export class AddNodeDialog {
     this.api.apiNodesPost({ name: this.name().trim(), token: this.token() }).subscribe({
       next: (created) => this.ref.close(created),
       error: (err) => {
-        this.error.set(err instanceof Error ? err.message : 'Failed to add the node');
+        this.error.set(this.messageFrom(err, 'Failed to add the node'));
         this.saving.set(false);
       },
     });


### PR DESCRIPTION
The Add-node dialog no longer emits a compose with an empty ControlPlaneUrl - the draft endpoint returns a clear 400 when Krint__PublicUrl is unset, the dialog surfaces it, and the docs mark it required.

Closes #298

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcjCutmJxzZ7spSbj7Utrb)_