### PR TITLE
Fixed node-hosted instances showing an unusable localhost host

### DIFF
--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -104,6 +104,55 @@ The node retries on its own if the control plane is unreachable at boot, and re-
 
 Pick the node from the create wizard's **Target node** dropdown (it appears once a node is online), or pass `nodeId` in the provision request. The instance then shows a node badge on the instances list.
 
+Manage it entirely through the control plane. To point one of your own apps at it, see [Connect an app to a node-hosted database](#connect-an-app-to-a-node-hosted-database). The published port is not reachable off the node.
+
+## Connect an app to a node-hosted database
+
+A node-hosted container publishes its port on the **node's loopback**, never on `0.0.0.0`. Nothing connects to a node directly, so there is deliberately no address on the node's host that another machine can dial. The **Public** visibility toggle is rejected for node-hosted instances for the same reason.
+
+That means the instances list shows `node-local` instead of a host, and the endpoint your app uses is the **container name on the node's Docker network**. KRINT attaches every container it provisions to its own network, so an app deployed on that node joins the same network and resolves the name.
+
+The create-success screen and the instance details dialog both give you the connection string and the compose fragment ready to copy. The shape is:
+
+```yaml
+services:
+  your-app:
+    environment:
+      # The container name and the engine's internal port, not the published one.
+      DATABASE_URL: "postgres://postgres:<password>@krint-pg-c77bea94:5432/postgres"
+    networks: [krint]
+
+networks:
+  krint:
+    external: true
+    name: krint_default
+```
+
+`krint_default` is the network the node's own compose project created. Confirm it on the node with:
+
+```sh
+docker network ls
+docker inspect -f '{{range $k,$v := .NetworkSettings.Networks}}{{$k}} {{end}}' krint-pg-c77bea94
+```
+
+::: warning
+Two mistakes account for almost every failure here.
+
+**Using the published port with the container name.** The port in the instances list (e.g. `30000`) is the *host* port on the node. Over the Docker network you use the engine's internal port, `5432` for Postgres. Pairing the container name with `30000` gives `Connection refused`.
+
+**Using `host.docker.internal` and the published port.** That resolves to the docker0 gateway, a different interface from loopback, so a loopback-bound port refuses the connection. It works for a *local* instance published on `0.0.0.0`, never for a node-hosted one.
+:::
+
+::: tip
+The default database and user shown for an instance are the ones KRINT provisioned. If your app expects its own database and role, create them first. On Postgres 15 and newer a plain role also needs ownership of the target database, or `CREATE TABLE` fails with `permission denied for schema public`:
+
+```sh
+docker exec krint-pg-c77bea94 psql -U postgres \
+  -c "CREATE USER myapp WITH PASSWORD '...';" \
+  -c "CREATE DATABASE myapp OWNER myapp;"
+```
+:::
+
 ## Register an existing database on a node
 
 Databases KRINT didn't provision can also live on a node. In **Register external database**, pick the node from the **Target node** dropdown (shown once a node is online): **Scan** then discovers containers on that node's Docker daemon, and the connection test plus every later operation is dispatched to the node - the control plane never connects to the database directly. Leave it on *Local (control plane)* to register a database reachable from the control plane, exactly as before.

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -266,6 +266,8 @@ Migrations run on startup; the vault, metadata, and provisioned containers are p
 | `SocketException (13): Permission denied` | Running as non-root without socket access - keep the default root user or `group_add` the docker GID. |
 | `No free host port in range` | `krint.yaml` `port_ranges` exhausted - delete an instance or widen the range. |
 | DB auth fails after changing the password | `POSTGRES_PASSWORD` only applies on first init - reset in-DB or wipe the volume. |
+| Your app gets `Name or service not known` or `Connection refused` for a provisioned DB | The host shown for an instance is only an address on the machine running the container. Connect by container name on KRINT's Docker network. See [Connect an app to a node-hosted database](./nodes.md#connect-an-app-to-a-node-hosted-database). |
+| `permission denied for schema public` on your app's migrations | Postgres 15+ dropped the implicit `CREATE` grant. Make your app's role the owner of its database. |
 
 </details>
 

--- a/src/KRINT.Application/Command/Database/CreateDatabaseCommand.cs
+++ b/src/KRINT.Application/Command/Database/CreateDatabaseCommand.cs
@@ -18,6 +18,11 @@ namespace KRINT.Application.Command.Database
 
     public class CreateDatabaseCommandHandler(IDockerServiceResolver dockerResolver, ISecretGeneratorService secretGenerator, ISecretsVaultService vault, KrintDbContext db, IOptions<KrintOptions> options, IActivityLogger activity, IInnerDatabaseServiceResolver innerDbs) : ICommandHandler<CreateDatabaseCommand, ProvisionedDatabaseDto>
     {
+        // Recorded on every provisioned instance and treated as a sentinel, not as an address: the
+        // probe and inner-DB resolvers rewrite it per deployment (see BuildProbeTarget /
+        // InnerDatabaseTargetLoader.ResolveTargetHost). It is only a real address from a shell on
+        // the machine running the container, so for node-hosted instances it is never usable by the
+        // caller. InstanceReachability is what the API surfaces to say where an instance really is.
         private const string Host = "localhost";
         // krint runs in its own container; localhost there is krint's loopback, not the Docker
         // host. host.docker.internal resolves to the host via the host-gateway alias set in
@@ -221,8 +226,28 @@ namespace KRINT.Application.Command.Database
 
                 var connectionString = ConnectionStringBuilder.Build(command.Engine, instance.Host, hostPort, instance.Username, password, instance.DatabaseName);
 
+                // Which networks the container ended up on (KRINT attaches it to its own after
+                // create). The success screen needs this to tell the user what their own compose
+                // service must join - for a node-hosted instance that's the only viable route,
+                // since the published port is bound to the node's loopback.
+                IEnumerable<string>? networks = null;
+                try
+                {
+                    var inspect = await docker.InspectContainerAsync(createResult.ID, cancellationToken);
+                    networks = inspect.NetworkSettings?.Networks?.Keys.ToList();
+                }
+                catch
+                {
+                    // Non-fatal: the instance is provisioned either way, we just can't name the
+                    // network and the UI falls back to telling the user how to look it up.
+                }
+
+                var nodeName = command.NodeId is { } createdOnNodeId
+                    ? await db.Nodes.Where(n => n.Id == createdOnNodeId).Select(n => n.Name).FirstOrDefaultAsync(cancellationToken)
+                    : null;
+
                 provisionedOk = true;
-                return instance.ToProvisionedDto(password, connectionString);
+                return instance.ToProvisionedDto(password, connectionString, nodeName, networks);
             }
             finally
             {

--- a/src/KRINT.Application/Dtos/Database/ProvisionedDatabaseDto.cs
+++ b/src/KRINT.Application/Dtos/Database/ProvisionedDatabaseDto.cs
@@ -18,5 +18,25 @@ namespace KRINT.Application.Dtos.Database
         public required bool IsPublic { get; init; }
         public string? State { get; init; }
         public required bool IsConfigManaged { get; init; }
+        /// <summary>The node this instance's container runs on, or null for the control plane's
+        /// local Docker daemon.</summary>
+        public Guid? NodeId { get; init; }
+        /// <summary>Display name of that node, so the UI can say where the instance lives instead
+        /// of showing a "localhost" that means nothing to the caller.</summary>
+        public string? NodeName { get; init; }
+        /// <summary>The engine's in-container port. Pairs with ContainerName on a shared Docker
+        /// network - the route that works no matter how the host port is bound.</summary>
+        public int? ContainerPort { get; init; }
+        /// <summary>Connection string against ContainerName:ContainerPort. For a node-hosted
+        /// instance this is the only endpoint another container can use, because Host:Port is
+        /// published on the node's loopback.</summary>
+        public string? ContainerConnectionString { get; init; }
+        /// <summary>A joinable Docker network the container is attached to, when we could inspect
+        /// it. This is what a user's own compose service has to declare as external to reach the
+        /// instance by container name.</summary>
+        public string? DockerNetwork { get; init; }
+        /// <summary>True when the published port is bound to 127.0.0.1 only, so nothing outside
+        /// the container's own host can dial it.</summary>
+        public bool LoopbackOnly { get; init; }
     }
 }

