### PR TITLE
Added node-aware external database discovery and registration

### DIFF
--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -99,3 +99,7 @@ The node retries on its own if the control plane is unreachable at boot, and re-
 ## Provision onto a node
 
 Pick the node from the create wizard's **Target node** dropdown (it appears once a node is online), or pass `nodeId` in the provision request. The instance then shows a node badge on the instances list.
+
+## Register an existing database on a node
+
+Databases KRINT didn't provision can also live on a node. In **Register external database**, pick the node from the **Target node** dropdown (shown once a node is online): **Scan** then discovers containers on that node's Docker daemon, and the connection test plus every later operation is dispatched to the node - the control plane never connects to the database directly. Leave it on *Local (control plane)* to register a database reachable from the control plane, exactly as before.

--- a/src/KRINT.API/Controllers/DatabaseController.cs
+++ b/src/KRINT.API/Controllers/DatabaseController.cs
@@ -73,9 +73,9 @@ namespace KRINT.API.Controllers
 
         [HttpGet("discover")]
         [ProducesResponseType(typeof(IReadOnlyList<DiscoveredContainerDto>), StatusCodes.Status200OK)]
-        public async Task<IActionResult> Discover(CancellationToken cancellationToken)
+        public async Task<IActionResult> Discover([FromQuery] Guid? nodeId, CancellationToken cancellationToken)
         {
-            var result = await mediator.Send(new DiscoverContainersQuery(), cancellationToken);
+            var result = await mediator.Send(new DiscoverContainersQuery(nodeId), cancellationToken);
             return Ok(result);
         }
 

--- a/src/KRINT.Application/Command/DatabaseInstance/RegisterExternalDatabaseCommand.cs
+++ b/src/KRINT.Application/Command/DatabaseInstance/RegisterExternalDatabaseCommand.cs
@@ -20,7 +20,7 @@ namespace KRINT.Application.Command.DatabaseInstance
         KrintDbContext db,
         ISecretsVaultService vault,
         IInnerDatabaseServiceResolver innerDbs,
