### PR TITLE
Fixed external database registration on a node failing to resolve its address

### DIFF
--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -80,6 +80,10 @@ services:
     image: ghcr.io/pianonic/krint:latest   # or pianonic/krint:latest (Docker Hub)
     container_name: krint-node
     restart: unless-stopped
+    extra_hosts:
+      # How the node reaches databases published on its host's ports. Without this,
+      # registering an existing database on this node fails to resolve its address.
+      - "host.docker.internal:host-gateway"
     environment:
       Krint__Role: "node"
       Node__ControlPlaneUrl: "https://krint.example.com"
@@ -103,3 +107,9 @@ Pick the node from the create wizard's **Target node** dropdown (it appears once
 ## Register an existing database on a node
 
 Databases KRINT didn't provision can also live on a node. In **Register external database**, pick the node from the **Target node** dropdown (shown once a node is online): **Scan** then discovers containers on that node's Docker daemon, and the connection test plus every later operation is dispatched to the node - the control plane never connects to the database directly. Leave it on *Local (control plane)* to register a database reachable from the control plane, exactly as before.
+
+The node reaches the database either over a shared Docker network (by container name) or at the address you registered. For the second route it needs the host-gateway alias, so keep `extra_hosts: ["host.docker.internal:host-gateway"]` on the node service.
+
+::: warning
+Registering fails with `Could not connect to ... Name or service not known` when the node is missing that `extra_hosts` entry - `localhost` then has no address the node can resolve. Add it and redeploy the node.
+:::

--- a/src/KRINT.Application/Command/DatabaseInstance/RegisterExternalDatabaseCommand.cs
+++ b/src/KRINT.Application/Command/DatabaseInstance/RegisterExternalDatabaseCommand.cs
@@ -54,8 +54,13 @@ namespace KRINT.Application.Command.DatabaseInstance
             {
                 // The DB lives on the node's host/network; only the node can reach it. Dispatch the
                 // probe there (NodeId set) and let the node resolve the reachable endpoint locally -
-                // the control plane must not pre-probe an address it can't see.
-                target = new InnerDatabaseTarget(req.Engine, preferredHost, req.Port, req.Username, req.Password, req.DatabaseName, probeNodeId);
+                // the control plane must not pre-probe an address it can't see. Carry the container
+                // name + internal port when adopting a container so the node can reach it directly
+                // over a shared Docker network, which also covers a container published only on the
+                // node's loopback; it falls back to the host address above when that isn't available.
+                target = new InnerDatabaseTarget(
+                    req.Engine, preferredHost, req.Port, req.Username, req.Password, req.DatabaseName,
+                    probeNodeId, req.ContainerName, InnerDatabaseTargetLoader.EngineInternalPort(req.Engine));
             }
             else
             {
@@ -68,7 +73,12 @@ namespace KRINT.Application.Command.DatabaseInstance
             }
             catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
             {
-                throw new ArgumentException($"Could not connect to {req.Engine} at {req.Host}:{req.Port}: {ex.Message}");
+                // Report the address actually attempted, not just what the user typed - "localhost"
+                // is rewritten to a host-gateway alias, and a DNS failure on that alias is otherwise
+                // impossible to diagnose from the message.
+                var attempted = target.Host == req.Host ? $"{req.Host}:{req.Port}" : $"{req.Host}:{req.Port} (as {target.Host}:{target.Port})";
+                var where = req.NodeId is null ? "" : " from the selected node";
+                throw new ArgumentException($"Could not connect to {req.Engine} at {attempted}{where}: {ex.Message}");
             }
 
             // Adoption path: when caller claims this is a Docker container on the local daemon,

--- a/src/KRINT.Application/InnerDatabaseTargetLoader.cs
+++ b/src/KRINT.Application/InnerDatabaseTargetLoader.cs
@@ -22,17 +22,21 @@ namespace KRINT.Application
                 ?? throw new InvalidOperationException($"Vault has no password for instance {instanceId}.");
 
             // Node-hosted: the operation is dispatched to the node, which runs it locally against the DB.
+            // Either way the node prefers reaching the container by name on its own Docker network (a
+            // containerized node can't see 127.0.0.1:<hostPort> on its host) and falls back to the host
+            // address below. ContainerName is null for a non-adopted external DB, which just means the
+            // node goes straight to that host address.
             if (instance.NodeId is { } nodeId)
             {
-                // Managed instances live in a KRINT container the node reaches by name on its own Docker
-                // network (a containerized node can't see 127.0.0.1:<hostPort> on its host); it falls back
-                // to that host port when it can't. External instances aren't KRINT's container - reach them
-                // at the host the user registered, resolved to the node's loopback/host-gateway on the node.
-                if (instance.IsManaged)
-                    return new InnerDatabaseTarget(instance.Engine, "127.0.0.1", instance.Port, instance.Username, password, instance.DatabaseName, nodeId, instance.ContainerName, EngineInternalPort(instance.Engine));
+                // Managed instances are KRINT's own container, published on the node's loopback.
+                // External ones live wherever the user registered them.
+                var nodeHost = instance.IsManaged
+                    ? "127.0.0.1"
+                    : ResolveTargetHost(instance.Host, instance.IsManaged, instance.IsPublic);
 
-                var externalHost = ResolveTargetHost(instance.Host, instance.IsManaged, instance.IsPublic);
-                return new InnerDatabaseTarget(instance.Engine, externalHost, instance.Port, instance.Username, password, instance.DatabaseName, nodeId);
+                return new InnerDatabaseTarget(
+                    instance.Engine, nodeHost, instance.Port, instance.Username, password, instance.DatabaseName,
+                    nodeId, instance.ContainerName, EngineInternalPort(instance.Engine));
             }
 
             var preferred = ResolveTargetHost(instance.Host, instance.IsManaged, instance.IsPublic);

--- a/src/KRINT.Frontend/src/app/nodes/add-node-dialog.ts
+++ b/src/KRINT.Frontend/src/app/nodes/add-node-dialog.ts
@@ -89,6 +89,8 @@ export class AddNodeDialog {
       '    image: ghcr.io/pianonic/krint:latest   # or pianonic/krint:latest (Docker Hub)',
       '    container_name: krint-node',
       '    restart: unless-stopped',
+      '    extra_hosts:',
+      '      - "host.docker.internal:host-gateway"   # how the node reaches DBs on published host ports',
       '    environment:',
       '      Krint__Role: "node"',
       `      Node__ControlPlaneUrl: "${url}"`,


### PR DESCRIPTION
Gives the node compose a host-gateway alias and carries the container name plus internal port so a node can actually reach an external database it is asked to register.

Closes #303

---
_Generated by [Claude Code](https://claude.ai/code/session_01EcjCutmJxzZ7spSbj7Utrb)_