--- a/src/KRINT.Application/Dtos/DatabaseInstance/DatabaseInstanceDto.cs
+++ b/src/KRINT.Application/Dtos/DatabaseInstance/DatabaseInstanceDto.cs
@@ -31,5 +31,12 @@ namespace KRINT.Application.Dtos.DatabaseInstance
         /// The UI shows a node badge and hides the not-yet-supported controls (logs, console,
         /// backups, upgrade, visibility) for node-hosted instances.</summary>
         public Guid? NodeId { get; init; }
+        /// <summary>Display name of that node. The instances table shows this in place of the
+        /// recorded Host, which for a node-hosted instance is a loopback address on the node and
+        /// so is not an address the caller can use.</summary>
+        public string? NodeName { get; init; }
+        /// <summary>True when the container's published port is bound to 127.0.0.1 only.
+        /// Always true for node-hosted instances.</summary>
+        public required bool LoopbackOnly { get; init; }
     }
 }

--- a/src/KRINT.Application/InstanceReachability.cs
+++ b/src/KRINT.Application/InstanceReachability.cs
@@ -1,0 +1,51 @@
+using KRINT.Application.Command.Database;
+using KRINT.Domain;
+
+namespace KRINT.Application
+{
+    /// <summary>
+    /// Works out how an instance can actually be reached, as opposed to the "localhost" that gets
+    /// stamped on every provisioned row. A node-hosted container publishes its port on the node's
+    /// loopback only, so the recorded host means nothing anywhere except a shell on that node. The
+    /// one endpoint another container can use is the container name on the node's Docker network.
+    /// This is presentation-only: the stored Host stays "localhost" because the readiness probe and
+    /// the inner-DB resolver key off that exact value.
+    /// </summary>
+    public static class InstanceReachability
+    {
+        /// <summary>Networks every container gets by default. None of them is a network a user's
+        /// own compose service can join, so they never qualify as the shared network to suggest.</summary>
+        private static readonly string[] ImplicitNetworks = ["bridge", "host", "none"];
+
+        /// <summary>The engine's in-container port - what to pair with the container name on a
+        /// shared Docker network. Null for engines we don't recognise.</summary>
+        public static int? InternalPortFor(string engine)
+        {
+            try
+            {
+                return CreateDatabaseCommandHandler.ResolveEngineSpec(engine, string.Empty).InternalPort;
+            }
+            catch (ArgumentException)
+            {
+                // Externally-registered instances can carry an engine we never provision.
+                return null;
+            }
+        }
+
+        /// <summary>True when the published port is bound to 127.0.0.1 rather than 0.0.0.0.
+        /// Node-hosted containers are always loopback-bound regardless of IsPublic (see the
+        /// PortBindings HostIP in CreateDatabaseCommand).</summary>
+        public static bool IsLoopbackOnly(DatabaseInstance instance) =>
+            instance.NodeId is not null || !instance.IsPublic;
+
+        /// <summary>True when the recorded Host:Port is a usable address for the caller. False for
+        /// node-hosted instances, where that pair only resolves on the node itself.</summary>
+        public static bool IsHostEndpointUsable(DatabaseInstance instance) => instance.NodeId is null;
+
+        /// <summary>Picks a network a user's own container could join, ignoring the implicit ones.
+        /// KRINT attaches every container it provisions to its own networks, so for a node-hosted
+        /// instance this is the node's compose network.</summary>
+        public static string? PickSharedNetwork(IEnumerable<string>? networks) =>
+            networks?.FirstOrDefault(n => !ImplicitNetworks.Contains(n, StringComparer.OrdinalIgnoreCase));
+    }
+}