-        IDockerService docker,
+        IDockerServiceResolver dockerResolver,
         IActivityLogger activity)
         : ICommandHandler<RegisterExternalDatabaseCommand, ProvisionedDatabaseDto>
     {
@@ -49,8 +49,19 @@ namespace KRINT.Application.Command.DatabaseInstance
             // local DB registers on the desktop too. The original host is stored as the user typed.
             var inner = ResolveInner(req.Engine);
             var preferredHost = InnerDatabaseTargetLoader.ResolveTargetHost(req.Host, isManaged: false, isPublic: false);
-            var probeHost = await InnerDatabaseTargetLoader.PickReachableHostAsync(preferredHost, req.Port, cancellationToken);
-            var target = new InnerDatabaseTarget(req.Engine, probeHost, req.Port, req.Username, req.Password, req.DatabaseName);
+            InnerDatabaseTarget target;
+            if (req.NodeId is { } probeNodeId)
+            {
+                // The DB lives on the node's host/network; only the node can reach it. Dispatch the
+                // probe there (NodeId set) and let the node resolve the reachable endpoint locally -
+                // the control plane must not pre-probe an address it can't see.
+                target = new InnerDatabaseTarget(req.Engine, preferredHost, req.Port, req.Username, req.Password, req.DatabaseName, probeNodeId);
+            }
+            else
+            {
+                var probeHost = await InnerDatabaseTargetLoader.PickReachableHostAsync(preferredHost, req.Port, cancellationToken);
+                target = new InnerDatabaseTarget(req.Engine, probeHost, req.Port, req.Username, req.Password, req.DatabaseName);
+            }
             try
             {
                 await inner.ListAsync(target, cancellationToken);
@@ -70,6 +81,8 @@ namespace KRINT.Application.Command.DatabaseInstance
             {
                 try
                 {
+                    // Inspect on the same daemon the DB runs on (the node's, when NodeId is set).
+                    var docker = dockerResolver.Resolve(req.NodeId);
                     var inspect = await docker.InspectContainerAsync(req.ContainerId, cancellationToken);
                     adoptedContainerId = inspect.ID;
                     adoptedContainerName = req.ContainerName;
@@ -93,6 +106,7 @@ namespace KRINT.Application.Command.DatabaseInstance
                 Username = req.Username,
                 DatabaseName = req.DatabaseName,
                 IsManaged = false,
+                NodeId = req.NodeId,
             };
             db.DatabaseInstances.Add(instance);
             await db.SaveChangesAsync(cancellationToken);

--- a/src/KRINT.Application/Dtos/DatabaseInstance/RegisterExternalDatabaseDto.cs
+++ b/src/KRINT.Application/Dtos/DatabaseInstance/RegisterExternalDatabaseDto.cs
@@ -26,5 +26,9 @@ namespace KRINT.Application.Dtos.DatabaseInstance
         public string? ContainerId { get; init; }
         /// <summary>Optional. Set alongside ContainerId.</summary>
         public string? ContainerName { get; init; }
+        /// <summary>Optional. The node the database runs on (null = the control plane's host). When set,
+        /// the connection probe, container adoption, and all later operations are dispatched to that
+        /// node - the control plane never connects to the DB directly.</summary>
+        public Guid? NodeId { get; init; }
     }
 }

--- a/src/KRINT.Application/InnerDatabaseTargetLoader.cs
+++ b/src/KRINT.Application/InnerDatabaseTargetLoader.cs
@@ -21,12 +21,19 @@ namespace KRINT.Application
             var password = await vault.RetrieveAsync(ConnectionStringBuilder.VaultKeyFor(instance), cancellationToken)
                 ?? throw new InvalidOperationException($"Vault has no password for instance {instanceId}.");
 
-            // Node-hosted: the operation is dispatched to the node, which runs it against the container.
-            // Carry the NodeId so the resolver routes it, plus the container name + internal port so the
-            // node can reach the container over its own Docker network (a containerized node can't see
-            // 127.0.0.1:<hostPort> on its host); the node falls back to that host port when it can't.
+            // Node-hosted: the operation is dispatched to the node, which runs it locally against the DB.
             if (instance.NodeId is { } nodeId)
-                return new InnerDatabaseTarget(instance.Engine, "127.0.0.1", instance.Port, instance.Username, password, instance.DatabaseName, nodeId, instance.ContainerName, EngineInternalPort(instance.Engine));
+            {
+                // Managed instances live in a KRINT container the node reaches by name on its own Docker
+                // network (a containerized node can't see 127.0.0.1:<hostPort> on its host); it falls back
+                // to that host port when it can't. External instances aren't KRINT's container - reach them
+                // at the host the user registered, resolved to the node's loopback/host-gateway on the node.
+                if (instance.IsManaged)
+                    return new InnerDatabaseTarget(instance.Engine, "127.0.0.1", instance.Port, instance.Username, password, instance.DatabaseName, nodeId, instance.ContainerName, EngineInternalPort(instance.Engine));
+
+                var externalHost = ResolveTargetHost(instance.Host, instance.IsManaged, instance.IsPublic);
+                return new InnerDatabaseTarget(instance.Engine, externalHost, instance.Port, instance.Username, password, instance.DatabaseName, nodeId);
+            }
 
             var preferred = ResolveTargetHost(instance.Host, instance.IsManaged, instance.IsPublic);
             var (host, port) = await PickReachableEndpointAsync(

--- a/src/KRINT.Application/Queries/Database/DiscoverContainersQuery.cs
+++ b/src/KRINT.Application/Queries/Database/DiscoverContainersQuery.cs
@@ -6,21 +6,25 @@ using KRINT.Infrastructure.Interfaces;
 
 namespace KRINT.Application.Queries.Database
 {
-    public record DiscoverContainersQuery : IQuery<IReadOnlyList<DiscoveredContainerDto>>;
+    /// <param name="NodeId">Which Docker host to scan: null = the control plane's local daemon,
+    /// a node id = that node's daemon (over SignalR). Lets the Register flow discover containers
+    /// running on a remote node, not just the control plane.</param>
+    public record DiscoverContainersQuery(Guid? NodeId = null) : IQuery<IReadOnlyList<DiscoveredContainerDto>>;
 
     /// <summary>
-    /// Walks the host's Docker containers, picks ones whose image matches a supported engine,
+    /// Walks the target host's Docker containers, picks ones whose image matches a supported engine,
     /// parses creds + port out of the inspect response, and returns them as candidates for the
     /// Register flow. Skips:
     ///   - anything labelled krint.managed=true (KRINT provisioned it; already in the list)
     ///   - anything whose container id matches a row in DatabaseInstances (registered already
     ///     as an external instance from an earlier discover round)
     /// </summary>
-    public class DiscoverContainersQueryHandler(KrintDbContext db, IDockerService docker)
+    public class DiscoverContainersQueryHandler(KrintDbContext db, IDockerServiceResolver dockerResolver)
         : IQueryHandler<DiscoverContainersQuery, IReadOnlyList<DiscoveredContainerDto>>
     {
         public async ValueTask<IReadOnlyList<DiscoveredContainerDto>> Handle(DiscoverContainersQuery query, CancellationToken cancellationToken)
         {
+            var docker = dockerResolver.Resolve(query.NodeId);
             var containers = await docker.ListContainersAsync(all: true, cancellationToken);
 
             var trackedIds = await db.DatabaseInstances

--- a/src/KRINT.Frontend/src/app/api/api/database.service.ts
+++ b/src/KRINT.Frontend/src/app/api/api/database.service.ts
@@ -95,14 +95,26 @@ export class DatabaseService extends BaseService {
 
     /**
      * @endpoint get /api/Database/discover
+     * @param nodeId 
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      * @param options additional options
      */
-    public apiDatabaseDiscoverGet(observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<Array<DiscoveredContainerDto>>;
-    public apiDatabaseDiscoverGet(observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<Array<DiscoveredContainerDto>>>;
-    public apiDatabaseDiscoverGet(observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<Array<DiscoveredContainerDto>>>;
-    public apiDatabaseDiscoverGet(observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+    public apiDatabaseDiscoverGet(nodeId?: string, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<Array<DiscoveredContainerDto>>;
+    public apiDatabaseDiscoverGet(nodeId?: string, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<Array<DiscoveredContainerDto>>>;
+    public apiDatabaseDiscoverGet(nodeId?: string, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<Array<DiscoveredContainerDto>>>;
+    public apiDatabaseDiscoverGet(nodeId?: string, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'text/plain' | 'application/json' | 'text/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+
+        let localVarQueryParameters = new OpenApiHttpParams(this.encoder);
+
+        localVarQueryParameters = this.addToHttpParams(
+            localVarQueryParameters,
+            'nodeId',
+            <any>nodeId,
+            QueryParamStyle.Form,
+            true,
+        );
+
 
         let localVarHeaders = this.defaultHeaders;
 
@@ -139,6 +151,7 @@ export class DatabaseService extends BaseService {
         return this.httpClient.request<Array<DiscoveredContainerDto>>('get', `${basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
+                params: localVarQueryParameters.toHttpParams(),
                 responseType: <any>responseType_,
                 ...(withCredentials ? { withCredentials } : {}),
                 headers: localVarHeaders,

--- a/src/KRINT.Frontend/src/app/api/model/registerExternalDatabaseDto.ts
+++ b/src/KRINT.Frontend/src/app/api/model/registerExternalDatabaseDto.ts
@@ -21,5 +21,6 @@ export interface RegisterExternalDatabaseDto {
     databaseName: string;
     containerId?: string | null;
     containerName?: string | null;
+    nodeId?: string | null;
 }
 

--- a/src/KRINT.Frontend/src/app/databases/database-register-external-dialog.ts
+++ b/src/KRINT.Frontend/src/app/databases/database-register-external-dialog.ts
@@ -9,7 +9,9 @@ import { HlmInputImports } from '@spartan-ng/helm/input';
 import { HlmLabelImports } from '@spartan-ng/helm/label';
 import { HlmSelectImports } from '@spartan-ng/helm/select';
 import { DatabaseService } from '../api/api/database.service';
+import { NodesService } from '../api/api/nodes.service';
 import { DiscoveredContainerDto } from '../api/model/discoveredContainerDto';
+import { NodeDto } from '../api/model/nodeDto';
 import { DatabasesStore } from '../shared/stores/databases.store';
 import { DatabaseMigrateDialog } from './database-migrate-dialog';
 
@@ -39,9 +41,33 @@ import { DatabaseMigrateDialog } from './database-migrate-dialog';
       </p>
     </hlm-dialog-header>
 
-    <!-- Discover panel. Scans the host's Docker for engine containers KRINT doesn't already
+    @if (onlineNodes().length > 0) {
+      <div class="flex flex-col gap-1.5">
+        <label hlmLabel class="text-muted-foreground text-xs uppercase tracking-wide">Target node</label>
+        <hlm-select
+          [value]="selectedNodeId() ?? ''"
+          (valueChange)="onNodeChange($event || null)"
+          [itemToString]="nodeLabel"
+        >
+          <hlm-select-trigger class="w-full">
+            <hlm-select-value placeholder="Local (control plane)" />
+          </hlm-select-trigger>
+          <hlm-select-content *hlmSelectPortal>
+            <hlm-select-item value="">Local (control plane)</hlm-select-item>
+            @for (n of onlineNodes(); track n.id) {
+              <hlm-select-item [value]="n.id">{{ n.name }}</hlm-select-item>
+            }
+          </hlm-select-content>
+        </hlm-select>
+        <span class="text-muted-foreground text-xs">
+          Which host to scan and reach the database on. Node-hosted databases are reached through the control plane.
+        </span>
+      </div>
+    }
+
+    <!-- Discover panel. Scans the selected host's Docker for engine containers KRINT doesn't already
          track, pre-fills creds from env vars where possible. Saves the user from re-typing
-         everything when the DB already runs on the same host. -->
+         everything when the DB already runs on that host. -->
     <section class="border-border rounded-md border">
       <header class="flex items-center justify-between gap-2 px-3 py-2 border-b">
         <div class="flex items-center gap-2 text-sm font-medium">
@@ -58,7 +84,7 @@ import { DatabaseMigrateDialog } from './database-migrate-dialog';
         <p class="text-destructive p-3 text-sm">{{ err }}</p>
       } @else if (candidates() === null) {
         <p class="text-muted-foreground p-3 text-sm">
-          Click <strong>Scan</strong> to look for database containers running on this Docker host.
+          Click <strong>Scan</strong> to look for database containers running on the selected host.
         </p>
       } @else if (candidates()!.length === 0) {
         <p class="text-muted-foreground p-3 text-sm">
@@ -212,7 +238,36 @@ export class DatabaseRegisterExternalDialog {
   protected readonly store = inject(DatabasesStore);
   private readonly ref = inject<BrnDialogRef<unknown>>(BrnDialogRef);
   private readonly api = inject(DatabaseService);
+  private readonly nodesApi = inject(NodesService);
   private readonly dialog = inject(HlmDialogService);
+
+  // Which host to scan / reach the DB on: null = the control plane, a node id = that node. Only
+  // online nodes are offered; the picker is hidden when none are connected.
+  protected readonly onlineNodes = signal<ReadonlyArray<NodeDto>>([]);
+  protected readonly selectedNodeId = signal<string | null>(null);
+  // Maps the selected id back to its name for the trigger label (lazy *hlmSelectPortal options
+  // aren't available to brn-select, so without this it shows the raw GUID).
+  protected readonly nodeLabel = (id: string): string => {
+    if (!id) return 'Local (control plane)';
+    return this.onlineNodes().find((n) => n.id === id)?.name ?? id;
+  };
+
+  constructor() {
+    this.nodesApi.apiNodesGet().subscribe({
+      next: (nodes) => this.onlineNodes.set(nodes.filter((n) => n.online)),
+      error: () => this.onlineNodes.set([]),
+    });
+  }
+
+  // Candidates + any adopted container belong to the previously scanned host, so clear them when
+  // the target host changes - otherwise the user could register a node's container against another.
+  protected onNodeChange(id: string | null): void {
+    this.selectedNodeId.set(id);
+    this.candidates.set(null);
+    this.scanError.set(null);
+    this.adoptedContainerId.set(null);
+    this.adoptedContainerName.set(null);
+  }
 
   // v1 of the migration command supports only the SQL engines with an existing IBackupService.
   // Keep this in sync with StreamMigrateContainerCommandHandler.SupportedSourceEngines.
@@ -269,7 +324,7 @@ export class DatabaseRegisterExternalDialog {
   protected scan(): void {
     this.scanning.set(true);
     this.scanError.set(null);
-    this.api.apiDatabaseDiscoverGet().subscribe({
+    this.api.apiDatabaseDiscoverGet(this.selectedNodeId() ?? undefined).subscribe({
       next: (list) => {
         this.candidates.set(list);
         this.scanning.set(false);
@@ -313,6 +368,7 @@ export class DatabaseRegisterExternalDialog {
         databaseName: this.databaseName().trim(),
         containerId: this.adoptedContainerId(),
         containerName: this.adoptedContainerName(),
+        nodeId: this.selectedNodeId(),
       },
       onResult: (res) => {
         this.submitting.set(false);


### PR DESCRIPTION
The Register-external dialog now offers a Target-node picker: discovery runs on the chosen node's Docker daemon and the connection test + all later operations are dispatched to the node, with the instance persisted against its NodeId.

Closes #300

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcjCutmJxzZ7spSbj7Utrb)_