--- a/src/KRINT.Application/Mappings/Database/ProvisionedDatabaseMappings.cs
+++ b/src/KRINT.Application/Mappings/Database/ProvisionedDatabaseMappings.cs
@@ -4,22 +4,47 @@ namespace KRINT.Application.Mappings.Database
 {
     public static class ProvisionedDatabaseMappings
     {
-        public static ProvisionedDatabaseDto ToProvisionedDto(this KRINT.Domain.DatabaseInstance instance, string password, string connectionString) => new()
+        /// <param name="nodeName">Display name of the node hosting this instance, when node-hosted.</param>
+        /// <param name="networks">Docker networks the container is attached to, when the caller
+        /// could inspect it. Used to suggest the network a user's own service must join.</param>
+        public static ProvisionedDatabaseDto ToProvisionedDto(
+            this KRINT.Domain.DatabaseInstance instance,
+            string password,
+            string connectionString,
+            string? nodeName = null,
+            IEnumerable<string>? networks = null)
         {
-            Id = instance.Id,
-            Engine = instance.Engine,
-            Version = instance.Version,
-            ContainerName = instance.ContainerName,
-            Host = instance.Host,
-            Port = instance.Port,
-            Username = instance.Username,
-            DatabaseName = instance.DatabaseName,
-            Password = password,
-            ConnectionString = connectionString,
-            CreatedAt = instance.CreatedAt,
-            IsManaged = instance.IsManaged,
-            IsPublic = instance.IsPublic,
-            IsConfigManaged = instance.IsConfigManaged,
-        };
+            var internalPort = InstanceReachability.InternalPortFor(instance.Engine);
+
+            // Only containers KRINT knows by name can be addressed on a shared network; externally
+            // registered instances have no container to point at.
+            var containerConnectionString = instance.ContainerName is not null && internalPort is { } port
+                ? ConnectionStringBuilder.Build(instance.Engine, instance.ContainerName, port, instance.Username, password, instance.DatabaseName)
+                : null;
+
+            return new()
+            {
+                Id = instance.Id,
+                Engine = instance.Engine,
+                Version = instance.Version,
+                ContainerName = instance.ContainerName,
+                Host = instance.Host,
+                Port = instance.Port,
+                Username = instance.Username,
+                DatabaseName = instance.DatabaseName,
+                Password = password,
+                ConnectionString = connectionString,
+                CreatedAt = instance.CreatedAt,
+                IsManaged = instance.IsManaged,
+                IsPublic = instance.IsPublic,
+                IsConfigManaged = instance.IsConfigManaged,
+                NodeId = instance.NodeId,
+                NodeName = nodeName,
+                ContainerPort = internalPort,
+                ContainerConnectionString = containerConnectionString,
+                DockerNetwork = InstanceReachability.PickSharedNetwork(networks),
+                LoopbackOnly = InstanceReachability.IsLoopbackOnly(instance),
+            };
+        }
     }
 }

--- a/src/KRINT.Application/Mappings/DatabaseInstance/DatabaseInstanceMappings.cs
+++ b/src/KRINT.Application/Mappings/DatabaseInstance/DatabaseInstanceMappings.cs
@@ -4,7 +4,8 @@ namespace KRINT.Application.Mappings.DatabaseInstance
 {
     public static class DatabaseInstanceMappings
     {
-        public static DatabaseInstanceDto ToDto(this KRINT.Domain.DatabaseInstance d) => new()
+        /// <param name="nodeName">Display name of the node hosting this instance, when node-hosted.</param>
+        public static DatabaseInstanceDto ToDto(this KRINT.Domain.DatabaseInstance d, string? nodeName = null) => new()
         {
             Id = d.Id,
             Engine = d.Engine,
@@ -21,6 +22,8 @@ namespace KRINT.Application.Mappings.DatabaseInstance
             IsPublic = d.IsPublic,
             IsConfigManaged = d.IsConfigManaged,
             NodeId = d.NodeId,
+            NodeName = nodeName,
+            LoopbackOnly = InstanceReachability.IsLoopbackOnly(d),
         };
     }
 }

--- a/src/KRINT.Application/Queries/Database/GetDatabaseDetailsQuery.cs
+++ b/src/KRINT.Application/Queries/Database/GetDatabaseDetailsQuery.cs
@@ -25,12 +25,16 @@ namespace KRINT.Application.Queries.Database
             var connectionString = ConnectionStringBuilder.Build(instance.Engine, instance.Host, instance.Port, instance.Username, password, instance.DatabaseName);
 
             string? state = null;
+            IEnumerable<string>? networks = null;
             if (instance.ContainerId is not null)
             {
                 try
                 {
                     var inspect = await dockerResolver.Resolve(instance.NodeId).InspectContainerAsync(instance.ContainerId, cancellationToken);
                     state = inspect.State?.Status;
+                    // The same inspect tells us which networks the container joined, which is what a
+                    // user's own compose service has to declare to reach it by container name.
+                    networks = inspect.NetworkSettings?.Networks?.Keys.ToList();
                 }
                 catch
                 {
@@ -39,7 +43,11 @@ namespace KRINT.Application.Queries.Database
                 }
             }
 
-            return instance.ToProvisionedDto(password, connectionString) with { State = state };
+            var nodeName = instance.NodeId is { } nodeId
+                ? await db.Nodes.Where(n => n.Id == nodeId).Select(n => n.Name).FirstOrDefaultAsync(cancellationToken)
+                : null;
+
+            return instance.ToProvisionedDto(password, connectionString, nodeName, networks) with { State = state };
         }
     }
 }

--- a/src/KRINT.Application/Queries/Database/ListDatabasesQuery.cs
+++ b/src/KRINT.Application/Queries/Database/ListDatabasesQuery.cs
@@ -40,9 +40,14 @@ namespace KRINT.Application.Queries.Database
                 }
             }
 
+            // Node names, so the UI can name where a node-hosted instance lives instead of showing
+            // the recorded "localhost" - an address that only resolves on the node itself.
+            var nodeNames = await db.Nodes
+                .ToDictionaryAsync(n => n.Id, n => n.Name, cancellationToken);
+
             return rows.Select(d =>
             {
-                var dto = d.ToDto();
+                var dto = d.ToDto(d.NodeId is { } nodeId && nodeNames.TryGetValue(nodeId, out var nodeName) ? nodeName : null);
                 if (d.ContainerName is not null && stateByName.TryGetValue(d.ContainerName, out var state))
                 {
                     dto = dto with { State = state };

--- a/src/KRINT.Frontend/src/app/api/model/databaseInstanceDto.ts
+++ b/src/KRINT.Frontend/src/app/api/model/databaseInstanceDto.ts
@@ -27,5 +27,7 @@ export interface DatabaseInstanceDto {
     state?: string | null;
     isConfigManaged: boolean;
     nodeId?: string | null;
+    nodeName?: string | null;
+    loopbackOnly: boolean;
 }
 

--- a/src/KRINT.Frontend/src/app/api/model/provisionedDatabaseDto.ts
+++ b/src/KRINT.Frontend/src/app/api/model/provisionedDatabaseDto.ts
@@ -26,5 +26,11 @@ export interface ProvisionedDatabaseDto {
     isPublic: boolean;
     state?: string | null;
     isConfigManaged: boolean;
+    nodeId?: string | null;
+    nodeName?: string | null;
+    containerPort?: DashboardStatsDtoTotalInstances | null;
+    containerConnectionString?: string | null;
+    dockerNetwork?: string | null;
+    loopbackOnly: boolean;
 }
 

--- a/src/KRINT.Frontend/src/app/create/create.html
+++ b/src/KRINT.Frontend/src/app/create/create.html
@@ -10,15 +10,68 @@
           Instance ready
         </h2>
         <p hlmCardDescription>
-          <code class="font-mono">{{ res.instance.containerName }}</code> is up on
-          <code class="font-mono">{{ res.instance.host }}:{{ res.instance.port }}</code
-          >.
+          @if (res.instance.nodeId) {
+            <code class="font-mono">{{ res.instance.containerName }}</code> is up on node
+            <code class="font-mono">{{ res.instance.nodeName ?? 'unknown' }}</code
+            >, listening on <code class="font-mono">{{ res.instance.port }}</code> on that node's
+            loopback.
+          } @else {
+            <code class="font-mono">{{ res.instance.containerName }}</code> is up on
+            <code class="font-mono">{{ res.instance.host }}:{{ res.instance.port }}</code
+            >.
+          }
         </p>
       </div>
 
       <div hlmCardContent class="flex flex-col gap-4">
+        @if (res.instance.nodeId && res.instance.containerConnectionString) {
+          <div class="border-primary/30 bg-primary/5 flex flex-col gap-3 rounded-md border p-3">
+            <p class="text-sm">
+              This instance runs on a node, so its port is bound to that node's loopback. Apps
+              connect to it by container name over the node's Docker network. Use the string below,
+              not the one from a shell on the node.
+            </p>
+
+            <div class="flex flex-col gap-2">
+              <span class="text-muted-foreground text-sm">Connection string for your app</span>
+              <div class="flex items-start gap-2">
+                <code class="bg-muted flex-1 break-all rounded-md p-3 font-mono text-xs">{{
+                  res.instance.containerConnectionString
+                }}</code>
+                <app-copy-button [value]="res.instance.containerConnectionString" />
+              </div>
+            </div>
+
+            <div class="flex flex-col gap-2">
+              <span class="text-muted-foreground text-sm"
+                >Add this to your app's compose file on that node</span
+              >
+              <div class="flex items-start gap-2">
+                <code
+                  class="bg-muted flex-1 overflow-x-auto rounded-md p-3 font-mono text-xs whitespace-pre"
+                  >{{ composeSnippet() }}</code
+                >
+                <app-copy-button [value]="composeSnippet()" />
+              </div>
+              @if (!res.instance.dockerNetwork) {
+                <p class="text-muted-foreground text-xs">
+                  KRINT could not read the container's networks. Run
+                  <code class="font-mono">docker network ls</code> on the node and use the network
+                  its KRINT compose project created.
+                </p>
+              }
+            </div>
+          </div>
+        }
+
         <div class="flex flex-col gap-2">
-          <span class="text-muted-foreground text-sm">Connection string (root)</span>
+          <span class="text-muted-foreground text-sm">
+            @if (res.instance.nodeId) {
+              Connection string (root) from a shell on the node
+            } @else {
+              Connection string (root)
+            }
+          </span>
           <div class="flex items-start gap-2">
             <code class="bg-muted flex-1 break-all rounded-md p-3 font-mono text-xs">{{
               res.instance.connectionString

--- a/src/KRINT.Frontend/src/app/create/create.ts
+++ b/src/KRINT.Frontend/src/app/create/create.ts
@@ -42,6 +42,7 @@ import { HlmSelectImports } from '@spartan-ng/helm/select';
 import { HlmTooltipImports } from '@spartan-ng/helm/tooltip';
 import { ContentHeader } from '../shared/components/content-header/content-header';
 import { CopyButton } from '../shared/components/copy-button/copy-button';
+import { dockerNetworkComposeSnippet } from '../shared/docker-network-compose';
 import {
   customAzurite,
   customMssql,
@@ -142,6 +143,10 @@ export class Create {
   protected readonly result = signal<ProvisionResultDto | null>(null);
 
   // ----- computed -----
+  protected readonly composeSnippet = computed(() =>
+    dockerNetworkComposeSnippet(this.result()?.instance.dockerNetwork),
+  );
+
   protected readonly versions = computed(
     () => this.supported().find((s) => s.key === this.engine())?.versions ?? [],
   );

--- a/src/KRINT.Frontend/src/app/databases/database-details-dialog.ts
+++ b/src/KRINT.Frontend/src/app/databases/database-details-dialog.ts
@@ -1,10 +1,11 @@
-import { ChangeDetectionStrategy, Component, effect, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, inject } from '@angular/core';
 import { DatePipe } from '@angular/common';
 import { BrnDialogRef, injectBrnDialogContext } from '@spartan-ng/brain/dialog';
 import { HlmButtonImports } from '@spartan-ng/helm/button';
 import { HlmDialogDescription, HlmDialogHeader, HlmDialogTitle } from '@spartan-ng/helm/dialog';
 import { DatabasesStore } from '../shared/stores/databases.store';
 import { CopyButton } from '../shared/components/copy-button/copy-button';
+import { dockerNetworkComposeSnippet } from '../shared/docker-network-compose';
 
 type DialogContext = { id: string };
 
@@ -23,9 +24,7 @@ type DialogContext = { id: string };
   template: `
     <hlm-dialog-header>
       <h3 hlmDialogTitle>Instance details</h3>
-      <p hlmDialogDescription>
-        Read-only view of the connection string and credentials.
-      </p>
+      <p hlmDialogDescription>Read-only view of the connection string and credentials.</p>
     </hlm-dialog-header>
 
     @if (store.loadingDetails()) {
@@ -36,8 +35,8 @@ type DialogContext = { id: string };
           <p class="font-medium">This database is not managed by KRINT.</p>
           <p class="text-muted-foreground mt-1">
             @if (d.containerName) {
-              It was adopted from an existing Docker container. KRINT can back up, exec, and
-              tail logs, but <strong>upgrade is disabled</strong> — the image is pinned by your
+              It was adopted from an existing Docker container. KRINT can back up, exec, and tail
+              logs, but <strong>upgrade is disabled</strong> — the image is pinned by your
               orchestrator (docker compose, etc.) and upgrade there. Delete is a "forget" — the
               container itself will not be removed.
             } @else {
@@ -60,12 +59,21 @@ type DialogContext = { id: string };
         }
 
         <dt class="text-muted-foreground">Host</dt>
-        <dd class="font-mono">{{ d.host }}</dd>
-        <app-copy-button [value]="d.host" />
+        @if (d.nodeId) {
+          <dd class="text-muted-foreground text-xs">
+            <span class="font-mono">{{ d.host }}:{{ d.port }}</span> on node
+            <span class="font-mono">{{ d.nodeName ?? 'unknown' }}</span
+            >, loopback only
+          </dd>
+          <span></span>
+        } @else {
+          <dd class="font-mono">{{ d.host }}</dd>
+          <app-copy-button [value]="d.host" />
 
-        <dt class="text-muted-foreground">Port</dt>
-        <dd class="font-mono">{{ d.port }}</dd>
-        <app-copy-button [value]="d.port.toString()" />
+          <dt class="text-muted-foreground">Port</dt>
+          <dd class="font-mono">{{ d.port }}</dd>
+          <app-copy-button [value]="d.port.toString()" />
+        }
 
         <dt class="text-muted-foreground">Database</dt>
         <dd class="font-mono">{{ d.databaseName }}</dd>
@@ -84,13 +92,64 @@ type DialogContext = { id: string };
         <span></span>
       </dl>
 
-      <div class="flex flex-col gap-2">
-        <span class="text-muted-foreground text-sm">Connection string</span>
-        <div class="flex items-start gap-2">
-          <code class="bg-muted flex-1 break-all rounded-md p-3 font-mono text-xs">{{ d.connectionString }}</code>
-          <app-copy-button [value]="d.connectionString" />
+      @if (d.nodeId && d.containerConnectionString) {
+        <div class="flex flex-col gap-2">
+          <span class="text-muted-foreground text-sm">
+            Connection string for other containers on
+            <span class="font-mono">{{ d.nodeName ?? 'the node' }}</span>
+          </span>
+          <div class="flex items-start gap-2">
+            <code class="bg-muted flex-1 break-all rounded-md p-3 font-mono text-xs">{{
+              d.containerConnectionString
+            }}</code>
+            <app-copy-button [value]="d.containerConnectionString" />
+          </div>
         </div>
-      </div>
+
+        @if (composeSnippet(); as snippet) {
+          <div class="flex flex-col gap-2">
+            <span class="text-muted-foreground text-sm">
+              Add this to your app's compose file so it can resolve that name
+            </span>
+            <div class="flex items-start gap-2">
+              <code
+                class="bg-muted flex-1 overflow-x-auto rounded-md p-3 font-mono text-xs whitespace-pre"
+                >{{ snippet }}</code
+              >
+              <app-copy-button [value]="snippet" />
+            </div>
+            @if (!d.dockerNetwork) {
+              <p class="text-muted-foreground text-xs">
+                KRINT could not read the container's networks. Find the name on the node with
+                <code class="font-mono">docker inspect {{ d.containerName }}</code> and put it in
+                <code class="font-mono">name:</code>.
+              </p>
+            }
+          </div>
+        }
+
+        <div class="flex flex-col gap-2">
+          <span class="text-muted-foreground text-sm"
+            >Connection string from a shell on the node</span
+          >
+          <div class="flex items-start gap-2">
+            <code class="bg-muted flex-1 break-all rounded-md p-3 font-mono text-xs">{{
+              d.connectionString
+            }}</code>
+            <app-copy-button [value]="d.connectionString" />
+          </div>
+        </div>
+      } @else {
+        <div class="flex flex-col gap-2">
+          <span class="text-muted-foreground text-sm">Connection string</span>
+          <div class="flex items-start gap-2">
+            <code class="bg-muted flex-1 break-all rounded-md p-3 font-mono text-xs">{{
+              d.connectionString
+            }}</code>
+            <app-copy-button [value]="d.connectionString" />
+          </div>
+        </div>
+      }
     } @else if (store.error(); as err) {
       <p class="text-destructive text-sm">{{ err }}</p>
     }
@@ -102,6 +161,13 @@ type DialogContext = { id: string };
 })
 export class DatabaseDetailsDialog {
   protected readonly store = inject(DatabasesStore);
+
+  protected readonly composeSnippet = computed(() => {
+    const d = this.store.details();
+    if (!d?.containerName) return null;
+    return dockerNetworkComposeSnippet(d.dockerNetwork);
+  });
+
   private readonly ref = inject<BrnDialogRef<unknown>>(BrnDialogRef);
   private readonly ctx = injectBrnDialogContext<DialogContext>();
 

--- a/src/KRINT.Frontend/src/app/databases/databases.html
+++ b/src/KRINT.Frontend/src/app/databases/databases.html
@@ -122,7 +122,23 @@
               <td hlmTableCell class="font-mono text-xs">
                 {{ db.containerName ?? '-' }}
               </td>
-              <td hlmTableCell>{{ db.host }}</td>
+              <td hlmTableCell>
+                @if (db.nodeId) {
+                  <span
+                    class="text-muted-foreground inline-flex items-center gap-1 text-xs"
+                    [hlmTooltip]="
+                      'Published on the loopback of ' +
+                      nodeName(db.nodeId) +
+                      '. Nothing off that host can dial it. Open instance details for an endpoint you can actually connect to.'
+                    "
+                  >
+                    <ng-icon name="lucideNetwork" size="12" />
+                    node-local
+                  </span>
+                } @else {
+                  {{ db.host }}
+                }
+              </td>
               <td hlmTableCell class="text-right font-mono">{{ db.port }}</td>
               <td hlmTableCell>{{ db.databaseName }}</td>
               <td hlmTableCell>{{ db.username }}</td>

--- a/src/KRINT.Frontend/src/app/shared/docker-network-compose.ts
+++ b/src/KRINT.Frontend/src/app/shared/docker-network-compose.ts
@@ -1,0 +1,24 @@
+/**
+ * Compose fragment a user's own service needs in order to reach a KRINT-provisioned container by
+ * name. KRINT attaches every container it provisions to its own Docker network, so joining that
+ * network as external is what makes the container name resolve.
+ *
+ * This is the only route to a node-hosted instance: its published port is bound to the node's
+ * loopback, so no address on the node's host is reachable from another container.
+ *
+ * When the network name is unknown (the inspect failed, or the node is offline) we emit a
+ * placeholder rather than guessing, because a wrong name fails at container start with a message
+ * that points nowhere near the cause.
+ */
+export function dockerNetworkComposeSnippet(dockerNetwork?: string | null): string {
+  return [
+    'services:',
+    '  your-app:',
+    '    networks: [krint]',
+    '',
+    'networks:',
+    '  krint:',
+    '    external: true',
+    `    name: ${dockerNetwork ?? '<your krint network>'}`,
+  ].join('\n');
+}

--- a/src/KRINT.Tests/Services/InstanceReachabilityTests.cs
+++ b/src/KRINT.Tests/Services/InstanceReachabilityTests.cs
@@ -1,0 +1,100 @@
+using KRINT.Application;
+using KRINT.Application.Mappings.Database;
+
+namespace KRINT.Tests.Services
+{
+    /// <summary>
+    /// Every provisioned instance records Host="localhost", which is only an address from a shell on
+    /// the machine running the container. These cover the reachability facts the API surfaces so the
+    /// UI can stop presenting that sentinel as a connectable endpoint.
+    /// </summary>
+    public class InstanceReachabilityTests
+    {
+        private static KRINT.Domain.DatabaseInstance Instance(bool isPublic = true, Guid? nodeId = null, string engine = "postgres", string? containerName = "krint-pg-c77bea94") =>
+            new()
+            {
+                Engine = engine,
+                Version = "18.4",
+                DisplayName = "ArgonFetch",
+                ContainerName = containerName,
+                Host = "localhost",
+                Port = 30000,
+                Username = "postgres",
+                DatabaseName = "postgres",
+                IsPublic = isPublic,
+                NodeId = nodeId,
+            };
+
+        [Test]
+        public async Task InternalPortFor_KnownEngines_ReturnsContainerPort()
+        {
+            await Assert.That(InstanceReachability.InternalPortFor("postgres")).IsEqualTo(5432);
+            await Assert.That(InstanceReachability.InternalPortFor("mongo")).IsEqualTo(27017);
+            await Assert.That(InstanceReachability.InternalPortFor("mssql")).IsEqualTo(1433);
+        }
+
+        [Test]
+        public async Task InternalPortFor_UnknownEngine_ReturnsNull()
+        {
+            // Externally-registered instances can name an engine KRINT never provisions.
+            await Assert.That(InstanceReachability.InternalPortFor("not-an-engine")).IsNull();
+        }
+
+        [Test]
+        public async Task IsLoopbackOnly_NodeHosted_IsTrueEvenWhenPublic()
+        {
+            // The create path forces HostIP=127.0.0.1 whenever NodeId is set, so IsPublic can't
+            // widen the binding. This is the case that made the displayed host unusable.
+            await Assert.That(InstanceReachability.IsLoopbackOnly(Instance(isPublic: true, nodeId: Guid.NewGuid()))).IsTrue();
+        }
+
+        [Test]
+        public async Task IsLoopbackOnly_LocalFollowsVisibility()
+        {
+            await Assert.That(InstanceReachability.IsLoopbackOnly(Instance(isPublic: true))).IsFalse();
+            await Assert.That(InstanceReachability.IsLoopbackOnly(Instance(isPublic: false))).IsTrue();
+        }
+
+        [Test]
+        public async Task IsHostEndpointUsable_FalseForNodeHosted()
+        {
+            await Assert.That(InstanceReachability.IsHostEndpointUsable(Instance(nodeId: Guid.NewGuid()))).IsFalse();
+            await Assert.That(InstanceReachability.IsHostEndpointUsable(Instance())).IsTrue();
+        }
+
+        [Test]
+        public async Task PickSharedNetwork_SkipsImplicitNetworks()
+        {
+            await Assert.That(InstanceReachability.PickSharedNetwork(["bridge", "krint_default"])).IsEqualTo("krint_default");
+            await Assert.That(InstanceReachability.PickSharedNetwork(["bridge"])).IsNull();
+            await Assert.That(InstanceReachability.PickSharedNetwork(null)).IsNull();
+        }
+
+        [Test]
+        public async Task ToProvisionedDto_NodeHosted_CarriesContainerEndpoint()
+        {
+            var dto = Instance(nodeId: Guid.NewGuid()).ToProvisionedDto(
+                "pw",
+                "postgres://postgres:pw@localhost:30000/postgres",
+                nodeName: "vps-xl-krint",
+                networks: ["bridge", "krint_default"]);
+
+            await Assert.That(dto.NodeName).IsEqualTo("vps-xl-krint");
+            await Assert.That(dto.ContainerPort).IsEqualTo(5432);
+            await Assert.That(dto.DockerNetwork).IsEqualTo("krint_default");
+            await Assert.That(dto.LoopbackOnly).IsTrue();
+            // The container endpoint uses the internal port, never the published one.
+            await Assert.That(dto.ContainerConnectionString)
+                .IsEqualTo("postgres://postgres:pw@krint-pg-c77bea94:5432/postgres");
+        }
+
+        [Test]
+        public async Task ToProvisionedDto_NoContainer_HasNoContainerEndpoint()
+        {
+            var dto = Instance(containerName: null).ToProvisionedDto("pw", "postgres://postgres:pw@db.example.com:5432/postgres");
+
+            await Assert.That(dto.ContainerConnectionString).IsNull();
+            await Assert.That(dto.DockerNetwork).IsNull();
+        }
+    }
+}


### PR DESCRIPTION
Surfaced where a node-hosted instance really is, and gave the create-success screen and details dialog a copy-ready connection string plus the compose fragment an app needs to reach it.

Closes #312